### PR TITLE
Add country persistence for buyer profiles

### DIFF
--- a/pantypost-backend/models/User.js
+++ b/pantypost-backend/models/User.js
@@ -36,6 +36,11 @@ const userSchema = new mongoose.Schema({
     maxlength: 500,
     default: ''
   },
+  country: {
+    type: String,
+    maxlength: 56,
+    default: ''
+  },
   profilePic: {
     type: String,
     default: 'https://via.placeholder.com/150' // Default avatar


### PR DESCRIPTION
## Summary
- add a `country` field to the `User` schema so buyer profile updates persist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd13b79ad083289cf017c47d270a4a