### PR TITLE
Fix profile routes avatar and country fallbacks

### DIFF
--- a/pantypost-backend/routes/user.routes.js
+++ b/pantypost-backend/routes/user.routes.js
@@ -79,8 +79,12 @@ router.get('/me/profile', authMiddleware, async (req, res) => {
         username: user.username,
         role: user.role,
         bio: user.bio || '',
-        profilePic: user.profilePic || null,
-        country: user?.settings?.country || ''
+        profilePic:
+          user.profilePic ||
+          user?.settings?.profilePic ||
+          user?.settings?.profilePicture ||
+          null,
+        country: user.country || user?.settings?.country
       }
     });
   } catch (error) {
@@ -128,6 +132,9 @@ router.patch('/me/profile', authMiddleware, async (req, res) => {
            pic.includes('placeholder')))
       ) {
         user.profilePic = pic;
+        user.settings = user.settings || {};
+        user.settings.profilePic = pic;
+        user.settings.profilePicture = pic;
       } else {
         return res.status(400).json({
           success: false,
@@ -159,8 +166,12 @@ router.patch('/me/profile', authMiddleware, async (req, res) => {
         username: user.username,
         role: user.role,
         bio: user.bio || '',
-        profilePic: user.profilePic || null,
-        country: user.country || user?.settings?.country || ''
+        profilePic:
+          user.profilePic ||
+          user?.settings?.profilePic ||
+          user?.settings?.profilePicture ||
+          null,
+        country: user.country || user?.settings?.country
       }
     });
   } catch (error) {
@@ -241,8 +252,12 @@ router.get('/:username/profile', async (req, res) => {
           data: {
             username: user.username,
             bio: user.bio,
-            profilePic: user.profilePic,
-            country: user.country || user?.settings?.country || null,
+            profilePic:
+              user.profilePic ||
+              user?.settings?.profilePic ||
+              user?.settings?.profilePicture ||
+              null,
+            country: user.country || user?.settings?.country,
             isVerified: user.isVerified,
             role: user.role,
             joinedDate: user.joinedDate
@@ -271,8 +286,12 @@ router.get('/:username/profile', async (req, res) => {
       data: {
         username: user.username,
         bio: user.bio,
-        profilePic: user.profilePic,
-        country: user.country || user?.settings?.country || null,
+        profilePic:
+          user.profilePic ||
+          user?.settings?.profilePic ||
+          user?.settings?.profilePicture ||
+          null,
+        country: user.country || user?.settings?.country,
         isVerified: user.isVerified,
         tier: user.tier,
         subscriptionPrice: user.subscriptionPrice,


### PR DESCRIPTION
## Summary
- restore the canonical profilePic and country fallbacks on the authenticated and public profile endpoints
- mirror profilePic updates into the legacy settings fields to keep older clients consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1c93bc548328b8e4e806fbda060c