### PR TITLE
Revamp admin analytics dashboard styling

### DIFF
--- a/src/app/wallet/admin/page.tsx
+++ b/src/app/wallet/admin/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import { useListings } from '@/context/ListingContext';
 import { useWallet } from '@/context/WalletContext';
 import RequireAuth from '@/components/RequireAuth';
-import { AlertCircle, BarChart3, Loader2, RefreshCw } from 'lucide-react';
+import { AlertCircle, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
 
 // Import split components
 import AdminMetrics from '@/components/admin/wallet/AdminMetrics';
@@ -14,7 +14,13 @@ import AdminRevenueChart from '@/components/admin/wallet/AdminRevenueChart';
 import AdminHealthSection from '@/components/admin/wallet/AdminHealthSection';
 import AdminMoneyFlow from '@/components/admin/wallet/AdminMoneyFlow';
 import AdminRecentActivity from '@/components/admin/wallet/AdminRecentActivity';
-import { getTimeFilteredData } from '@/utils/admin/walletHelpers';
+import {
+  calculatePlatformProfit,
+  calculateSubscriptionProfit,
+  calculateSubscriptionRevenue,
+  calculateTotalRevenue,
+  getTimeFilteredData
+} from '@/utils/admin/walletHelpers';
 
 type TimeFilter = 'today' | 'week' | 'month' | '3months' | 'year' | 'all';
 
@@ -41,6 +47,45 @@ const AdminProfitDashboardContent = memo(function AdminProfitDashboardContent() 
 
   const [isReloading, setIsReloading] = useState(false);
   const [mounted, setMounted] = useState(false);
+
+  const adminDisplayName = useMemo(
+    () => user?.displayName || user?.username || 'Platform Admin',
+    [user?.displayName, user?.username]
+  );
+
+  const adminInitial = useMemo(() => adminDisplayName.charAt(0).toUpperCase(), [adminDisplayName]);
+
+  const usersArray = useMemo(() => (users ? Object.values(users) : []), [users]);
+
+  const totalSellers = useMemo(
+    () => usersArray.filter((info: any) => info?.role === 'seller').length,
+    [usersArray]
+  );
+
+  const totalBuyers = useMemo(
+    () => usersArray.filter((info: any) => info?.role === 'buyer').length,
+    [usersArray]
+  );
+
+  const verifiedSellers = useMemo(
+    () =>
+      usersArray.filter(
+        (info: any) => info?.role === 'seller' && (info?.verified || info?.verificationStatus === 'verified')
+      ).length,
+    [usersArray]
+  );
+
+  const totalListings = useMemo(() => (Array.isArray(listings) ? listings.length : 0), [listings]);
+
+  const premiumListings = useMemo(
+    () => (Array.isArray(listings) ? listings.filter((listing: any) => listing?.isPremium).length : 0),
+    [listings]
+  );
+
+  const safeAdminBalance = useMemo(
+    () => (typeof adminBalance === 'number' && Number.isFinite(adminBalance) ? adminBalance : 0),
+    [adminBalance]
+  );
   
   // Use a ref to track loading state for the guard check
   const isReloadingRef = useRef(false);
@@ -148,6 +193,113 @@ const AdminProfitDashboardContent = memo(function AdminProfitDashboardContent() 
   );
   // -----------------------------------------------------------------
 
+  const financialSnapshot = useMemo(() => {
+    const ensureNumber = (value: number) => (Number.isFinite(value) ? value : 0);
+
+    const safeFilteredOrders = Array.isArray(filteredData.orders) ? filteredData.orders : [];
+    const safeFilteredActions = Array.isArray(filteredData.actions) ? filteredData.actions : [];
+    const safeOrderHistory = Array.isArray(orderHistory) ? orderHistory : [];
+    const safeAdminActions = Array.isArray(adminActions) ? adminActions : [];
+
+    const periodSalesRevenue = ensureNumber(calculateTotalRevenue(safeFilteredOrders));
+    const periodSubscriptionRevenue = ensureNumber(calculateSubscriptionRevenue(safeFilteredActions));
+    const periodSalesProfit = ensureNumber(calculatePlatformProfit(safeFilteredOrders));
+    const periodSubscriptionProfit = ensureNumber(calculateSubscriptionProfit(safeFilteredActions));
+
+    const allSalesRevenue = ensureNumber(calculateTotalRevenue(safeOrderHistory));
+    const allSubscriptionRevenue = ensureNumber(calculateSubscriptionRevenue(safeAdminActions));
+    const allSalesProfit = ensureNumber(calculatePlatformProfit(safeOrderHistory));
+    const allSubscriptionProfit = ensureNumber(calculateSubscriptionProfit(safeAdminActions));
+
+    const revenue =
+      timeFilter === 'all'
+        ? allSalesRevenue + allSubscriptionRevenue
+        : periodSalesRevenue + periodSubscriptionRevenue;
+
+    const profit =
+      timeFilter === 'all'
+        ? allSalesProfit + allSubscriptionProfit
+        : periodSalesProfit + periodSubscriptionProfit;
+
+    return { revenue, profit };
+  }, [
+    adminActions,
+    filteredData.actions,
+    filteredData.orders,
+    orderHistory,
+    timeFilter
+  ]);
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    []
+  );
+
+  const formatCurrency = useCallback(
+    (amount: number) => currencyFormatter.format(Number.isFinite(amount) ? amount : 0),
+    [currencyFormatter]
+  );
+
+  const currentPeriodLabel = useMemo(() => {
+    switch (timeFilter) {
+      case 'today':
+        return 'Today';
+      case 'week':
+        return 'This Week';
+      case 'month':
+        return 'This Month';
+      case '3months':
+        return 'Last 90 Days';
+      case 'year':
+        return 'This Year';
+      default:
+        return 'All Time';
+    }
+  }, [timeFilter]);
+
+  const heroStats = useMemo(
+    () => [
+      {
+        label: `${timeFilter === 'all' ? 'Total' : 'Period'} Revenue`,
+        value: formatCurrency(financialSnapshot.revenue),
+        sublabel: 'Sales + subscriptions',
+        accent: 'from-[#ff950e]/40 via-[#ff6b00]/20 to-transparent text-[#ffbf7f]'
+      },
+      {
+        label: `${timeFilter === 'all' ? 'Total' : 'Period'} Profit`,
+        value: formatCurrency(financialSnapshot.profit),
+        sublabel: 'After platform fees',
+        accent: 'from-emerald-500/40 via-emerald-400/20 to-transparent text-emerald-200'
+      },
+      {
+        label: 'Platform Balance',
+        value: formatCurrency(safeAdminBalance),
+        sublabel: 'Cash available right now',
+        accent: 'from-sky-500/30 via-sky-400/15 to-transparent text-sky-200'
+      },
+      {
+        label: 'Live Listings',
+        value: totalListings.toLocaleString(),
+        sublabel: `${premiumListings.toLocaleString()} premium • ${totalSellers.toLocaleString()} sellers`,
+        accent: 'from-purple-500/40 via-purple-400/20 to-transparent text-purple-200'
+      }
+    ], [
+      financialSnapshot,
+      formatCurrency,
+      premiumListings,
+      safeAdminBalance,
+      timeFilter,
+      totalListings,
+      totalSellers
+    ]
+  );
+
   // Fixed handleForceReload function
   const handleForceReload = useCallback(async () => {
     // Use ref for guard check to avoid stale closure
@@ -239,71 +391,133 @@ const AdminProfitDashboardContent = memo(function AdminProfitDashboardContent() 
   }
 
   return (
-    <main className="min-h-screen bg-black text-white py-6 px-4 sm:px-6 overflow-x-hidden">
+    <main className="relative min-h-screen bg-[#050505] text-white py-10 px-4 sm:px-6 lg:px-8 overflow-x-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-32 -right-24 h-72 w-72 rounded-full bg-[#ff6b00]/20 blur-3xl" aria-hidden="true" />
+        <div className="absolute top-48 -left-16 h-96 w-96 rounded-full bg-purple-500/10 blur-3xl" aria-hidden="true" />
+      </div>
+
       {isReloading && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
-          <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800 shadow-xl">
-            <Loader2 className="w-8 h-8 text-[#ff950e] animate-spin mx-auto mb-3" />
-            <p className="text-white font-medium">Reloading analytics data...</p>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-md">
+          <div className="rounded-2xl border border-white/10 bg-black/80 px-8 py-6 shadow-2xl shadow-[#ff950e]/20">
+            <Loader2 className="mb-3 h-10 w-10 animate-spin text-[#ff950e]" />
+            <p className="text-sm font-medium text-white">Reloading analytics data...</p>
           </div>
         </div>
       )}
 
-      <div className="max-w-7xl mx-auto">
-        <div className="flex flex-col lg:flex-row lg:items-center justify-between mb-8 gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-[#ff950e] flex items-center gap-3">
-              <BarChart3 className="h-8 w-8" />
-              Platform Analytics
-            </h1>
-            <p className="text-gray-400 mt-1">Your money-making machine dashboard 💰</p>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="flex bg-[#1a1a1a] border border-gray-800 rounded-lg overflow-hidden">
-              {[
-                { value: 'today', label: 'Today' },
-                { value: 'week', label: 'Week' },
-                { value: 'month', label: 'Month' },
-                { value: '3months', label: '3 Months' },
-                { value: 'year', label: 'Year' },
-                { value: 'all', label: 'All Time' },
-              ].map((filter) => (
-                <button
-                  key={filter.value}
-                  onClick={() => handleTimeFilterChange(filter.value as TimeFilter)}
-                  className={`px-3 py-2 text-sm font-medium transition-all whitespace-nowrap ${
-                    timeFilter === filter.value
-                      ? 'bg-[#ff950e] text-black shadow-lg'
-                      : 'text-gray-300 hover:text-white hover:bg-[#252525]'
-                  }`}
-                >
-                  {filter.label}
-                </button>
-              ))}
-            </div>
+      <div className="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-10">
+        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#1f0b0b]/90 via-[#120606]/90 to-[#050303]/90 p-6 sm:p-8 shadow-2xl shadow-[#ff950e]/10">
+          <div className="pointer-events-none absolute -top-24 -left-20 h-64 w-64 rounded-full bg-[#ff950e]/30 blur-3xl" aria-hidden="true" />
+          <div className="pointer-events-none absolute bottom-0 right-0 h-56 w-56 rounded-full bg-purple-500/20 blur-3xl" aria-hidden="true" />
 
-            <button
-              onClick={handleForceReload}
-              disabled={isReloading}
-              className="px-4 py-2 bg-[#1a1a1a] border border-gray-800 hover:bg-[#252525] text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <RefreshCw className={`w-4 h-4 ${isReloading ? 'animate-spin' : ''}`} />
-              {isReloading ? 'Reloading...' : 'Force Reload'}
-            </button>
-          </div>
-        </div>
-
-        {walletInitialized && (
-          <div className="mb-6 p-4 bg-[#1a1a1a] border border-gray-800 rounded-lg">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                <span className="text-sm text-gray-400">Data synchronized</span>
+          <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-start gap-5">
+              <div className="relative">
+                <div
+                  className="absolute inset-0 rounded-full bg-gradient-to-tr from-[#ff950e]/50 to-[#ff6b00]/40 blur-lg"
+                  aria-hidden="true"
+                />
+                <div className="relative flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-black/80 text-3xl font-bold">
+                  {adminInitial}
+                </div>
               </div>
-              <div className="text-xs text-gray-500">Last updated: {new Date().toLocaleTimeString()}</div>
+              <div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <h1 className="text-3xl font-bold sm:text-4xl">{adminDisplayName}</h1>
+                  <span className="flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-200">
+                    <ShieldCheck className="h-3.5 w-3.5" />
+                    Super Admin
+                  </span>
+                </div>
+                <p className="mt-2 max-w-xl text-sm text-gray-300">
+                  Welcome back! Monitor payouts, marketplace traction, and subscription momentum without leaving the command
+                  center.
+                </p>
+                <p className="mt-3 text-xs font-semibold uppercase tracking-[0.35em] text-[#ffbf7f]">
+                  Performance • {currentPeriodLabel}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+              <div className="flex flex-wrap gap-2">
+                {[
+                  { value: 'today', label: 'Today' },
+                  { value: 'week', label: 'Week' },
+                  { value: 'month', label: 'Month' },
+                  { value: '3months', label: '90 Days' },
+                  { value: 'year', label: 'Year' },
+                  { value: 'all', label: 'All Time' },
+                ].map((filter) => (
+                  <button
+                    key={filter.value}
+                    onClick={() => handleTimeFilterChange(filter.value as TimeFilter)}
+                    className={`rounded-full px-3 py-1.5 text-sm font-medium transition-all whitespace-nowrap ${
+                      timeFilter === filter.value
+                        ? 'bg-gradient-to-r from-[#ff950e] to-[#ff6b00] text-black shadow-lg shadow-[#ff950e]/30'
+                        : 'bg-white/10 text-gray-300 hover:bg-white/20'
+                    }`}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+
+              <button
+                onClick={handleForceReload}
+                disabled={isReloading}
+                className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition-colors hover:border-[#ff950e]/60 hover:bg-[#ff950e]/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={`h-4 w-4 text-[#ffbf7f] transition-transform ${
+                    isReloading ? 'animate-spin' : 'group-hover:rotate-6'
+                  }`}
+                />
+                <span>{isReloading ? 'Reloading...' : 'Force Reload'}</span>
+              </button>
             </div>
           </div>
-        )}
+
+          <div className="relative mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {heroStats.map((stat) => (
+              <div
+                key={stat.label}
+                className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur-sm transition duration-300 hover:border-[#ff950e]/60 hover:shadow-lg hover:shadow-[#ff950e]/15"
+              >
+                <div
+                  className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${stat.accent} opacity-0 transition-opacity duration-300 group-hover:opacity-100`}
+                  aria-hidden="true"
+                />
+                <div className="relative flex flex-col gap-3">
+                  <span className="text-xs font-semibold uppercase tracking-widest text-gray-400">{stat.label}</span>
+                  <span className="text-3xl font-bold text-white">{stat.value}</span>
+                  <span className="text-xs text-gray-400">{stat.sublabel}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {walletInitialized && (
+            <div className="relative mt-6 flex flex-wrap items-center gap-4 text-xs sm:text-sm text-gray-300">
+              <div className="flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/15 px-3 py-1">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+                <span>Data synchronized</span>
+                <span className="text-emerald-200/80">Last updated {new Date().toLocaleTimeString()}</span>
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                <span className="text-xs font-semibold uppercase tracking-widest text-[#ffbf7f]">Audience</span>
+                <span>
+                  {totalSellers.toLocaleString()} sellers • {totalBuyers.toLocaleString()} buyers
+                </span>
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1">
+                <span className="text-xs font-semibold uppercase tracking-widest text-[#ffbf7f]">Verified</span>
+                <span>{verifiedSellers.toLocaleString()} sellers</span>
+              </div>
+            </div>
+          )}
+        </section>
 
         {adminBalance !== undefined && (
           <AdminMetrics

--- a/src/components/admin/wallet/AdminHealthSection.tsx
+++ b/src/components/admin/wallet/AdminHealthSection.tsx
@@ -203,18 +203,19 @@ export default function AdminHealthSection({
     }).format(Number.isFinite(amount) ? amount : 0);
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 mb-8">
+    <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
       {/* Platform Health */}
-      <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800">
-        <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
-          <Activity className="h-5 w-5 text-[#ff950e]" />
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7 backdrop-blur-sm shadow-xl shadow-black/30">
+        <div className="pointer-events-none absolute -top-16 -right-14 h-48 w-48 rounded-full bg-emerald-500/10 blur-3xl" aria-hidden="true" />
+        <h3 className="relative mb-4 flex items-center gap-2 text-lg font-bold text-white">
+          <Activity className="h-5 w-5 text-emerald-300" />
           Platform Health
         </h3>
-        <div className="space-y-4">
-          <div className="flex justify-between items-center p-4 bg-[#252525] rounded-lg">
+        <div className="relative space-y-4">
+          <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex items-center gap-3">
-              <Users className="h-5 w-5 text-blue-400" />
-              <span className="text-white">Total Users</span>
+              <Users className="h-5 w-5 text-sky-300" />
+              <span className="text-sm font-medium text-white/80">Total Users</span>
             </div>
             <div className="text-right">
               <span className="text-2xl font-bold text-white">{totalUsersCount}</span>
@@ -224,10 +225,10 @@ export default function AdminHealthSection({
             </div>
           </div>
 
-          <div className="flex justify-between items-center p-4 bg-[#252525] rounded-lg">
+          <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex items-center gap-3">
-              <CheckCircle2 className="h-5 w-5 text-green-400" />
-              <span className="text-white">Verified Sellers</span>
+              <CheckCircle2 className="h-5 w-5 text-emerald-300" />
+              <span className="text-sm font-medium text-white/80">Verified Sellers</span>
             </div>
             <div className="text-right">
               <span className="text-2xl font-bold text-white">{verifiedSellers.length}</span>
@@ -237,10 +238,10 @@ export default function AdminHealthSection({
             </div>
           </div>
 
-          <div className="flex justify-between items-center p-4 bg-[#252525] rounded-lg">
+          <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex items-center gap-3">
-              <ShoppingBag className="h-5 w-5 text-purple-400" />
-              <span className="text-white">Active Listings</span>
+              <ShoppingBag className="h-5 w-5 text-purple-300" />
+              <span className="text-sm font-medium text-white/80">Active Listings</span>
             </div>
             <div className="text-right">
               <span className="text-2xl font-bold text-white">{activeListings}</span>
@@ -251,25 +252,29 @@ export default function AdminHealthSection({
       </div>
 
       {/* Top Earning Sellers */}
-      <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800">
-        <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
-          <Star className="h-5 w-5 text-[#ff950e]" />
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7 backdrop-blur-sm shadow-xl shadow-black/30">
+        <div className="pointer-events-none absolute -bottom-16 -left-12 h-48 w-48 rounded-full bg-[#ff6b00]/15 blur-3xl" aria-hidden="true" />
+        <h3 className="relative mb-4 flex items-center gap-2 text-lg font-bold text-white">
+          <Star className="h-5 w-5 text-[#ffbf7f]" />
           Top Earning Sellers
         </h3>
-        <div className="space-y-3">
+        <div className="relative space-y-3">
           {topSellers.length > 0 ? (
             topSellers.map(([username, balance], index) => (
-              <div key={username} className="flex items-center justify-between p-3 bg-[#252525] rounded-lg">
+              <div
+                key={username}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+              >
                 <div className="flex items-center gap-3">
                   <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+                    className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold ${
                       index === 0
-                        ? 'bg-yellow-500 text-black'
+                        ? 'bg-yellow-400 text-black'
                         : index === 1
-                        ? 'bg-gray-400 text-black'
+                        ? 'bg-slate-300 text-black'
                         : index === 2
-                        ? 'bg-orange-600 text-white'
-                        : 'bg-[#333] text-gray-300'
+                        ? 'bg-orange-500 text-white'
+                        : 'bg-white/10 text-gray-300'
                     }`}
                     aria-label={`Rank ${index + 1}`}
                   >
@@ -285,14 +290,14 @@ export default function AdminHealthSection({
                   </div>
                 </div>
                 <div className="text-right">
-                  <p className="font-bold text-white">{formatCurrency(Number(balance))}</p>
-                  <p className="text-xs text-gray-500">earned</p>
+                  <p className="font-semibold text-white">{formatCurrency(Number(balance))}</p>
+                  <p className="text-xs text-gray-400">earned</p>
                 </div>
               </div>
             ))
           ) : (
-            <div className="text-center py-8 text-gray-500">
-              <Star className="h-8 w-8 mx-auto mb-2 text-gray-600" />
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] py-8 text-center text-gray-400">
+              <Star className="mx-auto mb-2 h-8 w-8 text-gray-600" />
               <p>No seller earnings yet</p>
             </div>
           )}
@@ -300,25 +305,29 @@ export default function AdminHealthSection({
       </div>
 
       {/* Top Depositors */}
-      <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800">
-        <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
-          <Download className="h-5 w-5 text-[#ff950e]" />
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7 backdrop-blur-sm shadow-xl shadow-black/30">
+        <div className="pointer-events-none absolute -top-12 right-0 h-44 w-44 rounded-full bg-sky-500/10 blur-3xl" aria-hidden="true" />
+        <h3 className="relative mb-4 flex items-center gap-2 text-lg font-bold text-white">
+          <Download className="h-5 w-5 text-sky-300" />
           Top Depositors
         </h3>
-        <div className="space-y-3">
+        <div className="relative space-y-3">
           {topDepositors.length > 0 ? (
             topDepositors.map(([username, totalDeposited], index) => (
-              <div key={username} className="flex items-center justify-between p-3 bg-[#252525] rounded-lg">
+              <div
+                key={username}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+              >
                 <div className="flex items-center gap-3">
                   <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+                    className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold ${
                       index === 0
-                        ? 'bg-blue-500 text-white'
+                        ? 'bg-sky-400 text-black'
                         : index === 1
-                        ? 'bg-blue-400 text-white'
+                        ? 'bg-sky-300 text-black'
                         : index === 2
-                        ? 'bg-blue-300 text-black'
-                        : 'bg-[#333] text-gray-300'
+                        ? 'bg-sky-200 text-black'
+                        : 'bg-white/10 text-gray-300'
                     }`}
                     aria-label={`Rank ${index + 1}`}
                   >
@@ -334,14 +343,14 @@ export default function AdminHealthSection({
                   </div>
                 </div>
                 <div className="text-right">
-                  <p className="font-bold text-blue-400">{formatCurrency(Number(totalDeposited))}</p>
-                  <p className="text-xs text-gray-500">deposited</p>
+                  <p className="font-semibold text-sky-200">{formatCurrency(Number(totalDeposited))}</p>
+                  <p className="text-xs text-gray-400">deposited</p>
                 </div>
               </div>
             ))
           ) : (
-            <div className="text-center py-8 text-gray-500">
-              <Download className="h-8 w-8 mx-auto mb-2 text-gray-600" />
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] py-8 text-center text-gray-400">
+              <Download className="mx-auto mb-2 h-8 w-8 text-gray-600" />
               <p>No deposits yet</p>
             </div>
           )}
@@ -349,25 +358,29 @@ export default function AdminHealthSection({
       </div>
 
       {/* Top Withdrawers */}
-      <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800">
-        <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
-          <Upload className="h-5 w-5 text-[#ff950e]" />
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7 backdrop-blur-sm shadow-xl shadow-black/30">
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 rounded-full bg-red-500/10 blur-3xl" aria-hidden="true" />
+        <h3 className="relative mb-4 flex items-center gap-2 text-lg font-bold text-white">
+          <Upload className="h-5 w-5 text-red-300" />
           Top Withdrawers
         </h3>
-        <div className="space-y-3">
+        <div className="relative space-y-3">
           {Object.keys(sellerWithdrawals || {}).length > 0 ? (
             topWithdrawers.map((withdrawer, index) => (
-              <div key={withdrawer.seller} className="flex items-center justify-between p-3 bg-[#252525] rounded-lg">
+              <div
+                key={withdrawer.seller}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+              >
                 <div className="flex items-center gap-3">
                   <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+                    className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold ${
                       index === 0
-                        ? 'bg-red-500 text-white'
-                        : index === 1
                         ? 'bg-red-400 text-white'
-                        : index === 2
+                        : index === 1
                         ? 'bg-red-300 text-black'
-                        : 'bg-[#333] text-gray-300'
+                        : index === 2
+                        ? 'bg-red-200 text-black'
+                        : 'bg-white/10 text-gray-300'
                     }`}
                     aria-label={`Rank ${index + 1}`}
                   >
@@ -383,14 +396,14 @@ export default function AdminHealthSection({
                   </div>
                 </div>
                 <div className="text-right">
-                  <p className="font-bold text-red-400">{formatCurrency(Number(withdrawer.totalWithdrawn))}</p>
-                  <p className="text-xs text-gray-500">withdrawn</p>
+                  <p className="font-semibold text-red-200">{formatCurrency(Number(withdrawer.totalWithdrawn))}</p>
+                  <p className="text-xs text-gray-400">withdrawn</p>
                 </div>
               </div>
             ))
           ) : (
-            <div className="text-center py-8 text-gray-500">
-              <Upload className="h-8 w-8 mx-auto mb-2 text-gray-600" />
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] py-8 text-center text-gray-400">
+              <Upload className="mx-auto mb-2 h-8 w-8 text-gray-600" />
               <p>No withdrawals yet</p>
             </div>
           )}

--- a/src/components/admin/wallet/AdminMetrics.tsx
+++ b/src/components/admin/wallet/AdminMetrics.tsx
@@ -75,8 +75,8 @@ function MetricCard({
   const cleanGrowth = Number.isFinite(growthRate as number) ? (growthRate as number) : 0;
 
   return (
-    <div className={`bg-gradient-to-br ${bgGradient} rounded-xl p-6 border relative overflow-hidden`}>
-      <div className="absolute top-0 right-0 w-32 h-32 bg-black/10 rounded-full -translate-y-16 translate-x-16" aria-hidden="true"></div>
+    <div className={`relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br ${bgGradient} p-6 backdrop-blur-sm`}>
+      <div className="pointer-events-none absolute top-0 right-0 h-32 w-32 -translate-y-16 translate-x-16 rounded-full bg-black/10" aria-hidden="true"></div>
       <div className="relative">
         <div className="flex items-center gap-3 mb-4">
           <div className={`p-3 ${iconColor} rounded-lg`} aria-hidden="true">

--- a/src/components/admin/wallet/AdminMoneyFlow.tsx
+++ b/src/components/admin/wallet/AdminMoneyFlow.tsx
@@ -5,39 +5,46 @@ import { Info, Download, ShoppingBag, Upload, TrendingUp } from 'lucide-react';
 
 export default function AdminMoneyFlow() {
   return (
-    <div className="bg-gradient-to-r from-[#1a1a1a] to-[#252525] rounded-xl p-6 border border-gray-800 mb-8">
-      <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
-        <Info className="h-5 w-5 text-[#ff950e]" aria-hidden="true" />
-        How Your Money Machine Works
-      </h3>
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <div className="text-center">
-          <div className="w-16 h-16 bg-blue-500/20 rounded-full flex items-center justify-center mx-auto mb-3">
-            <Download className="h-8 w-8 text-blue-400" aria-hidden="true" />
-          </div>
-          <h4 className="font-bold text-white mb-2">1. Buyer Deposits</h4>
-          <p className="text-sm text-gray-400">Buyer adds $100 to wallet → You collect $100 upfront cash flow</p>
-        </div>
-        <div className="text-center">
-          <div className="w-16 h-16 bg-[#ff950e]/20 rounded-full flex items-center justify-center mx-auto mb-3">
-            <ShoppingBag className="h-8 w-8 text-[#ff950e]" aria-hidden="true" />
-          </div>
-          <h4 className="font-bold text-white mb-2">2. Purchase Made</h4>
-          <p className="text-sm text-gray-400">$1000 item → Buyer pays $1100 → Seller gets $900 → You keep $200 (20%)</p>
-        </div>
-        <div className="text-center">
-          <div className="w-16 h-16 bg-red-500/20 rounded-full flex items-center justify-center mx-auto mb-3">
-            <Upload className="h-8 w-8 text-red-400" aria-hidden="true" />
-          </div>
-          <h4 className="font-bold text-white mb-2">3. Seller Withdraws</h4>
-          <p className="text-sm text-gray-400">Seller requests payout of their earnings from completed sales</p>
-        </div>
-        <div className="text-center">
-          <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-3">
-            <TrendingUp className="h-8 w-8 text-green-400" aria-hidden="true" />
-          </div>
-          <h4 className="font-bold text-white mb-2">4. Pure Profit</h4>
-          <p className="text-sm text-gray-400">20% profit margin on all sales + 25% from subscriptions</p>
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-8 backdrop-blur-sm shadow-xl shadow-black/30">
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-1/3 bg-gradient-to-r from-[#ff6b00]/20 via-transparent to-transparent" aria-hidden="true" />
+      <div className="relative">
+        <h3 className="mb-6 flex items-center gap-2 text-lg font-bold text-white">
+          <Info className="h-5 w-5 text-[#ffbf7f]" aria-hidden="true" />
+          How Your Money Machine Works
+        </h3>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
+          {[{
+            title: '1. Buyer Deposits',
+            description: 'Buyer adds $100 to wallet → You collect $100 upfront cash flow',
+            icon: Download,
+            ring: 'from-sky-500/20 to-sky-400/10 text-sky-300'
+          }, {
+            title: '2. Purchase Made',
+            description: '$1000 item → Buyer pays $1100 → Seller gets $900 → You keep $200 (20%)',
+            icon: ShoppingBag,
+            ring: 'from-[#ff950e]/30 to-[#ff6b00]/10 text-[#ffbf7f]'
+          }, {
+            title: '3. Seller Withdraws',
+            description: 'Seller requests payout of their earnings from completed sales',
+            icon: Upload,
+            ring: 'from-rose-500/25 to-rose-400/10 text-rose-200'
+          }, {
+            title: '4. Pure Profit',
+            description: '20% profit margin on all sales + 25% from subscriptions',
+            icon: TrendingUp,
+            ring: 'from-emerald-500/25 to-emerald-400/10 text-emerald-200'
+          }].map(({ title, description, icon: Icon, ring }) => (
+            <div
+              key={title}
+              className="relative flex flex-col items-center rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center transition-colors hover:border-[#ff950e]/40"
+            >
+              <div className={`mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br ${ring}`}>
+                <Icon className="h-8 w-8" aria-hidden="true" />
+              </div>
+              <h4 className="mb-2 text-base font-semibold text-white">{title}</h4>
+              <p className="text-sm text-gray-300">{description}</p>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/admin/wallet/AdminRecentActivity.tsx
+++ b/src/components/admin/wallet/AdminRecentActivity.tsx
@@ -119,10 +119,13 @@ export default function AdminRecentActivity({
   }, [filteredDeposits, filteredSellerWithdrawals, filteredAdminWithdrawals, filteredActions, filteredOrders]);
 
   return (
-    <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800">
-      <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center mb-6 gap-2">
-        <h3 className="text-lg font-bold text-white flex items-center gap-2">
-          <Clock className="h-5 w-5 text-[#ff950e]" />
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-8 backdrop-blur-sm shadow-xl shadow-black/30">
+      <div className="pointer-events-none absolute -top-20 -left-20 h-64 w-64 rounded-full bg-[#ff6b00]/15 blur-3xl" aria-hidden="true" />
+      <div className="pointer-events-none absolute bottom-0 right-0 h-56 w-56 rounded-full bg-purple-500/10 blur-3xl" aria-hidden="true" />
+
+      <div className="relative mb-6 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <h3 className="flex items-center gap-2 text-lg font-bold text-white">
+          <Clock className="h-5 w-5 text-[#ffbf7f]" />
           Recent Money Activity
         </h3>
         <div className="text-sm text-gray-400">
@@ -131,8 +134,8 @@ export default function AdminRecentActivity({
       </div>
 
       {allActivities.length > 0 ? (
-        <div className="overflow-hidden">
-          <div className="max-h-80 overflow-y-auto">
+        <div className="relative overflow-hidden">
+          <div className="max-h-80 overflow-y-auto pr-1">
             <div className="space-y-3">
               {allActivities.map((item, index) => {
                 if (!item || !item.data) return null;
@@ -141,63 +144,72 @@ export default function AdminRecentActivity({
                   const deposit = item.data;
                   const method = typeof deposit?.method === 'string' ? deposit.method.replace('_', ' ') : 'unknown';
                   return (
-                    <div key={`deposit-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-blue-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-blue-500/20 text-blue-400">
+                    <div
+                      key={`deposit-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-blue-500/30 bg-blue-500/5 p-4 transition-colors hover:border-blue-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-blue-500/20 p-2 text-blue-300">
                           <Download className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">💳 Deposit Received</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">💳 Deposit Received</p>
+                          <div className="truncate text-sm text-gray-300">
                             <SecureMessageDisplay content={deposit?.username || 'Unknown'} allowBasicFormatting={false} className="inline" />
                             <span> via {method}</span>
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-blue-400">+{formatCurrency(Number(deposit?.amount) || 0)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(deposit?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-blue-300">+{formatCurrency(Number(deposit?.amount) || 0)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(deposit?.date)}</p>
                       </div>
                     </div>
                   );
                 } else if (item.type === 'seller_withdrawal') {
                   const withdrawal = item.data;
                   return (
-                    <div key={`seller-withdrawal-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-red-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-red-500/20 text-red-400">
+                    <div
+                      key={`seller-withdrawal-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-red-500/30 bg-red-500/5 p-4 transition-colors hover:border-red-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-red-500/20 p-2 text-red-300">
                           <Upload className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">💸 Seller Withdrawal</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">💸 Seller Withdrawal</p>
+                          <div className="truncate text-sm text-gray-300">
                             <SecureMessageDisplay content={withdrawal?.seller || 'Unknown'} allowBasicFormatting={false} className="inline" />
                             <span> cashed out</span>
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-red-400">-{formatCurrency(Number(withdrawal?.amount) || 0)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(withdrawal?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-red-300">-{formatCurrency(Number(withdrawal?.amount) || 0)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(withdrawal?.date)}</p>
                       </div>
                     </div>
                   );
                 } else if (item.type === 'admin_withdrawal') {
                   const withdrawal = item.data;
                   return (
-                    <div key={`admin-withdrawal-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-purple-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-purple-500/20 text-purple-400">
+                    <div
+                      key={`admin-withdrawal-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-purple-500/30 bg-purple-500/5 p-4 transition-colors hover:border-purple-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-purple-500/20 p-2 text-purple-200">
                           <Wallet className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">👑 Admin Withdrawal</p>
-                          <p className="text-sm text-gray-400 truncate">Platform profit withdrawal</p>
+                          <p className="truncate font-medium text-white">👑 Admin Withdrawal</p>
+                          <p className="truncate text-sm text-gray-300">Platform profit withdrawal</p>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-purple-400">-{formatCurrency(Number(withdrawal?.amount) || 0)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(withdrawal?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-purple-200">-{formatCurrency(Number(withdrawal?.amount) || 0)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(withdrawal?.date)}</p>
                       </div>
                     </div>
                   );
@@ -209,14 +221,17 @@ export default function AdminRecentActivity({
                   const adminShare = Number(action?.amount) || 0;
                   const fullAmount = adminShare * 4; // 25% admin share → full price approx
                   return (
-                    <div key={`subscription-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-pink-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-pink-500/20 text-pink-400">
+                    <div
+                      key={`subscription-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-pink-500/30 bg-pink-500/5 p-4 transition-colors hover:border-pink-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-pink-500/20 p-2 text-pink-300">
                           <TrendingUp className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">🎉 Subscription Revenue</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">🎉 Subscription Revenue</p>
+                          <div className="truncate text-sm text-gray-300">
                             <SecureMessageDisplay content={buyer} allowBasicFormatting={false} className="inline" />
                             <span> → </span>
                             <SecureMessageDisplay content={seller} allowBasicFormatting={false} className="inline" />
@@ -224,9 +239,9 @@ export default function AdminRecentActivity({
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-pink-400">+{formatCurrency(adminShare)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(action?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-pink-300">+{formatCurrency(adminShare)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(action?.date)}</p>
                       </div>
                     </div>
                   );
@@ -242,14 +257,17 @@ export default function AdminRecentActivity({
                   const bonusPercent = percentMatch ? percentMatch[1] : '';
 
                   return (
-                    <div key={`tier-credit-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-yellow-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-yellow-500/20 text-yellow-400">
+                    <div
+                      key={`tier-credit-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-yellow-500/30 bg-yellow-500/5 p-4 transition-colors hover:border-yellow-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-yellow-500/20 p-2 text-yellow-200">
                           <Award className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">🏆 Tier Credit Paid Out</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">🏆 Tier Credit Paid Out</p>
+                          <div className="truncate text-sm text-gray-300">
                             <span>To </span>
                             <SecureMessageDisplay content={seller} allowBasicFormatting={false} className="inline" />
                             {tierName && <span> ({tierName} tier)</span>}
@@ -257,9 +275,9 @@ export default function AdminRecentActivity({
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-yellow-400">-{formatCurrency(Math.abs(Number(action?.amount) || 0))}</p>
-                        <p className="text-xs text-gray-500">{formatDate(action?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-yellow-200">-{formatCurrency(Math.abs(Number(action?.amount) || 0))}</p>
+                        <p className="text-xs text-gray-400">{formatDate(action?.date)}</p>
                       </div>
                     </div>
                   );
@@ -268,14 +286,17 @@ export default function AdminRecentActivity({
                   const base = Number(order?.finalBid ?? order?.price ?? 0);
                   const platformProfit = base * 0.2;
                   return (
-                    <div key={`auction-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-purple-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-purple-500/20 text-purple-400">
+                    <div
+                      key={`auction-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-purple-500/30 bg-purple-500/5 p-4 transition-colors hover:border-purple-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-purple-500/20 p-2 text-purple-200">
                           <Gavel className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">🔨 Auction Completed</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">🔨 Auction Completed</p>
+                          <div className="truncate text-sm text-gray-300">
                             <SecureMessageDisplay content={order?.buyer || 'Unknown'} allowBasicFormatting={false} className="inline" />
                             <span> won "</span>
                             <SecureMessageDisplay content={order?.title || 'Unknown Item'} allowBasicFormatting={false} className="inline" maxLength={50} />
@@ -283,9 +304,9 @@ export default function AdminRecentActivity({
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-purple-400">+{formatCurrency(platformProfit)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(order?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-purple-200">+{formatCurrency(platformProfit)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(order?.date)}</p>
                       </div>
                     </div>
                   );
@@ -294,14 +315,17 @@ export default function AdminRecentActivity({
                   const price = Number(order?.price) || 0;
                   const platformProfit = price * 0.2;
                   return (
-                    <div key={`sale-${index}`} className="flex items-center justify-between p-4 bg-[#252525] rounded-lg hover:bg-[#2a2a2a] transition-colors border-l-4 border-green-500/50">
-                      <div className="flex items-center gap-4 min-w-0 flex-1">
-                        <div className="p-2 rounded-lg flex-shrink-0 bg-green-500/20 text-green-400">
+                    <div
+                      key={`sale-${index}`}
+                      className="flex items-center justify-between gap-4 rounded-2xl border border-green-500/30 bg-green-500/5 p-4 transition-colors hover:border-green-400/40"
+                    >
+                      <div className="min-w-0 flex-1 flex items-center gap-4">
+                        <div className="flex-shrink-0 rounded-xl bg-green-500/20 p-2 text-green-300">
                           <ShoppingBag className="w-4 h-4" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-white truncate">🛍️ Regular Sale</p>
-                          <div className="text-sm text-gray-400 truncate">
+                          <p className="truncate font-medium text-white">🛍️ Regular Sale</p>
+                          <div className="truncate text-sm text-gray-300">
                             <SecureMessageDisplay content={order?.buyer || 'Unknown'} allowBasicFormatting={false} className="inline" />
                             <span> bought "</span>
                             <SecureMessageDisplay content={order?.title || 'Unknown Item'} allowBasicFormatting={false} className="inline" maxLength={50} />
@@ -309,9 +333,9 @@ export default function AdminRecentActivity({
                           </div>
                         </div>
                       </div>
-                      <div className="text-right flex-shrink-0 ml-4">
-                        <p className="font-bold text-green-400">+{formatCurrency(platformProfit)}</p>
-                        <p className="text-xs text-gray-500">{formatDate(order?.date)}</p>
+                      <div className="ml-4 flex-shrink-0 text-right">
+                        <p className="font-bold text-green-300">+{formatCurrency(platformProfit)}</p>
+                        <p className="text-xs text-gray-400">{formatDate(order?.date)}</p>
                       </div>
                     </div>
                   );
@@ -322,10 +346,10 @@ export default function AdminRecentActivity({
           </div>
         </div>
       ) : (
-        <div className="text-center py-12 text-gray-500">
-          <Activity className="h-12 w-12 mx-auto mb-4 text-gray-600" />
-          <h4 className="text-lg font-medium text-gray-400 mb-2">No Activity Yet</h4>
-          <p className="text-sm">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] py-12 text-center text-gray-400">
+          <Activity className="mx-auto mb-4 h-12 w-12 text-gray-600" />
+          <h4 className="mb-2 text-lg font-medium text-gray-300">No Activity Yet</h4>
+          <p className="text-sm text-gray-400">
             {timeFilter === 'all'
               ? "Start making money and it'll show up here! 🚀"
               : `No activity for ${getPeriodDisplayName().toLowerCase()}`}

--- a/src/components/admin/wallet/AdminRevenueChart.tsx
+++ b/src/components/admin/wallet/AdminRevenueChart.tsx
@@ -55,37 +55,40 @@ export default function AdminRevenueChart({ timeFilter, orderHistory, adminActio
   };
 
   return (
-    <div className="bg-[#1a1a1a] rounded-xl p-6 border border-gray-800 mb-8 overflow-hidden">
-      <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center mb-6 gap-2">
-        <h3 className="text-lg font-bold text-white flex items-center gap-2">
-          <BarChart3 className="h-5 w-5 text-[#ff950e]" />
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-8 backdrop-blur-sm shadow-xl shadow-black/30">
+      <div className="pointer-events-none absolute -top-24 -right-16 h-56 w-56 rounded-full bg-[#ff6b00]/15 blur-3xl" aria-hidden="true" />
+      <div className="pointer-events-none absolute bottom-0 left-0 h-48 w-48 rounded-full bg-purple-500/10 blur-3xl" aria-hidden="true" />
+
+      <div className="relative flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <h3 className="flex items-center gap-2 text-lg font-bold text-white">
+          <BarChart3 className="h-5 w-5 text-[#ffbf7f]" />
           Revenue Trend
         </h3>
         <div className="text-sm text-gray-400">{getChartPeriodDescription()}</div>
       </div>
 
       {chartData.length === 0 ? (
-        <div className="text-center text-gray-500 py-12">No revenue data for this period</div>
+        <div className="relative py-12 text-center text-gray-500">No revenue data for this period</div>
       ) : (
-        <>
+        <div className="relative mt-8">
           <div className="overflow-x-auto">
-            <div className="min-w-[600px] h-64 flex items-end justify-between gap-1 mb-4">
+            <div className="flex h-64 min-w-[600px] items-end justify-between gap-1">
               {chartData.map((period, index) => {
                 const heightPx = Math.max((period.revenue / maxRevenue) * 200, 4); // min bar height for visibility
                 return (
-                  <div key={index} className="flex-1 flex flex-col items-center group">
-                    <div className="relative w-full flex justify-center mb-2">
+                  <div key={index} className="group flex flex-1 flex-col items-center">
+                    <div className="relative mb-2 flex w-full justify-center">
                       <div
-                        className="w-8 bg-gradient-to-t from-[#ff950e] to-[#ff6b00] rounded-t-lg transition-all duration-300 group-hover:from-[#ff6b00] group-hover:to-[#ff950e] min-h-[4px]"
+                        className="min-h-[4px] w-8 rounded-t-lg bg-gradient-to-t from-[#ff950e] to-[#ff6b00] transition-all duration-300 group-hover:from-[#ff6b00] group-hover:to-[#ff950e]"
                         style={{ height: `${heightPx}px` }}
                         aria-label={`${period.date}: ${formatCurrency(period.revenue)}`}
                         role="img"
                       />
-                      <div className="absolute -top-8 bg-black/80 text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10">
+                      <div className="absolute -top-8 z-10 whitespace-nowrap rounded bg-black/80 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
                         {formatCurrency(period.revenue)}
                       </div>
                     </div>
-                    <span className="text-xs text-gray-500 transform -rotate-45 origin-center whitespace-nowrap block mt-1">
+                    <span className="mt-1 block origin-center -rotate-45 whitespace-nowrap text-xs text-gray-500">
                       {period.date}
                     </span>
                   </div>
@@ -93,26 +96,27 @@ export default function AdminRevenueChart({ timeFilter, orderHistory, adminActio
               })}
             </div>
           </div>
-
-          <div className="grid grid-cols-3 gap-4 pt-4 border-t border-gray-800">
-            <div className="text-center">
-              <p className="text-xs text-gray-500">
+          <div className="mt-6 grid grid-cols-1 gap-4 border-t border-white/10 pt-4 text-center sm:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">
                 Highest {timeFilter === 'today' ? 'Hour' : timeFilter === 'year' ? 'Month' : 'Day'}
               </p>
-              <p className="font-bold text-green-400">{formatCurrency(chartData.reduce((m, d) => Math.max(m, d.revenue), 0))}</p>
+              <p className="font-semibold text-emerald-300">
+                {formatCurrency(chartData.reduce((m, d) => Math.max(m, d.revenue), 0))}
+              </p>
             </div>
-            <div className="text-center">
-              <p className="text-xs text-gray-500">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">
                 Average {timeFilter === 'today' ? 'Hour' : timeFilter === 'year' ? 'Month' : 'Day'}
               </p>
-              <p className="font-bold text-white">{formatCurrency(averageChartRevenue)}</p>
+              <p className="font-semibold text-white">{formatCurrency(averageChartRevenue)}</p>
             </div>
-            <div className="text-center">
-              <p className="text-xs text-gray-500">Total Period</p>
-              <p className="font-bold text-[#ff950e]">{formatCurrency(totalChartRevenue)}</p>
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">Total Period</p>
+              <p className="font-semibold text-[#ffbf7f]">{formatCurrency(totalChartRevenue)}</p>
             </div>
           </div>
-        </>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- redesign the admin analytics dashboard shell with a hero overview, richer stats, and refreshed controls
- restyle supporting analytics components (revenue chart, money flow, recent activity, health cards) with the new gradient/glass aesthetic
- update metric cards to use rounded translucent surfaces that match the updated admin theme

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors across contexts, utils, and types)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fcdd33fc8328a12ced1aa8979f22