### PR TITLE
feat: refresh buyer orders UI with dashboard aesthetic

### DIFF
--- a/src/app/buyers/my-orders/page.tsx
+++ b/src/app/buyers/my-orders/page.tsx
@@ -15,17 +15,21 @@ import { AlertCircle, Loader2 } from 'lucide-react';
 // Error component (Enhanced UI styling)
 function OrdersError({ error, onRetry }: { error: string; onRetry: () => void }) {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-black via-[#050505] to-[#0a0a0a]">
-      <div className="p-6 md:p-10">
-        <div className="max-w-md mx-auto text-center pt-20">
-          <div className="mx-auto mb-6 inline-flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-red-500/10 to-red-600/10 ring-1 ring-red-500/20 backdrop-blur-sm">
-            <AlertCircle className="w-10 h-10 text-red-400" />
+    <div className="relative min-h-screen overflow-hidden bg-[#020202] text-white">
+      <div className="absolute inset-0">
+        <div className="pointer-events-none absolute -top-40 right-[-20%] h-[480px] w-[480px] rounded-full bg-[#ff950e]/15 blur-3xl" />
+        <div className="pointer-events-none absolute bottom-[-30%] left-[-10%] h-[420px] w-[420px] rounded-full bg-[#ff7a00]/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-10 text-center shadow-[0_25px_80px_-40px_rgba(255,149,14,0.45)] backdrop-blur-xl">
+          <div className="mx-auto mb-8 flex h-20 w-20 items-center justify-center rounded-2xl border border-red-500/30 bg-red-500/10">
+            <AlertCircle className="h-10 w-10 text-red-400" />
           </div>
-          <h1 className="text-3xl font-bold tracking-tight text-white mb-3">Error loading orders</h1>
-          <p className="text-base text-gray-400 mb-8">{error}</p>
+          <h1 className="text-3xl font-semibold tracking-tight">We couldn't load your orders</h1>
+          <p className="mt-3 text-sm text-gray-400">{error}</p>
           <button
             onClick={onRetry}
-            className="px-8 py-3.5 rounded-xl bg-gradient-to-r from-[#ff950e] to-[#ff7a00] text-black font-semibold hover:from-[#ff7a00] hover:to-[#ff950e] transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#ff950e]/50 transform hover:scale-105 active:scale-95"
+            className="mt-8 inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#ff950e] to-[#ff7a00] px-8 py-3 text-base font-semibold text-black shadow-[0_18px_45px_-25px_rgba(255,149,14,0.9)] transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#ff950e]/60"
           >
             Try again
           </button>
@@ -38,15 +42,17 @@ function OrdersError({ error, onRetry }: { error: string; onRetry: () => void })
 // Loading component (Enhanced UI)
 function OrdersLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-black via-[#050505] to-[#0a0a0a]">
-      <div className="p-6 md:p-10">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center py-20">
-            <div className="mx-auto mb-6 inline-flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-[#ff950e]/10 to-[#ff950e]/5 ring-1 ring-[#ff950e]/20 backdrop-blur-sm">
-              <Loader2 className="w-8 h-8 text-[#ff950e] animate-spin" />
-            </div>
-            <p className="text-gray-300 text-lg">Loading your orders…</p>
+    <div className="relative min-h-screen overflow-hidden bg-[#020202] text-white">
+      <div className="absolute inset-0">
+        <div className="pointer-events-none absolute left-1/2 top-[-20%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[#ff950e]/12 blur-3xl" />
+        <div className="pointer-events-none absolute bottom-[-10%] left-1/3 h-[420px] w-[420px] rounded-full bg-[#ff7a00]/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
+        <div className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/[0.03] px-10 py-16 shadow-[0_20px_60px_-30px_rgba(255,149,14,0.4)] backdrop-blur-xl">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+            <Loader2 className="h-8 w-8 animate-spin text-[#ff950e]" />
           </div>
+          <p className="text-base text-gray-300">Loading your orders…</p>
         </div>
       </div>
     </div>
@@ -91,51 +97,58 @@ function MyOrdersContent() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-black via-[#050505] to-[#0a0a0a] p-4 md:p-10">
-      <div className="max-w-7xl mx-auto space-y-6 md:space-y-8">
-        
-        {/* Page Header - Enhanced styling */}
-        <section className="relative overflow-hidden rounded-2xl border border-white/5 bg-gradient-to-br from-white/[0.03] to-transparent backdrop-blur-md p-6 md:p-8 lg:p-10">
-          <div className="absolute inset-0 bg-gradient-to-br from-[#ff950e]/5 via-transparent to-transparent pointer-events-none" />
-          <div className="relative z-10">
-            <OrdersHeader />
-          </div>
-        </section>
-
-        {/* Stats Cards - Better responsive grid */}
-        <section className="rounded-2xl border border-white/5 bg-white/[0.02] p-4 md:p-6 backdrop-blur-sm">
-          <OrderStats stats={safeStats} />
-        </section>
-
-        {/* Orders Section - Enhanced card layout */}
-        <section className="rounded-2xl border border-white/5 bg-gradient-to-br from-white/[0.02] to-transparent p-4 md:p-6">
-          {safeUserOrders.length === 0 ? (
-            <div className="rounded-xl bg-black/30 backdrop-blur-sm border border-white/5 p-8 md:p-12">
-              <EmptyOrdersState />
-            </div>
-          ) : (
-            <OrderSections
-              directOrders={safeDirectOrders}
-              customRequestOrders={safeCustomRequestOrders}
-              auctionOrders={safeAuctionOrders}
-              expandedOrder={expandedOrder}
-              onToggleExpanded={setExpandedOrder}
-              onOpenAddressModal={handleOpenAddressModal}
-            />
-          )}
-        </section>
-
-        {/* Address Modal */}
-        <AddressConfirmationModal
-          isOpen={addressModalOpen}
-          onClose={() => {
-            setAddressModalOpen(false);
-          }}
-          onConfirm={handleConfirmAddress}
-          existingAddress={getSelectedOrderAddress()}
-          orderId={selectedOrder || ''}
-        />
+    <main className="relative min-h-screen overflow-hidden bg-[#020202]">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-15%] top-[-20%] h-[520px] w-[520px] rounded-full bg-[#ff950e]/15 blur-3xl" />
+        <div className="absolute right-[-10%] top-[30%] h-[480px] w-[480px] rounded-full bg-[#ff7a00]/12 blur-3xl" />
+        <div className="absolute bottom-[-25%] left-[25%] h-[420px] w-[420px] rounded-full bg-emerald-500/10 blur-3xl" />
       </div>
+
+      <div className="relative z-10 px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-8">
+          {/* Page Header */}
+          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 sm:p-8 lg:p-12 shadow-[0_30px_90px_-45px_rgba(255,149,14,0.6)] backdrop-blur-xl">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.15),_transparent_55%)]" />
+            <div className="relative z-10">
+              <OrdersHeader />
+            </div>
+          </section>
+
+          {/* Stats */}
+          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.8)] backdrop-blur-xl">
+            <OrderStats stats={safeStats} />
+          </section>
+
+          {/* Orders */}
+          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8 shadow-[0_25px_80px_-45px_rgba(0,0,0,0.9)] backdrop-blur-xl">
+            {safeUserOrders.length === 0 ? (
+              <div className="rounded-3xl border border-dashed border-white/15 bg-black/40 p-10">
+                <EmptyOrdersState />
+              </div>
+            ) : (
+              <OrderSections
+                directOrders={safeDirectOrders}
+                customRequestOrders={safeCustomRequestOrders}
+                auctionOrders={safeAuctionOrders}
+                expandedOrder={expandedOrder}
+                onToggleExpanded={setExpandedOrder}
+                onOpenAddressModal={handleOpenAddressModal}
+              />
+            )}
+          </section>
+        </div>
+      </div>
+
+      {/* Address Modal */}
+      <AddressConfirmationModal
+        isOpen={addressModalOpen}
+        onClose={() => {
+          setAddressModalOpen(false);
+        }}
+        onConfirm={handleConfirmAddress}
+        existingAddress={getSelectedOrderAddress()}
+        orderId={selectedOrder || ''}
+      />
     </main>
   );
 }

--- a/src/components/buyers/my-orders/EmptyOrdersState.tsx
+++ b/src/components/buyers/my-orders/EmptyOrdersState.tsx
@@ -7,34 +7,35 @@ import { Package, MessageCircle } from 'lucide-react';
 
 export default function EmptyOrdersState() {
   return (
-    <div className="text-center py-20 bg-[#1a1a1a] rounded-2xl border border-gray-800">
-      <Package className="w-24 h-24 text-gray-600 mx-auto mb-8" />
-      <h3 className="text-2xl font-bold text-gray-400 mb-4">No orders yet</h3>
-      <p className="text-gray-500 text-lg mb-8 max-w-md mx-auto">
-        Your purchases from direct sales, auctions, and custom requests will appear here once you start shopping.
-      </p>
-      <div className="flex flex-wrap justify-center gap-4">
-        <Link
-          href="/browse"
-          className="group relative inline-flex items-center gap-2 bg-transparent text-[#ff950e] font-semibold px-8 py-3 rounded-xl transition-all duration-300 border-2 border-[#ff950e]/70 hover:border-[#ff950e] hover:bg-[#ff950e]/10 hover:-translate-y-1 shadow-[0_4px_0_0] shadow-[#ff950e]/50 hover:shadow-[0_6px_0_0] hover:shadow-[#ff950e]/70"
-        >
-          <Package className="w-5 h-5 transition-transform duration-300 group-hover:scale-110" />
-          <span className="relative">
-            Browse Listings
-            <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-[#ff950e] transition-all duration-300 group-hover:w-full"></span>
-          </span>
-        </Link>
-        
-        <Link
-          href="/buyers/messages"
-          className="group relative inline-flex items-center gap-2 bg-transparent text-[#ff950e] font-semibold px-8 py-3 rounded-xl transition-all duration-300 border-2 border-[#ff950e]/70 hover:border-[#ff950e] hover:bg-[#ff950e]/10 hover:-translate-y-1 shadow-[0_4px_0_0] shadow-[#ff950e]/50 hover:shadow-[0_6px_0_0] hover:shadow-[#ff950e]/70"
-        >
-          <MessageCircle className="w-5 h-5 transition-transform duration-300 group-hover:rotate-12" />
-          <span className="relative">
-            Send Custom Requests
-            <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-[#ff950e] transition-all duration-300 group-hover:w-full"></span>
-          </span>
-        </Link>
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/[0.03] via-black/40 to-black/60 px-8 py-16 text-center shadow-[0_30px_90px_-50px_rgba(255,149,14,0.5)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.18),_transparent_60%)]" />
+      <div className="relative z-10 mx-auto flex max-w-2xl flex-col items-center gap-8">
+        <div className="flex h-24 w-24 items-center justify-center rounded-[28px] border border-white/10 bg-black/40">
+          <Package className="h-12 w-12 text-white/40" />
+        </div>
+        <div className="space-y-3">
+          <h3 className="text-3xl font-semibold text-white">You haven't placed any orders yet</h3>
+          <p className="text-base text-gray-400">
+            Discover verified sellers, browse curated drops, or send a custom request to get something made just for you.
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link
+            href="/browse"
+            className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[#ff950e] to-[#ff7a00] px-8 py-3 text-base font-semibold text-black shadow-[0_18px_45px_-25px_rgba(255,149,14,0.8)] transition-transform hover:-translate-y-0.5"
+          >
+            <Package className="h-5 w-5" />
+            Explore listings
+          </Link>
+
+          <Link
+            href="/buyers/messages"
+            className="inline-flex items-center gap-2 rounded-2xl border border-white/15 bg-white/5 px-8 py-3 text-base font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-white/10"
+          >
+            <MessageCircle className="h-5 w-5" />
+            Send a custom request
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/components/buyers/my-orders/ExpandedOrderContent.tsx
+++ b/src/components/buyers/my-orders/ExpandedOrderContent.tsx
@@ -56,112 +56,105 @@ export default function ExpandedOrderContent({
   const trackingNumber = getTrackingNumber(order);
 
   return (
-    <div className="px-6 pb-6 space-y-6 animate-in slide-in-from-top-2 duration-200">
-      {/* Seller Info - Cleaner layout */}
-      <div className="flex items-center justify-between p-4 bg-white/[0.02] rounded-xl">
-        <Link
-          href={`/sellers/${sanitizedUsername}`}
-          className="flex items-center gap-3 group"
-        >
-          {sellerProfilePic ? (
-            <SecureImage
-              src={sellerProfilePic}
-              alt={order.seller}
-              className="w-12 h-12 rounded-full object-cover ring-2 ring-white/10 group-hover:ring-[#ff950e]/50 transition-all"
-              fallbackSrc="/placeholder-avatar.png"
-            />
-          ) : (
-            <div className="w-12 h-12 rounded-full bg-gradient-to-br from-gray-700 to-gray-600 flex items-center justify-center text-white font-bold ring-2 ring-white/10 group-hover:ring-[#ff950e]/50 transition-all">
-              {order.seller ? order.seller.charAt(0).toUpperCase() : '?'}
-            </div>
-          )}
-          <div>
-            <div className="font-semibold text-white group-hover:text-[#ff950e] transition-colors flex items-center gap-2">
-              <SecureMessageDisplay
-                content={order.seller}
-                allowBasicFormatting={false}
-                as="span"
+    <div className="relative z-10 border-t border-white/10 bg-black/25 px-6 pb-8 pt-6 sm:px-8">
+      <div className="space-y-8">
+        {/* Seller Info */}
+        <div className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/[0.03] p-5 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href={`/sellers/${sanitizedUsername}`}
+            className="group flex items-center gap-4"
+          >
+            {sellerProfilePic ? (
+              <SecureImage
+                src={sellerProfilePic}
+                alt={order.seller}
+                className="h-14 w-14 rounded-full object-cover ring-2 ring-white/10 transition duration-300 group-hover:ring-[#ff950e]/60"
+                fallbackSrc="/placeholder-avatar.png"
               />
-              {isSellerVerified && (
-                <img src="/verification_badge.png" alt="Verified" className="w-4 h-4" />
+            ) : (
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.25),_transparent)] text-lg font-semibold text-white ring-2 ring-white/10 transition duration-300 group-hover:ring-[#ff950e]/60">
+                {order.seller ? order.seller.charAt(0).toUpperCase() : '?'}
+              </div>
+            )}
+            <div>
+              <div className="flex items-center gap-2 text-base font-semibold text-white transition-colors duration-300 group-hover:text-[#ffb469]">
+                <SecureMessageDisplay content={order.seller} allowBasicFormatting={false} as="span" />
+                {isSellerVerified && <img src="/verification_badge.png" alt="Verified" className="h-4 w-4" />}
+              </div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">View seller profile</p>
+            </div>
+          </Link>
+
+          <Link
+            href={`/buyers/messages?thread=${sanitizedUsername}`}
+            className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-white/10"
+          >
+            <MessageCircle className="h-4 w-4" />
+            Message seller
+          </Link>
+        </div>
+
+        {/* Info Grid */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="rounded-3xl border border-white/10 bg-black/30 p-5">
+            <h4 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-gray-400">
+              <Package className="h-4 w-4" />
+              Order details
+            </h4>
+            <div className="mt-4 space-y-3 text-sm">
+              <div className="flex items-center justify-between text-gray-400">
+                <span>Order ID</span>
+                <span className="font-mono text-xs text-gray-300">
+                  {order.id ? `${order.id.slice(0, 12)}...` : '—'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-gray-400">
+                <span>Type</span>
+                <span className="text-gray-200 capitalize">{type} purchase</span>
+              </div>
+              {trackingNumber && (
+                <div className="flex items-center justify-between text-gray-400">
+                  <span>Tracking</span>
+                  <span className="font-mono text-xs text-gray-200">{trackingNumber}</span>
+                </div>
               )}
             </div>
-            <div className="text-xs text-gray-500">View Profile</div>
           </div>
-        </Link>
 
-        <Link
-          href={`/buyers/messages?thread=${sanitizedUsername}`}
-          className="flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 text-white rounded-lg transition-all text-sm font-medium"
-        >
-          <MessageCircle className="w-4 h-4" />
-          Message
-        </Link>
-      </div>
-
-      {/* Info Grid - Cleaner presentation */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* Order Info */}
-        <div className="space-y-3">
-          <h4 className="text-sm font-semibold text-gray-400 flex items-center gap-2">
-            <Package className="w-4 h-4" />
-            ORDER DETAILS
-          </h4>
-          <div className="space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-500">Order ID</span>
-              <span className="text-gray-300 font-mono">
-                {order.id ? `${order.id.slice(0, 12)}...` : '—'}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-500">Type</span>
-              <span className="text-gray-300 capitalize">{type} Purchase</span>
-            </div>
-            {trackingNumber && (
-              <div className="flex justify-between">
-                <span className="text-gray-500">Tracking</span>
-                <span className="text-gray-300 font-mono">{trackingNumber}</span>
+          <div className="rounded-3xl border border-white/10 bg-black/30 p-5">
+            <h4 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-gray-400">
+              <CreditCard className="h-4 w-4" />
+              Payment summary
+            </h4>
+            <div className="mt-4 space-y-3 text-sm">
+              <div className="flex items-center justify-between text-gray-400">
+                <span>Item price</span>
+                <span className="text-gray-200">${order.price.toFixed(2)}</span>
               </div>
-            )}
+              <div className="flex items-center justify-between text-gray-400">
+                <span>Platform fee</span>
+                <span className="text-gray-200">
+                  ${((order.markedUpPrice || order.price) - order.price).toFixed(2)}
+                </span>
+              </div>
+              {order.tierCreditAmount && order.tierCreditAmount > 0 && (
+                <div className="flex items-center justify-between text-emerald-300">
+                  <span>Bonus credit</span>
+                  <span>+${order.tierCreditAmount.toFixed(2)}</span>
+                </div>
+              )}
+              <div className="flex items-center justify-between border-t border-white/10 pt-3 text-base font-semibold text-white">
+                <span>Total</span>
+                <span className="text-[#ffb469]">
+                  ${(order.markedUpPrice || order.price).toFixed(2)}
+                </span>
+              </div>
+            </div>
           </div>
         </div>
 
-        {/* Payment Summary */}
-        <div className="space-y-3">
-          <h4 className="text-sm font-semibold text-gray-400 flex items-center gap-2">
-            <CreditCard className="w-4 h-4" />
-            PAYMENT SUMMARY
-          </h4>
-          <div className="space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-500">Item Price</span>
-              <span className="text-gray-300">${order.price.toFixed(2)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-500">Platform Fee</span>
-              <span className="text-gray-300">
-                ${((order.markedUpPrice || order.price) - order.price).toFixed(2)}
-              </span>
-            </div>
-            {order.tierCreditAmount && order.tierCreditAmount > 0 && (
-              <div className="flex justify-between text-green-400">
-                <span>Bonus Credit</span>
-                <span>+${order.tierCreditAmount.toFixed(2)}</span>
-              </div>
-            )}
-            <div className="flex justify-between pt-2 border-t border-white/5 font-semibold">
-              <span className="text-white">Total</span>
-              <span className="text-[#ff950e]">
-                ${(order.markedUpPrice || order.price).toFixed(2)}
-              </span>
-            </div>
-          </div>
-        </div>
+        <ReviewSection order={order} />
       </div>
-
-      {/* Review Section */}
-      <ReviewSection order={order} />
     </div>
   );
 }

--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -49,36 +49,46 @@ export default function OrderCard({
   const needsAddress = order.wasAuction && !hasDeliveryAddress;
 
   return (
-    <div className={`relative overflow-hidden transition-all duration-300 ${
-      isExpanded 
-        ? 'bg-black/40 backdrop-blur-sm shadow-2xl' 
-        : 'bg-black/20 hover:bg-black/30 shadow-lg hover:shadow-xl'
-    }`}>
-      {/* Subtle type indicator bar */}
-      <div className={`absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r ${
-        type === 'auction' ? 'from-purple-500 to-violet-500' :
-        type === 'custom' ? 'from-blue-500 to-cyan-500' :
-        'from-[#ff950e] to-orange-500'
-      }`} />
+    <div
+      className={`group relative overflow-hidden rounded-3xl border transition-all duration-300 ${
+        isExpanded
+          ? `bg-black/45 shadow-[0_35px_90px_-40px_rgba(0,0,0,0.85)] ${styles.borderStyle}`
+          : `bg-black/35 ${styles.borderStyle} hover:-translate-y-1 hover:shadow-[0_40px_95px_-45px_rgba(0,0,0,0.9)]`
+      }`}
+    >
+      <div className={`pointer-events-none absolute inset-0 opacity-80 transition-opacity duration-500 group-hover:opacity-100 bg-gradient-to-br ${styles.gradientStyle}`} />
+      <div className="absolute inset-0 bg-black/30" />
 
-      {/* Auction Won Badge - Refined */}
+      {/* Accent border glow */}
+      <div
+        className="pointer-events-none absolute inset-0 rounded-3xl border border-white/5"
+        aria-hidden
+      />
+
+      {/* Action indicator */}
+      <div
+        className={`pointer-events-none absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r ${
+          type === 'auction'
+            ? 'from-purple-500 via-purple-400 to-violet-500'
+            : type === 'custom'
+              ? 'from-blue-500 via-sky-400 to-cyan-500'
+              : 'from-[#ff950e] via-[#ffb469] to-orange-500'
+        }`}
+      />
+
+      {/* Auction action badge */}
       {order.wasAuction && needsAddress && (
-        <div className="absolute top-4 right-4 z-10">
-          <div className="bg-emerald-500/10 backdrop-blur-md border border-emerald-500/20 text-emerald-400 px-4 py-1.5 rounded-full text-xs font-medium flex items-center gap-2">
+        <div className="absolute right-6 top-6 z-10">
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/50 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-200 shadow-[0_12px_30px_-20px_rgba(16,185,129,0.8)]">
             <span className="text-base">🏆</span>
-            <span>Action Required</span>
+            <span>Confirm address</span>
           </div>
         </div>
       )}
 
-      {/* Main Content */}
-      <div className={`p-6 transition-all duration-300 ${isExpanded ? 'pb-0' : ''}`}>
-        <OrderHeader
-          order={order}
-          type={type}
-          styles={styles}
-        />
-        
+      <div className="relative z-10 p-6 sm:p-8">
+        <OrderHeader order={order} type={type} styles={styles} />
+
         <OrderDetails
           order={order}
           type={type}
@@ -89,7 +99,6 @@ export default function OrderCard({
         />
       </div>
 
-      {/* Expanded Content - Seamless transition */}
       {isExpanded && (
         <ExpandedOrderContent
           order={order}

--- a/src/components/buyers/my-orders/OrderDetails.tsx
+++ b/src/components/buyers/my-orders/OrderDetails.tsx
@@ -30,15 +30,15 @@ export default function OrderDetails({
   return (
     <>
       {/* Streamlined Meta Info */}
-      <div className="flex flex-wrap items-center gap-6 mt-4 text-sm">
-        <div className="flex items-center gap-2 text-gray-400">
-          <Calendar className="w-4 h-4 opacity-60" />
+      <div className="mt-6 flex flex-wrap items-center gap-3 text-xs text-gray-400 sm:text-sm">
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
+          <Calendar className="h-4 w-4 text-white/60" />
           <span>{formatOrderDate(order.date)}</span>
         </div>
-        
+
         {order.tags && order.tags.length > 0 && (
-          <div className="flex items-center gap-2 text-gray-400">
-            <Tag className="w-4 h-4 opacity-60" />
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
+            <Tag className="h-4 w-4 text-white/60" />
             <span className="opacity-80">
               {order.tags.slice(0, 2).join(', ')}
               {order.tags.length > 2 && ` +${order.tags.length - 2}`}
@@ -46,61 +46,59 @@ export default function OrderDetails({
           </div>
         )}
 
-        {/* Inline status badge */}
-        {getShippingStatusBadge(order.shippingStatus)}
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs sm:text-sm">
+          {getShippingStatusBadge(order.shippingStatus)}
+        </div>
       </div>
 
       {/* Type-specific highlight - More subtle */}
       {isAuction && (
-        <div className="mt-4 pl-4 border-l-2 border-purple-500/30">
-          <p className="text-sm text-purple-300">
-            Winning bid: <span className="font-semibold">${order.finalBid?.toFixed(2) || order.price.toFixed(2)}</span>
-          </p>
+        <div className="mt-5 rounded-2xl border border-purple-500/30 bg-purple-500/10 px-5 py-4 text-sm text-purple-100">
+          Winning bid
+          <span className="ml-2 font-semibold text-white">${order.finalBid?.toFixed(2) || order.price.toFixed(2)}</span>
         </div>
       )}
 
       {isCustom && order.originalRequestId && (
-        <div className="mt-4 pl-4 border-l-2 border-blue-500/30">
-          <p className="text-sm text-blue-300">
-            Custom Request • <span className="font-mono text-xs opacity-60">#{order.originalRequestId.slice(0, 8)}</span>
-          </p>
+        <div className="mt-5 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-5 py-4 text-sm text-sky-100">
+          Custom Request •
+          <span className="ml-2 font-mono text-xs text-sky-200/80">#{order.originalRequestId.slice(0, 8)}</span>
         </div>
       )}
 
-      {/* Simplified Actions Bar */}
-      <div className="flex items-center justify-between mt-6 pt-4 border-t border-white/5">
+      <div className="mt-8 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/5 bg-black/30 px-4 py-4">
         {!hasDeliveryAddress ? (
           <button
             onClick={() => onOpenAddressModal(order.id)}
-            className="flex items-center gap-2 px-4 py-2 bg-yellow-500/10 hover:bg-yellow-500/20 text-yellow-400 rounded-lg transition-all text-sm font-medium"
+            className="inline-flex items-center gap-2 rounded-2xl border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition-all hover:-translate-y-0.5 hover:border-amber-300/60 hover:bg-amber-500/15"
           >
-            <MapPin className="w-4 h-4" />
-            Add Delivery Address
+            <MapPin className="h-4 w-4" />
+            Confirm delivery address
           </button>
         ) : (
-          <div className="flex items-center gap-2 text-green-400 text-sm">
-            <CheckCircle className="w-4 h-4" />
-            <span>Address Confirmed</span>
+          <div className="inline-flex items-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200">
+            <CheckCircle className="h-4 w-4" />
+            Address confirmed
           </div>
         )}
-        
+
         <button
-          className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all text-sm font-medium ${
-            isExpanded 
-              ? 'text-gray-400 hover:text-white' 
-              : 'text-[#ff950e] hover:bg-[#ff950e]/10'
+          className={`inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition-all ${
+            isExpanded
+              ? 'text-gray-300 hover:-translate-y-0.5 hover:text-white'
+              : 'bg-gradient-to-r from-[#ff950e]/20 to-[#ff7a00]/20 text-[#ffb469] hover:-translate-y-0.5 hover:from-[#ff950e]/30 hover:to-[#ff7a00]/30'
           }`}
           onClick={() => onToggleExpanded(isExpanded ? null : order.id)}
         >
           {isExpanded ? (
             <>
-              <ChevronUp className="w-4 h-4" />
-              Less
+              <ChevronUp className="h-4 w-4" />
+              Hide details
             </>
           ) : (
             <>
-              Details
-              <ChevronDown className="w-4 h-4" />
+              View details
+              <ChevronDown className="h-4 w-4" />
             </>
           )}
         </button>

--- a/src/components/buyers/my-orders/OrderSections.tsx
+++ b/src/components/buyers/my-orders/OrderSections.tsx
@@ -29,10 +29,12 @@ export default function OrderSections({
 
   if (allOrders.length === 0) {
     return (
-      <div className="text-center py-20">
-        <Package className="w-20 h-20 text-gray-700 mx-auto mb-4" />
-        <h3 className="text-2xl font-semibold text-gray-400 mb-2">No orders yet</h3>
-        <p className="text-gray-600">Your purchases will appear here</p>
+      <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-white/10 bg-black/40 p-12 text-center text-gray-400">
+        <Package className="h-16 w-16 text-white/20" />
+        <h3 className="text-2xl font-semibold text-white/80">No orders yet</h3>
+        <p className="max-w-md text-sm text-gray-500">
+          Your direct purchases, custom requests, and auction wins will appear here once you start shopping.
+        </p>
       </div>
     );
   }
@@ -46,51 +48,68 @@ export default function OrderSections({
   };
 
   const tabConfig = [
-    { id: 'all', label: 'All Orders', count: allOrders.length, icon: ShoppingBag },
-    { id: 'purchases', label: 'Direct', count: directOrders.length, icon: Package, show: directOrders.length > 0 },
-    { id: 'custom', label: 'Custom', count: customRequestOrders.length, icon: Settings, show: customRequestOrders.length > 0 },
-    { id: 'auctions', label: 'Auctions', count: auctionOrders.length, icon: Gavel, show: auctionOrders.length > 0 },
-  ];
+    { id: 'all', label: 'All orders', count: allOrders.length, icon: ShoppingBag, gradient: 'from-[#ff950e]/35 to-[#ff7a00]/30', iconBg: 'bg-[#ff950e]/15 text-[#ffb469]' },
+    { id: 'purchases', label: 'Direct', count: directOrders.length, icon: Package, show: directOrders.length > 0, gradient: 'from-emerald-500/25 to-teal-500/25', iconBg: 'bg-emerald-500/15 text-emerald-300' },
+    { id: 'custom', label: 'Custom', count: customRequestOrders.length, icon: Settings, show: customRequestOrders.length > 0, gradient: 'from-sky-500/25 to-cyan-500/20', iconBg: 'bg-sky-500/15 text-sky-300' },
+    { id: 'auctions', label: 'Auctions', count: auctionOrders.length, icon: Gavel, show: auctionOrders.length > 0, gradient: 'from-purple-500/25 to-violet-500/20', iconBg: 'bg-purple-500/15 text-purple-300' },
+  ] as const;
+
+  const activeTabConfig = tabConfig.find((tab) => tab.id === activeTab);
 
   return (
     <div className="space-y-6">
       {/* Enhanced Tab Navigation */}
-      <div className="relative">
-        <div className="flex gap-1 p-1 bg-black/40 rounded-xl">
-          {tabConfig.map((tab) => {
-            if (tab.show === false) return null;
-            const Icon = tab.icon;
-            const isActive = activeTab === tab.id;
-            
-            return (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id as any)}
-                className={`
-                  flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg
-                  font-medium transition-all duration-200
-                  ${isActive 
-                    ? 'bg-[#ff950e]/20 text-[#ff950e] shadow-lg' 
-                    : 'text-gray-400 hover:text-white hover:bg-white/5'
-                  }
-                `}
-              >
-                <Icon className="w-4 h-4" />
-                <span className="hidden sm:inline">{tab.label}</span>
-                <span className={`
-                  px-2 py-0.5 rounded-full text-xs font-semibold
-                  ${isActive ? 'bg-[#ff950e]/30' : 'bg-white/10'}
-                `}>
-                  {tab.count}
-                </span>
-              </button>
-            );
-          })}
+      <div className="space-y-4">
+        <div className="rounded-3xl border border-white/10 bg-black/40 p-2">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            {tabConfig.map((tab) => {
+              if (tab.show === false) return null;
+              const Icon = tab.icon;
+              const isActive = activeTab === tab.id;
+
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-left transition-all duration-200 ${
+                    isActive
+                      ? `bg-gradient-to-r ${tab.gradient} text-white shadow-[0_18px_45px_-35px_rgba(255,149,14,0.8)]`
+                      : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                  }`}
+                >
+                  <span className={`flex h-9 w-9 items-center justify-center rounded-xl ${tab.iconBg} transition-transform duration-200 group-hover:scale-105`}>
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <span className="flex flex-1 items-center justify-between gap-2">
+                    <span className="text-sm font-semibold capitalize">{tab.label}</span>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        isActive ? 'bg-black/30 text-white' : 'bg-white/10 text-gray-400'
+                      }`}
+                    >
+                      {tab.count}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/5 bg-black/30 px-4 py-3 text-xs text-gray-400">
+          <span>
+            Showing{' '}
+            <span className="font-semibold text-white">{activeTabConfig?.count ?? allOrders.length}</span>{' '}
+            order{(activeTabConfig?.count ?? allOrders.length) === 1 ? '' : 's'}
+          </span>
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-widest text-gray-300">
+            Sorted by most recent
+          </span>
         </div>
       </div>
 
       {/* Orders List with improved spacing */}
-      <div className="space-y-3">
+      <div className="space-y-4">
         {shouldShowOrder('direct') && directOrders.map((order) => (
           <OrderCard
             key={`${order.id}-${order.date}`}

--- a/src/components/buyers/my-orders/OrderStats.tsx
+++ b/src/components/buyers/my-orders/OrderStats.tsx
@@ -11,42 +11,48 @@ interface OrderStatsProps {
 
 export default function OrderStats({ stats }: OrderStatsProps) {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-6">
       {/* Total Spent Card */}
-      <div className="bg-gradient-to-br from-[#ff950e]/10 via-[#ff950e]/5 to-transparent p-5 md:p-6 rounded-xl border border-[#ff950e]/20 hover:border-[#ff950e]/40 transition-all duration-300 hover:shadow-lg hover:shadow-[#ff950e]/10 group">
-        <div className="flex items-center justify-between">
+      <div className="group relative overflow-hidden rounded-3xl border border-[#ff950e]/30 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.16),_rgba(17,17,17,0.6))] p-6 shadow-[0_20px_60px_-45px_rgba(255,149,14,0.8)] transition-transform duration-300 hover:-translate-y-1 hover:border-[#ff950e]/50">
+        <div className="pointer-events-none absolute -right-12 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full bg-[#ff950e]/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <div className="relative flex items-center justify-between">
           <div>
-            <p className="text-[#ff950e] text-sm font-medium mb-1">Total Spent</p>
-            <p className="text-white text-2xl md:text-3xl font-bold">${stats.totalSpent.toFixed(2)}</p>
+            <p className="text-xs font-medium uppercase tracking-wider text-[#ffb469]">Total spent</p>
+            <p className="mt-2 text-3xl font-bold text-white">${stats.totalSpent.toFixed(2)}</p>
+            <p className="mt-1 text-xs text-[#ffb469]/80">Includes platform fees and credits redeemed</p>
           </div>
-          <div className="bg-gradient-to-br from-[#ff950e]/20 to-[#ff950e]/10 p-3 md:p-4 rounded-xl group-hover:scale-110 transition-transform duration-300">
-            <DollarSign className="w-7 h-7 md:w-8 md:h-8 text-[#ff950e]" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-[#ff950e]/50 bg-[#ff950e]/15 text-[#ff950e] transition-transform duration-300 group-hover:scale-105">
+            <DollarSign className="h-6 w-6" />
           </div>
         </div>
       </div>
 
       {/* Pending Orders Card */}
-      <div className="bg-gradient-to-br from-yellow-500/10 via-amber-500/5 to-transparent p-5 md:p-6 rounded-xl border border-yellow-500/20 hover:border-yellow-400/40 transition-all duration-300 hover:shadow-lg hover:shadow-yellow-500/10 group">
-        <div className="flex items-center justify-between">
+      <div className="group relative overflow-hidden rounded-3xl border border-yellow-400/25 bg-[radial-gradient(circle_at_top,_rgba(250,204,21,0.15),_rgba(17,17,17,0.65))] p-6 shadow-[0_20px_60px_-50px_rgba(250,204,21,0.6)] transition-transform duration-300 hover:-translate-y-1 hover:border-yellow-300/50">
+        <div className="pointer-events-none absolute -left-16 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full bg-yellow-300/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <div className="relative flex items-center justify-between">
           <div>
-            <p className="text-yellow-400 text-sm font-medium mb-1">Pending Orders</p>
-            <p className="text-white text-2xl md:text-3xl font-bold">{stats.pendingOrders}</p>
+            <p className="text-xs font-medium uppercase tracking-wider text-yellow-200/80">Pending orders</p>
+            <p className="mt-2 text-3xl font-bold text-white">{stats.pendingOrders}</p>
+            <p className="mt-1 text-xs text-yellow-100/70">Awaiting seller confirmation or shipment</p>
           </div>
-          <div className="bg-gradient-to-br from-yellow-500/20 to-yellow-500/10 p-3 md:p-4 rounded-xl group-hover:scale-110 transition-transform duration-300">
-            <Clock className="w-7 h-7 md:w-8 md:h-8 text-yellow-400" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-yellow-300/50 bg-yellow-300/15 text-yellow-200 transition-transform duration-300 group-hover:scale-105">
+            <Clock className="h-6 w-6" />
           </div>
         </div>
       </div>
 
       {/* Shipped Orders Card */}
-      <div className="bg-gradient-to-br from-blue-500/10 via-sky-500/5 to-transparent p-5 md:p-6 rounded-xl border border-blue-500/20 hover:border-blue-400/40 transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/10 group sm:col-span-2 lg:col-span-1">
-        <div className="flex items-center justify-between">
+      <div className="group relative overflow-hidden rounded-3xl border border-sky-400/25 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15),_rgba(17,17,17,0.65))] p-6 shadow-[0_20px_60px_-50px_rgba(56,189,248,0.6)] transition-transform duration-300 hover:-translate-y-1 hover:border-sky-300/50">
+        <div className="pointer-events-none absolute -right-10 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full bg-sky-400/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <div className="relative flex items-center justify-between">
           <div>
-            <p className="text-blue-400 text-sm font-medium mb-1">Shipped Orders</p>
-            <p className="text-white text-2xl md:text-3xl font-bold">{stats.shippedOrders}</p>
+            <p className="text-xs font-medium uppercase tracking-wider text-sky-200/80">Shipped orders</p>
+            <p className="mt-2 text-3xl font-bold text-white">{stats.shippedOrders}</p>
+            <p className="mt-1 text-xs text-sky-100/70">In transit and ready for doorstep delivery</p>
           </div>
-          <div className="bg-gradient-to-br from-blue-500/20 to-blue-500/10 p-3 md:p-4 rounded-xl group-hover:scale-110 transition-transform duration-300">
-            <Truck className="w-7 h-7 md:w-8 md:h-8 text-blue-400" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-sky-300/50 bg-sky-300/15 text-sky-200 transition-transform duration-300 group-hover:scale-105">
+            <Truck className="h-6 w-6" />
           </div>
         </div>
       </div>

--- a/src/components/buyers/my-orders/OrdersHeader.tsx
+++ b/src/components/buyers/my-orders/OrdersHeader.tsx
@@ -2,54 +2,84 @@
 'use client';
 
 import React from 'react';
-import { ShoppingBag, TrendingUp, Package, Sparkles } from 'lucide-react';
+import { ShoppingBag, TrendingUp, Package, Sparkles, ShieldCheck } from 'lucide-react';
 
 export default function OrdersHeader() {
   return (
-    <div className="relative">
-      {/* Background decorations */}
-      <div className="absolute -top-6 -left-6 w-32 h-32 bg-[#ff950e]/10 rounded-full blur-3xl" />
-      <div className="absolute -top-10 -right-10 w-40 h-40 bg-[#ff950e]/5 rounded-full blur-3xl" />
-      
-      <div className="relative">
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-          {/* Title section */}
+    <div className="relative flex flex-col gap-8">
+      {/* Background glows */}
+      <div className="pointer-events-none absolute -top-10 left-0 h-40 w-40 rounded-full bg-[#ff950e]/20 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-12 right-6 h-48 w-48 rounded-full bg-[#ff7a00]/10 blur-3xl" />
+
+      <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+        {/* Title section */}
+        <div className="flex flex-1 flex-col gap-6">
           <div className="flex items-center gap-4">
-            {/* Animated icon container */}
-            <div className="relative group">
-              <div className="absolute inset-0 bg-gradient-to-r from-[#ff950e] to-[#ff6b00] rounded-xl blur-lg opacity-40 group-hover:opacity-60 transition-opacity duration-300" />
-              <div className="relative bg-gradient-to-r from-[#ff950e] to-[#ff6b00] p-3.5 md:p-4 rounded-xl shadow-xl">
-                <ShoppingBag className="w-7 h-7 md:w-8 md:h-8 text-white" />
-              </div>
+            <div className="relative inline-flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border border-[#ff950e]/40 bg-gradient-to-br from-[#ff950e]/40 via-[#ff7a00]/60 to-[#ff6b00]/70 shadow-[0_15px_40px_-25px_rgba(255,149,14,0.9)]">
+              <span className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.25),_transparent_60%)]" />
+              <ShoppingBag className="relative z-10 h-6 w-6 text-white" />
             </div>
-            
-            {/* Title with gradient */}
             <div>
-              <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold">
-                <span className="bg-gradient-to-r from-white via-gray-100 to-gray-300 bg-clip-text text-transparent">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-gray-200/70">
+                Buyer hub
+              </span>
+              <h1 className="mt-3 text-3xl font-bold sm:text-4xl lg:text-5xl">
+                <span className="bg-gradient-to-r from-white via-gray-200 to-gray-400 bg-clip-text text-transparent">
                   My Orders
                 </span>
               </h1>
-              <p className="text-gray-400 text-sm md:text-base mt-1">
-                Track purchases & manage deliveries
+              <p className="mt-2 max-w-xl text-sm text-gray-400 sm:text-base">
+                Track purchases, review deliveries, and stay in sync with every seller you're supporting.
               </p>
             </div>
           </div>
-          
-          {/* Quick stats/tags */}
-          <div className="flex items-center gap-3 flex-wrap">
-            <div className="flex items-center gap-2 bg-gradient-to-r from-green-500/10 to-emerald-500/10 px-4 py-2 rounded-full border border-green-500/20">
-              <TrendingUp className="w-4 h-4 text-green-400" />
-              <span className="text-green-400 text-sm font-medium">Live Tracking</span>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/15">
+                <TrendingUp className="h-5 w-5 text-emerald-300" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wider text-gray-500">Live Tracking</p>
+                <p className="text-sm font-semibold text-white">Real-time updates</p>
+              </div>
             </div>
-            <div className="flex items-center gap-2 bg-gradient-to-r from-blue-500/10 to-sky-500/10 px-4 py-2 rounded-full border border-blue-500/20">
-              <Package className="w-4 h-4 text-blue-400" />
-              <span className="text-blue-400 text-sm font-medium">Secure Delivery</span>
+            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/15">
+                <Package className="h-5 w-5 text-sky-300" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wider text-gray-500">Fulfillment</p>
+                <p className="text-sm font-semibold text-white">Secure delivery</p>
+              </div>
             </div>
-            <div className="flex items-center gap-2 bg-gradient-to-r from-purple-500/10 to-violet-500/10 px-4 py-2 rounded-full border border-purple-500/20">
-              <Sparkles className="w-4 h-4 text-purple-400" />
-              <span className="text-purple-400 text-sm font-medium">Premium Support</span>
+            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple-500/15">
+                <Sparkles className="h-5 w-5 text-purple-300" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wider text-gray-500">Aftercare</p>
+                <p className="text-sm font-semibold text-white">Premium support</p>
+              </div>
             </div>
+          </div>
+        </div>
+
+        {/* Trust panel */}
+        <div className="relative flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300 shadow-[0_15px_45px_-30px_rgba(255,149,14,0.6)]">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-[#ff950e]/30 bg-[#ff950e]/10">
+              <ShieldCheck className="h-6 w-6 text-[#ff950e]" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-white">Buyer protection enabled</p>
+              <p className="text-xs text-gray-500">Encrypted payments & escrow on every transaction.</p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-white/5 bg-black/30 p-4 text-xs text-gray-400">
+            <p>
+              Keep an eye on address confirmations for auction wins and leave reviews to unlock loyalty bonuses with your favorite sellers.
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle the buyer my-orders page with gradient backgrounds and glassmorphism treatments to mirror the dashboard experience
- modernize supporting components (headers, stats, tabs, cards, empty state) with cohesive typography, spacing, and interaction polish
- refine expanded order details with seller profile card, payment summary, and action chips aligned to the updated aesthetic

## Testing
- npm run lint *(fails: existing lint errors across legacy context and utility files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f3fbf20083289c6fd11c83ffe067