### PR TITLE
Streamline buyer dashboard navigation and insights

### DIFF
--- a/src/app/buyers/dashboard/page.tsx
+++ b/src/app/buyers/dashboard/page.tsx
@@ -1,7 +1,7 @@
 // src/app/buyers/dashboard/page.tsx
 'use client';
 
-import React, { useCallback, useState, useRef, useEffect } from 'react';
+import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useFavorites } from '@/context/FavoritesContext';
 import RequireAuth from '@/components/RequireAuth';
@@ -11,12 +11,12 @@ import DashboardHeader from '@/components/buyers/dashboard/DashboardHeader';
 import StatsGrid from '@/components/buyers/dashboard/StatsGrid';
 import QuickActions from '@/components/buyers/dashboard/QuickActions';
 import RecentActivity from '@/components/buyers/dashboard/RecentActivity';
-import SubscribedSellers from '@/components/buyers/dashboard/SubscribedSellers';
-import { Truck, Clock, CheckCircle, Heart, Star, X, AlertCircle } from 'lucide-react';
+import { Truck, Clock, CheckCircle, Heart, Star, X, AlertCircle, Crown } from 'lucide-react';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import TierBadge from '@/components/TierBadge';
+import { SecureMessageDisplay, SecureImage } from '@/components/ui/SecureMessageDisplay';
+import { sanitizeUsername } from '@/utils/security/sanitization';
 
 // Error Boundary Component
 class ErrorBoundary extends React.Component<
@@ -85,14 +85,60 @@ function DashboardContent() {
     isLoading
   } = useDashboardData();
 
