### PR TITLE
Refine placeholder metrics and utility helpers

### DIFF
--- a/src/components/admin/PerformanceMetrics.tsx
+++ b/src/components/admin/PerformanceMetrics.tsx
@@ -13,6 +13,36 @@ interface MetricData {
   timestamp: string;
 }
 
+const PLACEHOLDER_METRICS: ReadonlyArray<Omit<MetricData, 'timestamp'>> = [
+  { name: 'First Contentful Paint', value: 1.2, rating: 'good' },
+  { name: 'Largest Contentful Paint', value: 2.1, rating: 'good' },
+  { name: 'First Input Delay', value: 45, rating: 'good' },
+  { name: 'Cumulative Layout Shift', value: 0.08, rating: 'good' },
+  { name: 'Time to Interactive', value: 3.2, rating: 'needs-improvement' }
+];
+
+const RATING_STYLES: Record<
+  Rating,
+  { textColor: string; barColor: string; progress: number; Icon: typeof TrendingUp }
+> = {
+  good: { textColor: 'text-green-500', barColor: 'bg-green-500', progress: 100, Icon: TrendingUp },
+  'needs-improvement': {
+    textColor: 'text-yellow-500',
+    barColor: 'bg-yellow-500',
+    progress: 66,
+    Icon: AlertCircle
+  },
+  poor: { textColor: 'text-red-500', barColor: 'bg-red-500', progress: 33, Icon: AlertCircle }
+};
+
+const buildPlaceholderMetrics = (): MetricData[] => {
+  const timestamp = new Date().toISOString();
+  return PLACEHOLDER_METRICS.map((metric) => ({
+    ...metric,
+    timestamp
+  }));
+};
+
 export function PerformanceMetrics() {
   const [metrics, setMetrics] = useState<MetricData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -20,18 +50,10 @@ export function PerformanceMetrics() {
   useEffect(() => {
     let mounted = true;
 
-    const fetchMetrics = async () => {
+    const loadMetrics = () => {
       try {
-        // Replace with real API call; keep mock safe/sanitized
-        const nowIso = new Date().toISOString();
-        const mockMetrics: MetricData[] = [
-          { name: 'First Contentful Paint', value: 1.2, rating: 'good', timestamp: nowIso },
-          { name: 'Largest Contentful Paint', value: 2.1, rating: 'good', timestamp: nowIso },
-          { name: 'First Input Delay', value: 45, rating: 'good', timestamp: nowIso },
-          { name: 'Cumulative Layout Shift', value: 0.08, rating: 'good', timestamp: nowIso },
-          { name: 'Time to Interactive', value: 3.2, rating: 'needs-improvement', timestamp: nowIso }
-        ];
-        if (mounted) setMetrics(mockMetrics);
+        const placeholderMetrics = buildPlaceholderMetrics();
+        if (mounted) setMetrics(placeholderMetrics);
       } catch (error) {
         console.error('Failed to fetch metrics:', error);
         if (mounted) setMetrics([]);
@@ -40,32 +62,11 @@ export function PerformanceMetrics() {
       }
     };
 
-    fetchMetrics();
+    loadMetrics();
     return () => {
       mounted = false;
     };
   }, []);
-
-  const getMetricColor = (rating: Rating) => {
-    switch (rating) {
-      case 'good':
-        return 'text-green-500';
-      case 'needs-improvement':
-        return 'text-yellow-500';
-      case 'poor':
-        return 'text-red-500';
-    }
-  };
-
-  const getMetricIcon = (rating: Rating) => {
-    switch (rating) {
-      case 'good':
-        return <TrendingUp className="h-4 w-4" />;
-      case 'needs-improvement':
-      case 'poor':
-        return <AlertCircle className="h-4 w-4" />;
-    }
-  };
 
   if (loading) {
     return (
@@ -103,40 +104,33 @@ export function PerformanceMetrics() {
 
       <div className="space-y-3">
         {metrics.map((metric) => {
-          const val = Number(metric.value);
-          const safeVal = Number.isFinite(val) ? val : 0;
-          const isCLS = metric.name.toLowerCase().includes('layout shift');
-          const isDelay = metric.name.toLowerCase().includes('delay');
+          const { textColor, barColor, progress, Icon } = RATING_STYLES[metric.rating];
+          const value = Number(metric.value);
+          const safeValue = Number.isFinite(value) ? value : 0;
+          const metricName = metric.name.toLowerCase();
+          const isLayoutShift = metricName.includes('layout shift');
+          const isDelay = metricName.includes('delay');
+          const unit = isLayoutShift ? '' : isDelay ? 'ms' : 's';
 
           return (
             <div key={metric.name} className="bg-black/30 rounded-lg p-4 border border-gray-800">
               <div className="flex items-center justify-between mb-2">
                 <h3 className="text-sm font-medium text-gray-300">{metric.name}</h3>
-                <div className={`flex items-center gap-1 ${getMetricColor(metric.rating)}`}>
-                  {getMetricIcon(metric.rating)}
+                <div className={`flex items-center gap-1 ${textColor}`}>
+                  <Icon className="h-4 w-4" />
                   <span className="text-xs uppercase">{metric.rating.replace('-', ' ')}</span>
                 </div>
               </div>
 
               <div className="flex items-baseline gap-2">
-                <span className="text-2xl font-bold text-white">{safeVal}</span>
-                <span className="text-sm text-gray-500">{isCLS ? '' : isDelay ? 'ms' : 's'}</span>
+                <span className="text-2xl font-bold text-white">{safeValue}</span>
+                <span className="text-sm text-gray-500">{unit}</span>
               </div>
 
               <div className="mt-2 h-2 bg-gray-800 rounded-full overflow-hidden" aria-hidden="true">
                 <div
-                  className={`h-full transition-all duration-500 ${
-                    metric.rating === 'good'
-                      ? 'bg-green-500'
-                      : metric.rating === 'needs-improvement'
-                      ? 'bg-yellow-500'
-                      : 'bg-red-500'
-                  }`}
-                  style={{
-                    width: `${
-                      metric.rating === 'good' ? 100 : metric.rating === 'needs-improvement' ? 66 : 33
-                    }%`
-                  }}
+                  className={`h-full transition-all duration-500 ${barColor}`}
+                  style={{ width: `${progress}%` }}
                 />
               </div>
             </div>

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -19,7 +19,7 @@ export const useLogin = () => {
   const router = useRouter();
   const { login, isAuthReady, user, error: authError, clearError } = useAuth();
   
-  // Rate limiting for login attempts - UPDATED TO USE LOGIN CONFIG
+  // Rate limiting for login attempts
   const { checkLimit: checkLoginLimit, resetLimit: resetLoginLimit } = useRateLimit('LOGIN_HOOK', RATE_LIMITS.LOGIN);
   
   // Track failed attempts for this session
@@ -28,7 +28,7 @@ export const useLogin = () => {
 
   const [state, setState] = useState<LoginState>({
     username: '',
-    password: '', // ADD THIS LINE - was missing
+    password: '',
     role: null,
     error: '',
     isLoading: false,
@@ -54,7 +54,7 @@ export const useLogin = () => {
     }
   }, [isAuthReady, user, router]);
 
-  // Sync auth context errors - ONLY on step 2 and when relevant
+  // Sync auth context errors - only on step 2 and when relevant
   useEffect(() => {
     // Only sync auth errors when we're on step 2 (role selection)
     // This prevents rate limit errors from showing on the username step
@@ -89,18 +89,23 @@ export const useLogin = () => {
     return MIN_LOGIN_DELAY + Math.random() * (MAX_LOGIN_DELAY - MIN_LOGIN_DELAY);
   }, []);
 
-  // Handle login with security enhancements - UPDATED to use password from state
+  // Handle login with security enhancements
   const handleLogin = useCallback(async (password?: string) => {
     const { username, role } = state;
-    const loginPassword = password || state.password || 'password123'; // Use passed password, state password, or dummy
-    
+    const loginPassword = password ?? state.password ?? '';
+
     // Clear any previous auth errors
     if (clearError) {
       clearError();
     }
-    
+
     // Clear local error state
     updateState({ error: '' });
+
+    if (!loginPassword) {
+      updateState({ error: 'Password is required.', isLoading: false });
+      return;
+    }
     
     // Check rate limit
     const rateLimitResult = checkLoginLimit();
@@ -152,11 +157,10 @@ export const useLogin = () => {
       const delay = getRandomDelay();
       await new Promise(resolve => setTimeout(resolve, delay));
       
-      // Sanitize username before login
       const sanitizedUsername = usernameValidation.data;
-      
-      console.log('[useLogin] Attempting login with:', { 
-        username: sanitizedUsername, 
+
+      console.log('[useLogin] Attempting login with:', {
+        username: sanitizedUsername,
         role,
         hasPassword: !!loginPassword
       });
@@ -357,7 +361,7 @@ export const useLogin = () => {
     handleUsernameSubmit,
     handleKeyPress,
     handleUsernameChange,
-    handlePasswordChange, // ADD THIS
+    handlePasswordChange,
     goBack,
     handleCrownClick,
     

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -3,26 +3,39 @@
  * Utility function for combining class names
  * Filters out falsy values and joins the remaining strings
  */
-export function cn(...inputs: (string | undefined | null | false | 0 | '')[]) {
+type PrimitiveClass = string | undefined | null | false | 0 | '';
+type ClassValue = PrimitiveClass | readonly ClassValue[];
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0;
+
+const collectClassNames = (values: readonly ClassValue[], acc: string[] = []): string[] => {
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      collectClassNames(value, acc);
+      continue;
+    }
+
+    if (isNonEmptyString(value)) {
+      acc.push(value);
+    }
+  }
+
+  return acc;
+};
+
+export function cn(...inputs: PrimitiveClass[]): string {
   return inputs.filter(Boolean).join(' ');
 }
 
 /**
  * Alternative implementation with more features if needed
- * This version also handles arrays and objects
+ * This version also handles nested arrays and ignores non-string values
  */
 export function cnAdvanced(...inputs: ClassValue[]): string {
-  return inputs
-    .flat()
-    .filter((x) => typeof x === 'string' && x.length > 0)
-    .join(' ');
+  return collectClassNames(inputs).join(' ');
 }
-
-type ClassValue = 
-  | string 
-  | undefined 
-  | null 
-  | false 
-  | 0 
-  | '' 
-  | ClassValue[];


### PR DESCRIPTION
## Summary
- add reusable placeholder data and styling helpers to the admin performance metrics widget
- tighten login handling by requiring real passwords and simplifying rate-limit messaging
- expand shared utilities for classNames, images, and URLs with safer helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de58644e548328bd029b01707d61b0