### PR TITLE
Remove buyer profile badge from buyer page

### DIFF
--- a/src/app/buyers/[username]/page.tsx
+++ b/src/app/buyers/[username]/page.tsx
@@ -414,11 +414,6 @@ export default function BuyerProfilePage() {
                           </div>
                         </div>
                       </div>
-                      <div className="flex flex-wrap items-center justify-center gap-3 lg:justify-start">
-                        <span className="rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-[#ffb347]">
-                          Buyer Profile
-                        </span>
-                      </div>
                     </div>
 
                     <div className="flex-1 space-y-6">


### PR DESCRIPTION
## Summary
- remove the decorative "Buyer Profile" badge from the buyer profile header

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1118d7f0c832892a7d2a8e1928c5d