+  const sectionNavItems = useMemo(
+    () => [
+      { id: 'overview', label: 'Overview' },
+      { id: 'connections', label: 'Connections' },
+      { id: 'timeline', label: 'Timeline' },
+      { id: 'insights', label: 'Insights' }
+    ],
+    []
+  );
+
+  const [activeSection, setActiveSection] = useState(sectionNavItems[0]?.id ?? 'overview');
+  const [activeCollection, setActiveCollection] = useState<'favorites' | 'subscriptions'>('favorites');
+
   // Track component mount status
   useEffect(() => {
     isMountedRef.current = true;
-    
+
     return () => {
       isMountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+        if (visible[0]?.target?.id) {
+          setActiveSection(visible[0].target.id);
+        }
+      },
+      {
+        rootMargin: '-45% 0px -45% 0px',
+        threshold: [0.1, 0.25, 0.5, 0.75],
+      }
+    );
+
+    sectionNavItems.forEach((item) => {
+      const element = document.getElementById(item.id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [sectionNavItems]);
 
   const handleRemoveFavorite = useCallback(async (favorite: any) => {
     // Validate favorite data
@@ -153,6 +199,15 @@ function DashboardContent() {
     });
   }, []);
 
+  const handleSectionNavigation = useCallback((targetId: string) => {
+    if (typeof window === 'undefined') return;
+    const element = document.getElementById(targetId);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setActiveSection(targetId);
+    }
+  }, []);
+
   if (!authUser || authUser.role !== 'buyer') {
     return (
       <BanCheck>
@@ -181,221 +236,429 @@ function DashboardContent() {
 
   // Safe favorites list
   const safeFavorites = Array.isArray(favorites) ? favorites : [];
+  const safeBalance =
+    typeof balance === 'number' && Number.isFinite(balance) ? balance : 0;
+  const safeSubscriptions = useMemo(
+    () => (Array.isArray(subscribedSellers) ? subscribedSellers : []),
+    [subscribedSellers]
+  );
+
+  const renderFavoritePreview = () => {
+    if (loadingFavorites) {
+      return (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {[...Array(4)].map((_, index) => (
+            <Skeleton key={`favorite-skeleton-${index}`} className="h-28 rounded-2xl bg-[#181818]" />
+          ))}
+        </div>
+      );
+    }
+
+    if (favoriteCount === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed border-white/10 bg-[#181818] p-8 text-center">
+          <Heart className="mx-auto mb-4 h-8 w-8 text-gray-600" />
+          <p className="text-sm text-gray-400">You haven&apos;t saved any sellers yet.</p>
+          <button
+            onClick={() => router.push('/browse')}
+            className="mt-6 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] px-5 py-2 text-sm font-semibold text-black shadow-lg transition hover:shadow-[#ff950e]/30"
+          >
+            Explore marketplace
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {safeFavorites.slice(0, 4).map((favorite) => {
+          if (!favorite?.sellerId || !favorite?.sellerUsername) return null;
+
+          return (
+            <div
+              key={favorite.sellerId}
+              className="group rounded-2xl border border-white/5 bg-gradient-to-br from-[#181818] to-[#0f0f0f] p-4 transition hover:border-[#ff950e]/40 hover:bg-[#161616]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleViewSellerProfile(favorite.sellerUsername)}
+                  className="flex items-center gap-3 text-left"
+                >
+                  <div className="relative h-11 w-11 overflow-hidden rounded-full border border-white/10 bg-black/40">
+                    {favorite.profilePicture && !imageErrors[favorite.sellerId] ? (
+                      <Image
+                        src={favorite.profilePicture}
+                        alt={favorite.sellerUsername}
+                        fill
+                        className="object-cover"
+                        onError={() => handleImageError(favorite.sellerId)}
+                        onLoad={() => handleImageLoad(favorite.sellerId)}
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-gray-600">
+                        <Heart className="h-4 w-4" />
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <p className="font-medium text-white transition group-hover:text-[#ff950e]">
+                      {favorite.sellerUsername}
+                    </p>
+                    <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+                      {favorite.isVerified && (
+                        <span className="flex items-center gap-1 text-blue-300">
+                          <Star className="h-3 w-3" /> Verified
+                        </span>
+                      )}
+                      {favorite.tier && (
+                        <span className="rounded-full bg-black/40 px-2 py-0.5 text-gray-400">{favorite.tier}</span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+                <button
+                  onClick={() => handleRemoveFavorite(favorite)}
+                  className="rounded-full border border-transparent p-1 text-gray-600 transition hover:border-[#ff950e]/40 hover:bg-black/40 hover:text-[#ff950e]"
+                  aria-label="Remove from favorites"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="mt-4 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-500">
+                <button
+                  onClick={() => handleViewSellerProfile(favorite.sellerUsername)}
+                  className="inline-flex items-center gap-1 font-semibold text-[#ff950e] transition hover:text-[#ffb347]"
+                >
+                  View profile
+                </button>
+                <span className="rounded-full bg-black/40 px-2 py-0.5 text-white/60">Favorite</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderSubscriptionPreview = () => {
+    if (isLoading) {
+      return (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {[...Array(3)].map((_, index) => (
+            <Skeleton key={`subscription-skeleton-${index}`} className="h-28 rounded-2xl bg-[#181818]" />
+          ))}
+        </div>
+      );
+    }
+
+    if (safeSubscriptions.length === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed border-white/10 bg-[#181818] p-8 text-center">
+          <Crown className="mx-auto mb-4 h-8 w-8 text-gray-600" />
+          <p className="text-sm text-gray-400">No active subscriptions yet.</p>
+          <button
+            onClick={() => router.push('/browse')}
+            className="mt-6 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] px-5 py-2 text-sm font-semibold text-black shadow-lg transition hover:shadow-[#ff950e]/30"
+          >
+            Browse sellers
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {safeSubscriptions.slice(0, 4).map((sub) => {
+          const sanitizedUsername = sanitizeUsername(sub.seller);
+          const monthlyPrice =
+            typeof sub.price === 'number'
+              ? sub.price
+              : typeof sub.price === 'string'
+              ? Number(sub.price)
+              : 0;
+          const priceDisplay = Number.isFinite(monthlyPrice) ? monthlyPrice.toFixed(2) : '0.00';
+          const newListings =
+            typeof sub.newListings === 'number'
+              ? Math.max(0, sub.newListings)
+              : Number.isFinite(Number(sub.newListings))
+              ? Math.max(0, Number(sub.newListings))
+              : 0;
+
+          return (
+            <div
+              key={`${sub.seller}-${sub.tier ?? 'tier'}`}
+              className="flex items-center justify-between gap-3 rounded-2xl border border-white/5 bg-gradient-to-br from-[#181818] to-[#0f0f0f] p-4 transition hover:border-[#ff950e]/40 hover:bg-[#161616]"
+            >
+              <div className="flex items-center gap-3">
+                {sub.pic ? (
+                  <SecureImage
+                    src={sub.pic}
+                    alt={sub.seller}
+                    className="h-11 w-11 rounded-full border border-white/10 object-cover"
+                  />
+                ) : (
+                  <div className="flex h-11 w-11 items-center justify-center rounded-full bg-black/40 text-amber-200">
+                    <Crown className="h-4 w-4" />
+                  </div>
+                )}
+                <div>
+                  <button
+                    onClick={() => router.push(`/sellers/${sanitizedUsername}`)}
+                    className="text-sm font-medium text-white transition hover:text-[#ff950e]"
+                  >
+                    <SecureMessageDisplay content={sub.seller} allowBasicFormatting={false} className="inline" />
+                  </button>
+                  <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                    ${priceDisplay}/month
+                    <span className="mx-2 text-white/20">•</span>
+                    {newListings} new listings
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={() => router.push(`/sellers/${sanitizedUsername}`)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs font-semibold text-gray-300 transition hover:border-[#ff950e] hover:text-[#ff950e]"
+              >
+                View
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
 
   return (
     <BanCheck>
       <RequireAuth role="buyer">
-        <main className="min-h-screen bg-black text-white">
-          <div className="max-w-7xl mx-auto px-6 py-8">
-            {/* Header Section */}
+        <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-black via-[#060606] to-[#0c0c0c] text-gray-100">
+          <div className="pointer-events-none absolute -left-32 top-0 h-72 w-72 rounded-full bg-[#ff950e]/10 blur-[140px]" aria-hidden />
+          <div className="pointer-events-none absolute -right-16 bottom-0 h-96 w-96 rounded-full bg-[#ff6b00]/5 blur-[160px]" aria-hidden />
+
+          <div className="relative mx-auto max-w-7xl space-y-10 px-4 pb-16 pt-12 sm:px-6 lg:px-8">
             {isLoading ? (
-              <div className="mb-12">
-                <Skeleton className="h-10 w-64 mb-4" />
-                <Skeleton className="h-6 w-48" />
-              </div>
+              <Skeleton className="h-44 rounded-3xl bg-[#1a1a1a]" />
             ) : (
               <DashboardHeader username={user?.username || authUser?.username || ''} />
             )}
 
-            {/* Stats Grid */}
-            {isLoading ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-                {[...Array(4)].map((_, i) => (
-                  <Skeleton key={i} className="h-32" />
-                ))}
-              </div>
-            ) : (
-              <StatsGrid stats={safeStats} />
-            )}
-
-            {/* Main Content Grid */}
-            <div className="grid grid-cols-1 xl:grid-cols-3 gap-8">
-              {/* Main Content Area */}
-              <div className="xl:col-span-2 space-y-8">
-                {/* Quick Actions */}
-                <QuickActions />
-
-                {/* Favorite Sellers Section */}
-                <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-                  <div className="flex items-center justify-between mb-5">
-                    <div className="flex items-center gap-2">
-                      <Heart className="w-5 h-5 text-[#ff950e]" />
-                      <h2 className="text-xl font-bold text-white">Favorite Sellers</h2>
-                      <span className="text-sm text-gray-400">({favoriteCount})</span>
-                    </div>
-                    {favoriteCount > 3 && (
+            <nav className="sticky top-6 z-30">
+              <div className="rounded-full border border-white/10 bg-black/40 p-1 backdrop-blur">
+                <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
+                  {sectionNavItems.map((item) => {
+                    const isActive = activeSection === item.id;
+                    return (
                       <button
-                        onClick={() => router.push('/browse')}
-                        className="text-sm text-[#ff950e] hover:text-[#ff7a00] transition-colors"
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleSectionNavigation(item.id)}
+                        className={`rounded-full px-4 py-2 text-xs font-semibold transition sm:text-sm ${
+                          isActive
+                            ? 'bg-white/15 text-white shadow-[0_12px_30px_-20px_rgba(255,149,14,0.75)] ring-1 ring-[#ff950e]/40'
+                            : 'text-gray-500 hover:text-white'
+                        }`}
                       >
-                        Browse more →
+                        {item.label}
                       </button>
-                    )}
-                  </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </nav>
 
-                  {loadingFavorites ? (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {[...Array(3)].map((_, i) => (
-                        <Skeleton key={i} className="h-24" />
+            <section id="overview" className="scroll-mt-32 space-y-6">
+              <div className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr),minmax(0,1fr)]">
+                <div className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_12px_40px_-24px_rgba(0,0,0,0.8)]">
+                  {isLoading ? (
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+                      {[...Array(4)].map((_, index) => (
+                        <Skeleton key={`overview-stat-${index}`} className="h-32 rounded-2xl bg-[#1a1a1a]" />
                       ))}
                     </div>
-                  ) : favoriteCount === 0 ? (
-                    <div className="text-center py-8">
-                      <Heart className="mx-auto mb-3 text-gray-600" size={32} />
-                      <p className="text-gray-400 mb-4">No favorite sellers yet</p>
-                      <button
-                        onClick={() => router.push('/browse')}
-                        className="px-4 py-2 bg-[#ff950e] text-black rounded-lg text-sm font-medium hover:bg-[#ff7a00] transition-colors"
-                      >
-                        Browse Sellers
-                      </button>
-                    </div>
                   ) : (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {safeFavorites.slice(0, 6).map((favorite) => {
-                        if (!favorite?.sellerId || !favorite?.sellerUsername) return null;
-                        
-                        return (
-                          <div
-                            key={favorite.sellerId}
-                            className="bg-[#111] rounded-lg p-4 hover:bg-[#222] transition-colors group"
-                          >
-                            <div className="flex items-start justify-between mb-3">
-                              <div className="flex items-center gap-3">
-                                <div 
-                                  className="relative w-10 h-10 rounded-full overflow-hidden bg-gray-800 cursor-pointer"
-                                  onClick={() => handleViewSellerProfile(favorite.sellerUsername)}
-                                >
-                                  {favorite.profilePicture && !imageErrors[favorite.sellerId] ? (
-                                    <Image
-                                      src={favorite.profilePicture}
-                                      alt={favorite.sellerUsername}
-                                      fill
-                                      className="object-cover"
-                                      onError={() => handleImageError(favorite.sellerId)}
-                                      onLoad={() => handleImageLoad(favorite.sellerId)}
-                                    />
-                                  ) : (
-                                    <div className="w-full h-full flex items-center justify-center text-gray-600">
-                                      <Heart size={16} />
-                                    </div>
-                                  )}
-                                </div>
-                                <div>
-                                  <h3 
-                                    className="font-medium text-white hover:text-[#ff950e] cursor-pointer transition-colors"
-                                    onClick={() => handleViewSellerProfile(favorite.sellerUsername)}
-                                  >
-                                    {favorite.sellerUsername}
-                                  </h3>
-                                  <div className="flex items-center gap-1 mt-0.5">
-                                    {favorite.isVerified && (
-                                      <Star className="text-[#ff950e]" size={12} />
-                                    )}
-                                    {favorite.tier && (
-                                      <span className="text-xs text-gray-400">{favorite.tier}</span>
-                                    )}
-                                  </div>
-                                </div>
-                              </div>
-                              <button
-                                onClick={() => handleRemoveFavorite(favorite)}
-                                className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500 transition-all"
-                                aria-label="Remove from favorites"
-                              >
-                                <X size={16} />
-                              </button>
-                            </div>
-                            <button
-                              onClick={() => handleViewSellerProfile(favorite.sellerUsername)}
-                              className="w-full px-3 py-1.5 bg-[#222] text-white rounded text-xs font-medium hover:bg-[#333] transition-colors"
-                            >
-                              View Profile
-                            </button>
+                    <StatsGrid stats={safeStats} />
+                  )}
+                </div>
+                {isLoading ? (
+                  <Skeleton className="h-full min-h-[280px] rounded-3xl bg-[#1a1a1a]" />
+                ) : (
+                  <QuickActions />
+                )}
+              </div>
+            </section>
+
+            <section id="connections" className="scroll-mt-32">
+              <div className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_12px_40px_-24px_rgba(0,0,0,0.8)]">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.25em] text-gray-500">Your network</p>
+                    <h2 className="mt-1 text-xl font-semibold text-white">Creators you follow</h2>
+                  </div>
+                  <div className="flex items-center gap-2 rounded-full border border-white/10 bg-black/30 p-1">
+                    <button
+                      type="button"
+                      onClick={() => setActiveCollection('favorites')}
+                      className={`rounded-full px-4 py-1.5 text-xs font-semibold transition sm:text-sm ${
+                        activeCollection === 'favorites'
+                          ? 'bg-white/15 text-white shadow-[0_8px_24px_-16px_rgba(255,149,14,0.75)]'
+                          : 'text-gray-500 hover:text-white'
+                      }`}
+                    >
+                      Favorites
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setActiveCollection('subscriptions')}
+                      className={`rounded-full px-4 py-1.5 text-xs font-semibold transition sm:text-sm ${
+                        activeCollection === 'subscriptions'
+                          ? 'bg-white/15 text-white shadow-[0_8px_24px_-16px_rgba(255,149,14,0.75)]'
+                          : 'text-gray-500 hover:text-white'
+                      }`}
+                    >
+                      Subscriptions
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-6 space-y-4">
+                  {activeCollection === 'favorites' ? (
+                    <>
+                      {renderFavoritePreview()}
+                      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500">
+                        <span>Showing up to four favorites</span>
+                        <button
+                          type="button"
+                          onClick={() => router.push('/browse')}
+                          className="font-semibold text-[#ff950e] transition hover:text-[#ffb347]"
+                        >
+                          Discover more sellers
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      {renderSubscriptionPreview()}
+                      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500">
+                        <span>Recent membership updates</span>
+                        <button
+                          type="button"
+                          onClick={() => router.push('/buyers/profile')}
+                          className="font-semibold text-[#ff950e] transition hover:text-[#ffb347]"
+                        >
+                          Manage subscriptions
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                {favError && activeCollection === 'favorites' && (
+                  <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+                    {favError}
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section id="timeline" className="scroll-mt-32">
+              {isLoading ? (
+                <Skeleton className="h-[340px] rounded-3xl bg-[#1a1a1a]" />
+              ) : (
+                <RecentActivity activities={recentActivity || []} />
+              )}
+            </section>
+
+            <section id="insights" className="scroll-mt-32">
+              {isLoading ? (
+                <Skeleton className="h-[340px] rounded-3xl bg-[#1a1a1a]" />
+              ) : (
+                <div className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_12px_40px_-24px_rgba(0,0,0,0.8)]">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.25em] text-gray-500">Financial pulse</p>
+                      <h2 className="mt-1 text-xl font-semibold text-white">Wallet &amp; activity</h2>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => router.push('/wallet/buyer')}
+                      className="rounded-full border border-white/10 px-3 py-1.5 text-xs font-semibold text-gray-300 transition hover:border-[#ff950e] hover:text-[#ff950e]"
+                    >
+                      Manage funds
+                    </button>
+                  </div>
+
+                  <div className="mt-8 grid gap-5 lg:grid-cols-3">
+                    <div className="rounded-2xl border border-white/5 bg-black/40 p-5">
+                      <p className="text-sm text-gray-500">Current balance</p>
+                      <p className="mt-3 text-3xl font-semibold text-white">${safeBalance.toFixed(2)}</p>
+                      <p className="mt-2 text-xs text-gray-500">Available wallet balance</p>
+                      <dl className="mt-6 space-y-3 text-sm text-gray-400">
+                        <div className="flex items-center justify-between">
+                          <dt>Orders this month</dt>
+                          <dd className="font-semibold text-white">{safeStats.thisMonthOrders}</dd>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <dt>Active subscriptions</dt>
+                          <dd className="font-semibold text-white">{safeStats.activeSubscriptions}</dd>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <dt>Open requests</dt>
+                          <dd className="font-semibold text-white">{safeStats.pendingRequests}</dd>
+                        </div>
+                      </dl>
+                    </div>
+
+                    <div className="rounded-2xl border border-white/5 bg-black/40 p-5">
+                      <div className="flex items-center gap-3">
+                        <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/15 text-blue-200">
+                          <Truck className="h-5 w-5" />
+                        </span>
+                        <div>
+                          <h3 className="text-base font-semibold text-white">Order status</h3>
+                          <p className="text-xs text-gray-500">Snapshot of your active deliveries</p>
+                        </div>
+                      </div>
+                      <div className="mt-6 space-y-3 text-sm text-gray-400">
+                        <div className="flex items-center justify-between rounded-xl bg-[#0b0b0b] px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <Clock className="h-4 w-4 text-yellow-300" />
+                            Processing
                           </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                  
-                  {/* Error message for favorites */}
-                  {favError && (
-                    <div className="mt-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
-                      <p className="text-red-400 text-sm">{favError}</p>
-                    </div>
-                  )}
-                </div>
-
-                {/* Recent Activity */}
-                {isLoading ? (
-                  <Skeleton className="h-96" />
-                ) : (
-                  <RecentActivity activities={recentActivity || []} />
-                )}
-              </div>
-
-              {/* Sidebar */}
-              <div className="xl:col-span-1 space-y-8">
-                {/* Subscriptions */}
-                {isLoading ? (
-                  <Skeleton className="h-64" />
-                ) : (
-                  <SubscribedSellers subscriptions={subscribedSellers || []} />
-                )}
-
-                {/* Order Status */}
-                <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-                  <div className="flex items-center gap-2 mb-5">
-                    <Truck className="w-5 h-5 text-blue-400" />
-                    <h2 className="text-xl font-bold text-white">Order Status</h2>
-                  </div>
-                  
-                  {isLoading ? (
-                    <div className="space-y-2">
-                      <Skeleton className="h-16" />
-                      <Skeleton className="h-16" />
-                    </div>
-                  ) : (
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between p-3 bg-[#111111] rounded-lg">
-                        <div className="flex items-center gap-3">
-                          <Clock className="w-4 h-4 text-yellow-400" />
-                          <span className="text-sm text-gray-300">Processing</span>
+                          <span className="font-semibold text-white">{safeStats.pendingShipments}</span>
                         </div>
-                        <span className="text-sm font-bold text-white">{safeStats.pendingShipments}</span>
-                      </div>
-                      
-                      <div className="flex items-center justify-between p-3 bg-[#111111] rounded-lg">
-                        <div className="flex items-center gap-3">
-                          <CheckCircle className="w-4 h-4 text-green-400" />
-                          <span className="text-sm text-gray-300">Delivered</span>
+                        <div className="flex items-center justify-between rounded-xl bg-[#0b0b0b] px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <CheckCircle className="h-4 w-4 text-emerald-300" />
+                            Delivered
+                          </div>
+                          <span className="font-semibold text-white">{safeStats.completedOrders}</span>
                         </div>
-                        <span className="text-sm font-bold text-white">{safeStats.completedOrders}</span>
                       </div>
                     </div>
-                  )}
-                </div>
 
-                {/* Quick Stats */}
-                <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-                  <h2 className="text-lg font-bold text-white mb-4">Quick Stats</h2>
-                  <div className="space-y-3">
-                    <div className="flex justify-between text-sm">
-                      <span className="text-gray-400">This Week Spent</span>
-                      <span className="text-white font-bold">${safeStats.thisWeekSpent.toFixed(2)}</span>
-                    </div>
-                    <div className="flex justify-between text-sm">
-                      <span className="text-gray-400">Average Order</span>
-                      <span className="text-white font-bold">${safeStats.averageOrderValue.toFixed(2)}</span>
-                    </div>
-                    <div className="flex justify-between text-sm">
-                      <span className="text-gray-400">Favorite Sellers</span>
-                      <span className="text-white font-bold">{favoriteCount}</span>
+                    <div className="rounded-2xl border border-white/5 bg-black/40 p-5">
+                      <h3 className="text-base font-semibold text-white">Spending insights</h3>
+                      <p className="mt-1 text-xs text-gray-500">Keep tabs on your purchasing habits</p>
+                      <div className="mt-6 space-y-4 text-sm text-gray-400">
+                        <div className="flex items-center justify-between rounded-xl bg-[#0b0b0b] px-4 py-3">
+                          <span className="text-gray-500">This week</span>
+                          <span className="font-semibold text-white">${safeStats.thisWeekSpent.toFixed(2)}</span>
+                        </div>
+                        <div className="flex items-center justify-between rounded-xl bg-[#0b0b0b] px-4 py-3">
+                          <span className="text-gray-500">Average order value</span>
+                          <span className="font-semibold text-white">${safeStats.averageOrderValue.toFixed(2)}</span>
+                        </div>
+                        <div className="flex items-center justify-between rounded-xl bg-[#0b0b0b] px-4 py-3">
+                          <span className="text-gray-500">Favorite sellers</span>
+                          <span className="font-semibold text-white">{favoriteCount}</span>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
+              )}
+            </section>
           </div>
         </main>
       </RequireAuth>

--- a/src/components/buyers/dashboard/DashboardHeader.tsx
+++ b/src/components/buyers/dashboard/DashboardHeader.tsx
@@ -1,6 +1,8 @@
 // src/components/buyers/dashboard/DashboardHeader.tsx
 'use client';
 
+import Link from 'next/link';
+import { ArrowUpRight } from 'lucide-react';
 import { SecureMessageDisplay } from '@/components/ui/SecureMessageDisplay';
 
 interface DashboardHeaderProps {
@@ -9,19 +11,35 @@ interface DashboardHeaderProps {
 
 export default function DashboardHeader({ username }: DashboardHeaderProps) {
   return (
-    <div className="mb-12">
-      <div>
-        <h1 className="text-4xl font-bold text-white mb-2">
-          Welcome back,{' '}
-          <SecureMessageDisplay
-            content={username}
-            allowBasicFormatting={false}
-            className="text-[#ff950e] inline"
-          />
-          !
-        </h1>
-        <p className="text-gray-400 text-lg">Here&apos;s an overview of your account activity</p>
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#111111]/90 px-8 py-10 shadow-[0_20px_60px_-30px_rgba(255,149,14,0.45)]">
+      <div className="absolute -left-20 top-0 h-64 w-64 rounded-full bg-[#ff950e]/10 blur-3xl" aria-hidden />
+      <div className="absolute -right-10 -bottom-16 h-56 w-56 rounded-full bg-[#ff6b00]/5 blur-3xl" aria-hidden />
+
+      <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-4">
+          <p className="text-[11px] uppercase tracking-[0.35em] text-gray-500">Buyer dashboard</p>
+          <div>
+            <p className="text-sm text-gray-400">Welcome back</p>
+            <h1 className="mt-1 text-3xl font-semibold text-white sm:text-4xl">
+              <SecureMessageDisplay content={username} allowBasicFormatting={false} className="inline" />
+            </h1>
+          </div>
+          <p className="max-w-xl text-sm text-gray-400 sm:text-base">
+            Monitor orders, discover new drops, and stay close to the creators you trust most.
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col gap-3 sm:w-auto">
+          <Link
+            href="/browse"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] px-5 py-2 text-sm font-semibold text-black shadow-lg transition hover:shadow-[#ff950e]/30"
+          >
+            Explore marketplace
+            <ArrowUpRight className="h-4 w-4" />
+          </Link>
+          <p className="text-xs text-gray-500">New drops land daily. Keep your wallet ready.</p>
+        </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/buyers/dashboard/QuickActions.tsx
+++ b/src/components/buyers/dashboard/QuickActions.tsx
@@ -2,51 +2,74 @@
 'use client';
 
 import Link from 'next/link';
-import { ShoppingBag, MessageCircle, Package, Wallet } from 'lucide-react';
+import { ArrowUpRight, MessageCircle, Package, ShoppingBag, Wallet } from 'lucide-react';
 import { QuickActionsProps } from '@/types/dashboard';
+
+const ACTIONS = [
+  {
+    title: 'Browse marketplace',
+    description: 'Curated listings tailored to your preferences.',
+    href: '/browse',
+    tone: 'bg-orange-500/15 text-orange-200',
+    icon: <ShoppingBag className="h-4 w-4" />,
+  },
+  {
+    title: 'Messages',
+    description: 'Continue conversations with trusted sellers.',
+    href: '/buyers/messages',
+    tone: 'bg-blue-500/15 text-blue-200',
+    icon: <MessageCircle className="h-4 w-4" />,
+  },
+  {
+    title: 'Track orders',
+    description: 'Follow fulfilment progress and delivery updates.',
+    href: '/buyers/my-orders',
+    tone: 'bg-purple-500/15 text-purple-200',
+    icon: <Package className="h-4 w-4" />,
+  },
+  {
+    title: 'Wallet',
+    description: 'Manage balance, deposits, and payouts.',
+    href: '/wallet/buyer',
+    tone: 'bg-emerald-500/15 text-emerald-200',
+    icon: <Wallet className="h-4 w-4" />,
+  },
+];
 
 export default function QuickActions({}: QuickActionsProps) {
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-      <h2 className="text-xl font-bold text-white mb-5">Quick Actions</h2>
-
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <Link
-          href="/browse"
-          className="bg-[#111111] border border-gray-700 hover:border-[#ff950e] hover:bg-[#1a1a1a] rounded-lg p-5 transition-all group"
-        >
-          <ShoppingBag className="w-7 h-7 text-[#ff950e] mb-3 group-hover:scale-110 transition-transform" />
-          <p className="text-white font-semibold mb-1 text-sm">Browse</p>
-          <p className="text-gray-400 text-xs">Find new items</p>
-        </Link>
-
-        <Link
-          href="/buyers/messages"
-          className="bg-[#111111] border border-gray-700 hover:border-blue-400 hover:bg-[#1a1a1a] rounded-lg p-5 transition-all group"
-        >
-          <MessageCircle className="w-7 h-7 text-blue-400 mb-3 group-hover:scale-110 transition-transform" />
-          <p className="text-white font-semibold mb-1 text-sm">Messages</p>
-          <p className="text-gray-400 text-xs">Chat with sellers</p>
-        </Link>
-
-        <Link
-          href="/buyers/my-orders"
-          className="bg-[#111111] border border-gray-700 hover:border-purple-400 hover:bg-[#1a1a1a] rounded-lg p-5 transition-all group"
-        >
-          <Package className="w-7 h-7 text-purple-400 mb-3 group-hover:scale-110 transition-transform" />
-          <p className="text-white font-semibold mb-1 text-sm">My Orders</p>
-          <p className="text-gray-400 text-xs">Track purchases</p>
-        </Link>
-
-        <Link
-          href="/wallet/buyer"
-          className="bg-[#111111] border border-gray-700 hover:border-green-400 hover:bg-[#1a1a1a] rounded-lg p-5 transition-all group"
-        >
-          <Wallet className="w-7 h-7 text-green-400 mb-3 group-hover:scale-110 transition-transform" />
-          <p className="text-white font-semibold mb-1 text-sm">Wallet</p>
-          <p className="text-gray-400 text-xs">Manage funds</p>
-        </Link>
+    <section className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_10px_30px_-18px_rgba(0,0,0,0.9)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Quick paths</h2>
+          <p className="text-xs text-gray-500">Go straight to the tools buyers use most.</p>
+        </div>
+        <ArrowUpRight className="h-4 w-4 text-gray-600" />
       </div>
-    </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {ACTIONS.map((action) => (
+          <Link
+            key={action.href}
+            href={action.href}
+            className="group flex h-full flex-col justify-between gap-4 rounded-2xl border border-white/5 bg-gradient-to-br from-[#181818] to-[#0f0f0f] p-4 transition hover:border-[#ff950e]/40 hover:bg-[#161616]"
+          >
+            <div className="flex items-start gap-3">
+              <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${action.tone}`}>
+                {action.icon}
+              </span>
+              <div>
+                <p className="text-sm font-semibold text-white">{action.title}</p>
+                <p className="text-xs text-gray-500">{action.description}</p>
+              </div>
+            </div>
+            <span className="flex items-center gap-1 text-xs font-semibold text-[#ff950e] transition group-hover:text-[#ffb347]">
+              Open
+              <ArrowUpRight className="h-3.5 w-3.5" />
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/src/components/buyers/dashboard/RecentActivity.tsx
+++ b/src/components/buyers/dashboard/RecentActivity.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowRight, Clock, CheckCircle, AlertCircle, Truck } from 'lucide-react';
+import { Clock, CheckCircle, AlertCircle, Truck } from 'lucide-react';
 import { SecureMessageDisplay } from '@/components/ui/SecureMessageDisplay';
 import { RecentActivityProps } from '@/types/dashboard';
 
@@ -40,61 +40,72 @@ export default function RecentActivity({ activities }: RecentActivityProps) {
   const safeActivities = Array.isArray(activities) ? activities : [];
 
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-      <div className="flex items-center justify-between mb-5">
-        <h2 className="text-xl font-bold text-white">Recent Activity</h2>
-        <Link href="/buyers/my-orders" className="text-[#ff950e] hover:text-[#e88800] font-medium flex items-center gap-2 text-sm">
-          View All <ArrowRight className="w-4 h-4" />
+    <section className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_10px_30px_-18px_rgba(0,0,0,0.9)]">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-lg font-semibold text-white">Recent activity</h2>
+        <Link
+          href="/buyers/my-orders"
+          className="text-xs font-medium text-[#ff950e] transition hover:text-[#ffb347]"
+        >
+          View all orders
         </Link>
       </div>
 
       {safeActivities.length > 0 ? (
-        <div className="space-y-3">
-          {safeActivities.map((activity) => (
-            <Link
-              key={activity.id}
-              href={activity.href || '#'}
-              className="flex items-center justify-between bg-[#111111] rounded-lg p-4 hover:bg-[#1a1a1a] transition-colors group"
-            >
-              <div className="flex items-center gap-4">
-                <div className={`p-2 rounded-lg bg-black ${getStatusColor(activity.type)}`}>{activity.icon}</div>
-                <div>
+        <div className="mt-6 space-y-6">
+          {safeActivities.map((activity, index) => (
+            <div key={activity.id} className="flex gap-4">
+              <div className="flex flex-col items-center">
+                <span className={`flex h-10 w-10 items-center justify-center rounded-full bg-black/40 ${getStatusColor(activity.type)}`}>
+                  {activity.icon}
+                </span>
+                {index !== safeActivities.length - 1 && <span className="mt-1 h-full w-px bg-white/10" aria-hidden="true" />}
+              </div>
+
+              <Link
+                href={activity.href || '#'}
+                className="flex flex-1 flex-col gap-2 rounded-2xl border border-white/5 bg-gradient-to-br from-[#181818] to-[#0f0f0f] p-4 transition hover:border-[#ff950e]/40 hover:bg-[#161616]"
+              >
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                   <SecureMessageDisplay
                     content={activity.title}
-                    className="text-white font-medium text-sm group-hover:text-[#ff950e] transition-colors"
+                    className="text-sm font-medium text-white"
                     allowBasicFormatting={false}
                     maxLength={100}
                   />
-                  <SecureMessageDisplay
-                    content={activity.subtitle}
-                    className="text-gray-500 text-xs mt-0.5"
-                    allowBasicFormatting={false}
-                    maxLength={80}
-                  />
+                  <p className="text-xs text-gray-500">{activity.time}</p>
                 </div>
-              </div>
+                <SecureMessageDisplay
+                  content={activity.subtitle}
+                  className="text-xs text-gray-500"
+                  allowBasicFormatting={false}
+                  maxLength={80}
+                />
 
-              <div className="text-right flex items-center gap-3">
-                <div>
-                  {typeof activity.amount === 'number' && !Number.isNaN(activity.amount) && (
-                    <p className="text-white font-semibold text-sm">${activity.amount.toFixed(2)}</p>
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  {typeof activity.amount === 'number' && !Number.isNaN(activity.amount) ? (
+                    <span className="font-semibold text-white">${activity.amount.toFixed(2)}</span>
+                  ) : (
+                    <span />
                   )}
-                  <p className="text-gray-500 text-xs">{activity.time}</p>
+                  {activity.status && getStatusIcon(activity.status)}
                 </div>
-                {activity.status && getStatusIcon(activity.status)}
-              </div>
-            </Link>
+              </Link>
+            </div>
           ))}
         </div>
       ) : (
-        <div className="text-center py-12 bg-[#111111] rounded-lg">
-          <Clock className="w-10 h-10 text-gray-600 mx-auto mb-3" />
-          <p className="text-gray-400">No recent activity</p>
-          <Link href="/browse" className="text-[#ff950e] hover:underline text-sm mt-2 inline-block">
-            Start browsing
+        <div className="mt-8 rounded-2xl border border-dashed border-white/10 bg-[#181818] p-10 text-center">
+          <Clock className="mx-auto mb-3 h-10 w-10 text-gray-600" />
+          <p className="text-sm text-gray-400">You&apos;re all caught up. Activity will appear here once you place new orders.</p>
+          <Link
+            href="/browse"
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] px-4 py-2 text-xs font-semibold text-black shadow-lg transition hover:shadow-[#ff950e]/30"
+          >
+            Discover new listings
           </Link>
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/components/buyers/dashboard/StatsGrid.tsx
+++ b/src/components/buyers/dashboard/StatsGrid.tsx
@@ -1,6 +1,7 @@
 // src/components/buyers/dashboard/StatsGrid.tsx
 'use client';
 
+import type { ReactNode } from 'react';
 import { DollarSign, ShoppingBag, MessageCircle, Crown } from 'lucide-react';
 import { StatsGridProps } from '@/types/dashboard';
 
@@ -11,38 +12,59 @@ export default function StatsGrid({ stats }: StatsGridProps) {
   const unreadMessages = Number(stats?.unreadMessages) || 0;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-5">
-        <div className="flex items-center gap-3 mb-3">
-          <DollarSign className="w-6 h-6 text-[#ff950e]" />
-        </div>
-        <p className="text-2xl font-bold text-white">${totalSpent.toFixed(2)}</p>
-        <p className="text-sm text-gray-400 mt-1">Total Spent</p>
-      </div>
-
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-5">
-        <div className="flex items-center justify-between mb-3">
-          <ShoppingBag className="w-6 h-6 text-purple-400" />
-        </div>
-        <p className="text-2xl font-bold text-white">{totalOrders}</p>
-        <p className="text-sm text-gray-400 mt-1">Total Orders</p>
-      </div>
-
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-5">
-        <div className="flex items-center justify-between mb-3">
-          <Crown className="w-6 h-6 text-[#ff950e]" />
-        </div>
-        <p className="text-2xl font-bold text-white">{activeSubscriptions}</p>
-        <p className="text-sm text-gray-400 mt-1">Subscriptions</p>
-      </div>
-
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-5">
-        <div className="flex items-center justify-between mb-3">
-          <MessageCircle className="w-6 h-6 text-blue-400" />
-        </div>
-        <p className="text-2xl font-bold text-white">{unreadMessages}</p>
-        <p className="text-sm text-gray-400 mt-1">Unread Messages</p>
-      </div>
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <StatCard
+        icon={<DollarSign className="h-4 w-4" />}
+        iconTone="bg-[#ff950e]/15 text-[#ffb347]"
+        label="Total spent"
+        value={`$${totalSpent.toFixed(2)}`}
+        supporting="Across all orders"
+      />
+      <StatCard
+        icon={<ShoppingBag className="h-4 w-4" />}
+        iconTone="bg-purple-500/15 text-purple-200"
+        label="Total orders"
+        value={totalOrders.toString()}
+        supporting="Completed purchases"
+      />
+      <StatCard
+        icon={<Crown className="h-4 w-4" />}
+        iconTone="bg-amber-500/15 text-amber-200"
+        label="Subscriptions"
+        value={activeSubscriptions.toString()}
+        supporting="Active plans"
+      />
+      <StatCard
+        icon={<MessageCircle className="h-4 w-4" />}
+        iconTone="bg-blue-500/15 text-blue-200"
+        label="Unread messages"
+        value={unreadMessages.toString()}
+        supporting="Sellers awaiting replies"
+      />
     </div>
+  );
+}
+
+interface StatCardProps {
+  icon: ReactNode;
+  iconTone: string;
+  label: string;
+  value: string;
+  supporting: string;
+}
+
+function StatCard({ icon, iconTone, label, value, supporting }: StatCardProps) {
+  return (
+    <article className="group relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#1b1b1b]/95 to-[#0f0f0f]/95 p-5 shadow-[0_14px_40px_-24px_rgba(0,0,0,0.8)] transition">
+      <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden>
+        <div className="absolute inset-0 bg-[#ff950e]/5" />
+      </div>
+      <div className="relative flex items-center justify-between">
+        <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${iconTone}`}>{icon}</span>
+      </div>
+      <p className="relative mt-6 text-2xl font-semibold text-white">{value}</p>
+      <p className="relative mt-1 text-sm text-gray-300">{label}</p>
+      <p className="relative mt-4 text-xs text-gray-500">{supporting}</p>
+    </article>
   );
 }

--- a/src/components/buyers/dashboard/SubscribedSellers.tsx
+++ b/src/components/buyers/dashboard/SubscribedSellers.tsx
@@ -12,31 +12,32 @@ export default function SubscribedSellers({ subscriptions }: SubscribedSellersPr
   const list = (Array.isArray(subscriptions) ? subscriptions : []) as SubscribedSellersProps['subscriptions'];
 
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-      <div className="flex items-center justify-between mb-5">
-        <h2 className="text-xl font-bold text-white flex items-center gap-2">
-          <Crown className="w-5 h-5 text-[#ff950e]" />
-          Subscriptions
-        </h2>
-        <span className="bg-[#ff950e] text-black text-sm font-bold px-2 py-0.5 rounded">
+    <section className="rounded-3xl border border-white/10 bg-[#111111]/85 p-6 shadow-[0_10px_30px_-18px_rgba(0,0,0,0.9)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/15 text-amber-200">
+            <Crown className="h-4 w-4" />
+          </span>
+          <h2 className="text-lg font-semibold text-white">Subscriptions</h2>
+        </div>
+        <span className="rounded-full bg-orange-400/20 px-3 py-1 text-xs font-semibold text-orange-200">
           {list.length}
         </span>
       </div>
 
       {list.length === 0 ? (
-        <div className="text-center py-8">
-          <Crown className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-          <p className="text-gray-400 mb-4">No active subscriptions</p>
+        <div className="mt-8 rounded-2xl border border-dashed border-white/10 bg-[#181818] p-10 text-center">
+          <Crown className="mx-auto mb-3 h-12 w-12 text-gray-600" />
+          <p className="text-sm text-gray-400">No active subscriptions yet.</p>
           <Link
             href="/browse"
-            className="inline-block bg-[#ff950e] hover:bg-[#e88800] text-black font-bold px-6 py-2.5 rounded-lg transition-colors text-base"
-            style={{ color: '#000000' }}
+            className="mt-6 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] px-5 py-2 text-sm font-semibold text-black shadow-lg transition hover:shadow-[#ff950e]/30"
           >
-            Browse Sellers
+            Browse sellers
           </Link>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="mt-6 space-y-4">
           {list.map((sub) => {
             const sanitizedUsername = sanitizeUsername(sub.seller);
 
@@ -57,43 +58,46 @@ export default function SubscribedSellers({ subscriptions }: SubscribedSellersPr
                 : 0;
 
             return (
-              <div key={sub.seller} className="bg-[#111111] rounded-lg p-4">
-                <div className="flex items-start justify-between">
+              <article
+                key={sub.seller}
+                className="flex flex-col gap-4 rounded-2xl border border-white/5 bg-gradient-to-br from-[#181818] to-[#0f0f0f] p-4 transition hover:border-[#ff950e]/40 hover:bg-[#161616]"
+              >
+                <div className="flex items-start justify-between gap-3">
                   <div className="flex items-start gap-3">
                     {sub.pic ? (
                       <SecureImage
                         src={sub.pic}
                         alt={sub.seller}
-                        className="w-12 h-12 rounded-full object-cover border-2 border-gray-700"
+                        className="h-12 w-12 rounded-full border border-white/10 object-cover"
                         fallbackSrc="/placeholder-avatar.png"
                       />
                     ) : (
-                      <div className="w-12 h-12 rounded-full bg-gray-8 00 flex items-center justify-center">
-                        <Crown className="w-5 h-5 text-gray-600" />
+                      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400">
+                        <Crown className="h-5 w-5" />
                       </div>
                     )}
 
                     <div>
-                      <div className="flex items-center gap-2 mb-1">
+                      <div className="flex flex-wrap items-center gap-2">
                         <Link
                           href={`/sellers/${sanitizedUsername}`}
-                          className="font-medium text-white hover:text-[#ff950e] transition-colors"
+                          className="text-sm font-medium text-white transition hover:text-[#ff950e]"
                         >
                           <SecureMessageDisplay content={sub.seller} allowBasicFormatting={false} className="inline" />
                         </Link>
                         {sub.verified && (
-                          <span title="Verified">
-                            <CheckCircle className="w-4 h-4 text-blue-400" />
+                          <span title="Verified" className="text-blue-200">
+                            <CheckCircle className="h-4 w-4" />
                           </span>
                         )}
                         {sub.tier && (
-                          <span className={`text-xs px-2 py-0.5 rounded-full ${getTierColor(sub.tier)}`}>
+                          <span className={`text-[10px] uppercase tracking-wide ${getTierColor(sub.tier)}`}>
                             {sub.tier}
                           </span>
                         )}
                       </div>
 
-                      <div className="text-sm text-gray-400 line-clamp-2 mb-2">
+                      <div className="mt-2 text-xs text-gray-500 line-clamp-2">
                         <SecureMessageDisplay
                           content={sub.bio}
                           allowBasicFormatting={false}
@@ -101,43 +105,43 @@ export default function SubscribedSellers({ subscriptions }: SubscribedSellersPr
                           className="inline"
                         />
                       </div>
-
-                      <div className="flex items-center gap-4 text-xs text-gray-500">
-                        <span>{newListings} new listings</span>
-                        <span>•</span>
-                        <span>${priceDisplay}/month</span>
-                      </div>
                     </div>
                   </div>
 
                   <Link
                     href={`/sellers/${sanitizedUsername}`}
-                    className="text-gray-400 hover:text-[#ff950e] transition-colors"
-                    title="View Profile"
+                    className="rounded-full border border-white/10 p-2 text-gray-500 transition hover:border-[#ff950e] hover:text-[#ff950e]"
+                    title="View profile"
                   >
-                    <ExternalLink className="w-4 h-4" />
+                    <ExternalLink className="h-4 w-4" />
                   </Link>
                 </div>
-              </div>
+
+                <div className="flex flex-wrap gap-3 text-[11px] uppercase tracking-wide text-gray-500">
+                  <span>{newListings} new listings</span>
+                  <span className="text-white/20">•</span>
+                  <span>${priceDisplay}/month</span>
+                </div>
+              </article>
             );
           })}
         </div>
       )}
-    </div>
+    </section>
   );
 }
 
 const getTierColor = (tier?: string) => {
   switch (tier) {
     case 'Goddess':
-      return 'text-purple-400 bg-purple-400/20';
+      return 'text-purple-200';
     case 'Desire':
-      return 'text-pink-400 bg-pink-400/20';
+      return 'text-pink-200';
     case 'Obsession':
-      return 'text-red-400 bg-red-400/20';
+      return 'text-red-200';
     case 'Flirt':
-      return 'text-orange-400 bg-orange-400/20';
+      return 'text-orange-200';
     default:
-      return 'text-yellow-400 bg-yellow-400/20';
+      return 'text-amber-200';
   }
 };


### PR DESCRIPTION
## Summary
- restructure the buyer dashboard with a sticky section navigator, compact overview grid, and tabbed connections preview to reduce page length
- consolidate wallet, order status, and spending cards into a single insights panel while limiting favorites/subscriptions previews with clear CTAs
- tighten the quick actions layout into balanced tiles that align with the refreshed dashboard shell

## Testing
- npm run lint *(fails: pre-existing lint violations across many contexts)*

------
https://chatgpt.com/codex/tasks/task_e_68e1375241bc8328a9168bf2977d7103