### PR TITLE
Refine My Orders page styling

### DIFF
--- a/src/app/buyers/my-orders/page.tsx
+++ b/src/app/buyers/my-orders/page.tsx
@@ -15,21 +15,17 @@ import { AlertCircle, Loader2 } from 'lucide-react';
 // Error component (Enhanced UI styling)
 function OrdersError({ error, onRetry }: { error: string; onRetry: () => void }) {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#020202] text-white">
-      <div className="absolute inset-0">
-        <div className="pointer-events-none absolute -top-40 right-[-20%] h-[480px] w-[480px] rounded-full bg-[#ff950e]/15 blur-3xl" />
-        <div className="pointer-events-none absolute bottom-[-30%] left-[-10%] h-[420px] w-[420px] rounded-full bg-[#ff7a00]/10 blur-3xl" />
-      </div>
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
-        <div className="w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-10 text-center shadow-[0_25px_80px_-40px_rgba(255,149,14,0.45)] backdrop-blur-xl">
+    <div className="min-h-screen bg-[#020202] text-white">
+      <div className="mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-white/[0.03] p-10 text-center">
           <div className="mx-auto mb-8 flex h-20 w-20 items-center justify-center rounded-2xl border border-red-500/30 bg-red-500/10">
             <AlertCircle className="h-10 w-10 text-red-400" />
           </div>
-          <h1 className="text-3xl font-semibold tracking-tight">We couldn't load your orders</h1>
+          <h1 className="text-3xl font-semibold tracking-tight">We couldn&apos;t load your orders</h1>
           <p className="mt-3 text-sm text-gray-400">{error}</p>
           <button
             onClick={onRetry}
-            className="mt-8 inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#ff950e] to-[#ff7a00] px-8 py-3 text-base font-semibold text-black shadow-[0_18px_45px_-25px_rgba(255,149,14,0.9)] transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#ff950e]/60"
+            className="mt-8 inline-flex items-center justify-center rounded-2xl bg-[#ff950e] px-8 py-3 text-base font-semibold text-black transition-colors hover:bg-[#ff7a00] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#ff950e]/60"
           >
             Try again
           </button>
@@ -42,13 +38,9 @@ function OrdersError({ error, onRetry }: { error: string; onRetry: () => void })
 // Loading component (Enhanced UI)
 function OrdersLoading() {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#020202] text-white">
-      <div className="absolute inset-0">
-        <div className="pointer-events-none absolute left-1/2 top-[-20%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[#ff950e]/12 blur-3xl" />
-        <div className="pointer-events-none absolute bottom-[-10%] left-1/3 h-[420px] w-[420px] rounded-full bg-[#ff7a00]/10 blur-3xl" />
-      </div>
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
-        <div className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/[0.03] px-10 py-16 shadow-[0_20px_60px_-30px_rgba(255,149,14,0.4)] backdrop-blur-xl">
+    <div className="min-h-screen bg-[#020202] text-white">
+      <div className="mx-auto flex min-h-screen max-w-7xl items-center justify-center px-6 py-16">
+        <div className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/[0.03] px-10 py-16">
           <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
             <Loader2 className="h-8 w-8 animate-spin text-[#ff950e]" />
           </div>
@@ -63,7 +55,6 @@ function OrdersLoading() {
 function MyOrdersContent() {
   const {
     // Data
-    user,
     userOrders,
     directOrders,
     customRequestOrders,
@@ -97,30 +88,21 @@ function MyOrdersContent() {
   };
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-[#020202]">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-[-15%] top-[-20%] h-[520px] w-[520px] rounded-full bg-[#ff950e]/15 blur-3xl" />
-        <div className="absolute right-[-10%] top-[30%] h-[480px] w-[480px] rounded-full bg-[#ff7a00]/12 blur-3xl" />
-        <div className="absolute bottom-[-25%] left-[25%] h-[420px] w-[420px] rounded-full bg-emerald-500/10 blur-3xl" />
-      </div>
-
-      <div className="relative z-10 px-4 py-12 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-[#020202]">
+      <div className="px-4 py-12 sm:px-6 lg:px-8">
         <div className="mx-auto flex max-w-7xl flex-col gap-8">
           {/* Page Header */}
-          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 sm:p-8 lg:p-12 shadow-[0_30px_90px_-45px_rgba(255,149,14,0.6)] backdrop-blur-xl">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.15),_transparent_55%)]" />
-            <div className="relative z-10">
-              <OrdersHeader />
-            </div>
+          <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6 sm:p-8 lg:p-12">
+            <OrdersHeader />
           </section>
 
           {/* Stats */}
-          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.8)] backdrop-blur-xl">
+          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8">
             <OrderStats stats={safeStats} />
           </section>
 
           {/* Orders */}
-          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8 shadow-[0_25px_80px_-45px_rgba(0,0,0,0.9)] backdrop-blur-xl">
+          <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-4 sm:p-6 lg:p-8">
             {safeUserOrders.length === 0 ? (
               <div className="rounded-3xl border border-dashed border-white/15 bg-black/40 p-10">
                 <EmptyOrdersState />

--- a/src/components/buyers/my-orders/EmptyOrdersState.tsx
+++ b/src/components/buyers/my-orders/EmptyOrdersState.tsx
@@ -7,14 +7,13 @@ import { Package, MessageCircle } from 'lucide-react';
 
 export default function EmptyOrdersState() {
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/[0.03] via-black/40 to-black/60 px-8 py-16 text-center shadow-[0_30px_90px_-50px_rgba(255,149,14,0.5)]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.18),_transparent_60%)]" />
-      <div className="relative z-10 mx-auto flex max-w-2xl flex-col items-center gap-8">
+    <div className="rounded-3xl border border-white/10 bg-black/40 px-8 py-16 text-center">
+      <div className="mx-auto flex max-w-2xl flex-col items-center gap-8">
         <div className="flex h-24 w-24 items-center justify-center rounded-[28px] border border-white/10 bg-black/40">
           <Package className="h-12 w-12 text-white/40" />
         </div>
         <div className="space-y-3">
-          <h3 className="text-3xl font-semibold text-white">You haven't placed any orders yet</h3>
+          <h3 className="text-3xl font-semibold text-white">You haven&apos;t placed any orders yet</h3>
           <p className="text-base text-gray-400">
             Discover verified sellers, browse curated drops, or send a custom request to get something made just for you.
           </p>
@@ -22,7 +21,7 @@ export default function EmptyOrdersState() {
         <div className="flex flex-wrap justify-center gap-4">
           <Link
             href="/browse"
-            className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[#ff950e] to-[#ff7a00] px-8 py-3 text-base font-semibold text-black shadow-[0_18px_45px_-25px_rgba(255,149,14,0.8)] transition-transform hover:-translate-y-0.5"
+            className="inline-flex items-center gap-2 rounded-2xl bg-[#ff950e] px-8 py-3 text-base font-semibold text-black transition-colors hover:bg-[#ff7a00]"
           >
             <Package className="h-5 w-5" />
             Explore listings
@@ -30,7 +29,7 @@ export default function EmptyOrdersState() {
 
           <Link
             href="/buyers/messages"
-            className="inline-flex items-center gap-2 rounded-2xl border border-white/15 bg-white/5 px-8 py-3 text-base font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-white/10"
+            className="inline-flex items-center gap-2 rounded-2xl border border-white/15 bg-white/5 px-8 py-3 text-base font-semibold text-white transition-colors hover:bg-white/10"
           >
             <MessageCircle className="h-5 w-5" />
             Send a custom request

--- a/src/components/buyers/my-orders/ExpandedOrderContent.tsx
+++ b/src/components/buyers/my-orders/ExpandedOrderContent.tsx
@@ -24,23 +24,21 @@ interface ExpandedOrderContentProps {
  *  - order.shipping?.trackingNumber: string
  */
 function getTrackingNumber(o: unknown): string | null {
-  if (!o || typeof o !== 'object') return null;
-
-  const anyOrder = o as Record<string, any>;
-
-  // Direct property (some code paths may attach it here)
-  if (typeof anyOrder.trackingNumber === 'string' && anyOrder.trackingNumber.trim().length > 0) {
-    return anyOrder.trackingNumber.trim();
+  if (!o || typeof o !== 'object' || o === null) {
+    return null;
   }
 
-  // Nested under shipping
-  if (
-    anyOrder.shipping &&
-    typeof anyOrder.shipping === 'object' &&
-    typeof anyOrder.shipping.trackingNumber === 'string' &&
-    anyOrder.shipping.trackingNumber.trim().length > 0
-  ) {
-    return anyOrder.shipping.trackingNumber.trim();
+  const orderRecord = o as Record<string, unknown>;
+  const directTracking = orderRecord.trackingNumber;
+
+  if (typeof directTracking === 'string' && directTracking.trim().length > 0) {
+    return directTracking.trim();
+  }
+
+  const shipping = orderRecord.shipping as { trackingNumber?: unknown } | undefined;
+
+  if (shipping && typeof shipping.trackingNumber === 'string' && shipping.trackingNumber.trim().length > 0) {
+    return shipping.trackingNumber.trim();
   }
 
   return null;
@@ -72,7 +70,7 @@ export default function ExpandedOrderContent({
                 fallbackSrc="/placeholder-avatar.png"
               />
             ) : (
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.25),_transparent)] text-lg font-semibold text-white ring-2 ring-white/10 transition duration-300 group-hover:ring-[#ff950e]/60">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-black/40 text-lg font-semibold text-white ring-2 ring-white/10 transition duration-300 group-hover:ring-[#ff950e]/60">
                 {order.seller ? order.seller.charAt(0).toUpperCase() : '?'}
               </div>
             )}
@@ -87,7 +85,7 @@ export default function ExpandedOrderContent({
 
           <Link
             href={`/buyers/messages?thread=${sanitizedUsername}`}
-            className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-white/10"
+            className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-white/10"
           >
             <MessageCircle className="h-4 w-4" />
             Message seller

--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -2,14 +2,13 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
 import { Order } from '@/types/order';
 import { useListings } from '@/context/ListingContext';
 import { getUserProfilePic } from '@/utils/profileUtils';
 import OrderHeader from './OrderHeader';
 import OrderDetails from './OrderDetails';
 import ExpandedOrderContent from './ExpandedOrderContent';
-import { formatOrderDate, getOrderStyles } from '@/utils/orderUtils';
+import { getOrderStyles } from '@/utils/orderUtils';
 
 interface OrderCardProps {
   order: Order;
@@ -28,9 +27,9 @@ export default function OrderCard({
 }: OrderCardProps) {
   const { users } = useListings();
   const styles = getOrderStyles(type);
-  
+
   const [sellerProfilePic, setSellerProfilePic] = useState<string | null>(null);
-  
+
   const sellerUser = users?.[order.seller ?? ''];
   const isSellerVerified = sellerUser?.verified || sellerUser?.verificationStatus === 'verified';
   const hasDeliveryAddress = !!order.deliveryAddress;
@@ -45,41 +44,31 @@ export default function OrderCard({
     loadProfilePic();
   }, [order.seller]);
 
-  const orderId = order.id || (order as any)._id || `order-${Date.now()}`;
+  const fallbackOrder = order as { _id?: string };
+  const orderId = order.id || fallbackOrder._id || `order-${Date.now()}`;
   const needsAddress = order.wasAuction && !hasDeliveryAddress;
 
   return (
     <div
-      className={`group relative overflow-hidden rounded-3xl border transition-all duration-300 ${
-        isExpanded
-          ? `bg-black/45 shadow-[0_35px_90px_-40px_rgba(0,0,0,0.85)] ${styles.borderStyle}`
-          : `bg-black/35 ${styles.borderStyle} hover:-translate-y-1 hover:shadow-[0_40px_95px_-45px_rgba(0,0,0,0.9)]`
-      }`}
+      className={`relative overflow-hidden rounded-3xl border bg-black/35 transition-colors duration-300 ${
+        isExpanded ? 'bg-black/45' : 'hover:bg-black/40'
+      } ${styles.borderStyle}`}
     >
-      <div className={`pointer-events-none absolute inset-0 opacity-80 transition-opacity duration-500 group-hover:opacity-100 bg-gradient-to-br ${styles.gradientStyle}`} />
-      <div className="absolute inset-0 bg-black/30" />
-
-      {/* Accent border glow */}
-      <div
-        className="pointer-events-none absolute inset-0 rounded-3xl border border-white/5"
-        aria-hidden
-      />
-
       {/* Action indicator */}
       <div
-        className={`pointer-events-none absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r ${
+        className={`pointer-events-none absolute inset-x-0 top-0 h-0.5 ${
           type === 'auction'
-            ? 'from-purple-500 via-purple-400 to-violet-500'
+            ? 'bg-purple-500'
             : type === 'custom'
-              ? 'from-blue-500 via-sky-400 to-cyan-500'
-              : 'from-[#ff950e] via-[#ffb469] to-orange-500'
+              ? 'bg-sky-400'
+              : 'bg-[#ff950e]'
         }`}
       />
 
       {/* Auction action badge */}
       {order.wasAuction && needsAddress && (
         <div className="absolute right-6 top-6 z-10">
-          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/50 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-200 shadow-[0_12px_30px_-20px_rgba(16,185,129,0.8)]">
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/50 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-200">
             <span className="text-base">🏆</span>
             <span>Confirm address</span>
           </div>

--- a/src/components/buyers/my-orders/OrderDetails.tsx
+++ b/src/components/buyers/my-orders/OrderDetails.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { Calendar, Tag, MapPin, CheckCircle, ChevronDown, ChevronUp } from 'lucide-react';
 import { Order } from '@/context/WalletContext';
 import { formatOrderDate, getShippingStatusBadge } from '@/utils/orderUtils';
-import { SecureMessageDisplay } from '@/components/ui/SecureMessageDisplay';
 
 interface OrderDetailsProps {
   order: Order;
@@ -70,7 +69,7 @@ export default function OrderDetails({
         {!hasDeliveryAddress ? (
           <button
             onClick={() => onOpenAddressModal(order.id)}
-            className="inline-flex items-center gap-2 rounded-2xl border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition-all hover:-translate-y-0.5 hover:border-amber-300/60 hover:bg-amber-500/15"
+            className="inline-flex items-center gap-2 rounded-2xl border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition-colors hover:border-amber-300/60 hover:bg-amber-500/15"
           >
             <MapPin className="h-4 w-4" />
             Confirm delivery address
@@ -83,10 +82,10 @@ export default function OrderDetails({
         )}
 
         <button
-          className={`inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition-all ${
+          className={`inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition-colors ${
             isExpanded
-              ? 'text-gray-300 hover:-translate-y-0.5 hover:text-white'
-              : 'bg-gradient-to-r from-[#ff950e]/20 to-[#ff7a00]/20 text-[#ffb469] hover:-translate-y-0.5 hover:from-[#ff950e]/30 hover:to-[#ff7a00]/30'
+              ? 'text-gray-300 hover:text-white'
+              : 'bg-[#ff950e]/15 text-[#ffb469] hover:bg-[#ff950e]/25'
           }`}
           onClick={() => onToggleExpanded(isExpanded ? null : order.id)}
         >

--- a/src/components/buyers/my-orders/OrderHeader.tsx
+++ b/src/components/buyers/my-orders/OrderHeader.tsx
@@ -20,14 +20,11 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   const accentColor = styles.accentColor;
   const accentWithAlpha = (alpha: string) => `${accentColor}${alpha}`;
 
-  const accentGlowStyle: React.CSSProperties = {
-    boxShadow: `0 25px 60px -30px ${accentWithAlpha('88')}`,
-  };
   const accentBorderStyle: React.CSSProperties = {
     borderColor: `${accentWithAlpha('55')}`,
   };
   const accentPillStyle: React.CSSProperties = {
-    background: `linear-gradient(120deg, ${accentWithAlpha('24')}, rgba(17,17,17,0.65))`,
+    backgroundColor: accentWithAlpha('24'),
     borderColor: `${accentWithAlpha('55')}`,
     color: accentColor,
   };
@@ -108,10 +105,10 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   return (
     <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
       {/* Product Image or Custom Request Icon */}
-      <div className="relative flex-shrink-0" style={accentGlowStyle}>
+      <div className="relative flex-shrink-0">
         <div className="relative h-28 w-28 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
           {isCustom ? (
-            <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.25),_transparent)]">
+            <div className="flex h-full w-full items-center justify-center bg-black/40">
               <Settings className="h-10 w-10 text-sky-300" />
             </div>
           ) : (
@@ -130,7 +127,7 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
                   onError={handleImageError}
                 />
               ) : (
-                <div className="flex h-full w-full flex-col items-center justify-center gap-1 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent)] text-gray-500">
+                <div className="flex h-full w-full flex-col items-center justify-center gap-1 bg-black/40 text-gray-500">
                   <span className="text-3xl font-semibold">{(order.title || '?').charAt(0).toUpperCase()}</span>
                   <span className="text-xs uppercase tracking-widest">No image</span>
                 </div>

--- a/src/components/buyers/my-orders/OrderSections.tsx
+++ b/src/components/buyers/my-orders/OrderSections.tsx
@@ -48,10 +48,10 @@ export default function OrderSections({
   };
 
   const tabConfig = [
-    { id: 'all', label: 'All orders', count: allOrders.length, icon: ShoppingBag, gradient: 'from-[#ff950e]/35 to-[#ff7a00]/30', iconBg: 'bg-[#ff950e]/15 text-[#ffb469]' },
-    { id: 'purchases', label: 'Direct', count: directOrders.length, icon: Package, show: directOrders.length > 0, gradient: 'from-emerald-500/25 to-teal-500/25', iconBg: 'bg-emerald-500/15 text-emerald-300' },
-    { id: 'custom', label: 'Custom', count: customRequestOrders.length, icon: Settings, show: customRequestOrders.length > 0, gradient: 'from-sky-500/25 to-cyan-500/20', iconBg: 'bg-sky-500/15 text-sky-300' },
-    { id: 'auctions', label: 'Auctions', count: auctionOrders.length, icon: Gavel, show: auctionOrders.length > 0, gradient: 'from-purple-500/25 to-violet-500/20', iconBg: 'bg-purple-500/15 text-purple-300' },
+    { id: 'all', label: 'All orders', count: allOrders.length, icon: ShoppingBag, iconBg: 'bg-[#ff950e]/15 text-[#ffb469]' },
+    { id: 'purchases', label: 'Direct', count: directOrders.length, icon: Package, show: directOrders.length > 0, iconBg: 'bg-emerald-500/15 text-emerald-300' },
+    { id: 'custom', label: 'Custom', count: customRequestOrders.length, icon: Settings, show: customRequestOrders.length > 0, iconBg: 'bg-sky-500/15 text-sky-300' },
+    { id: 'auctions', label: 'Auctions', count: auctionOrders.length, icon: Gavel, show: auctionOrders.length > 0, iconBg: 'bg-purple-500/15 text-purple-300' },
   ] as const;
 
   const activeTabConfig = tabConfig.find((tab) => tab.id === activeTab);
@@ -71,10 +71,8 @@ export default function OrderSections({
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-left transition-all duration-200 ${
-                    isActive
-                      ? `bg-gradient-to-r ${tab.gradient} text-white shadow-[0_18px_45px_-35px_rgba(255,149,14,0.8)]`
-                      : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                  className={`group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-left transition-colors duration-200 ${
+                    isActive ? 'bg-white/10 text-white' : 'text-gray-400 hover:bg-white/5 hover:text-white'
                   }`}
                 >
                   <span className={`flex h-9 w-9 items-center justify-center rounded-xl ${tab.iconBg} transition-transform duration-200 group-hover:scale-105`}>

--- a/src/components/buyers/my-orders/OrderStats.tsx
+++ b/src/components/buyers/my-orders/OrderStats.tsx
@@ -13,45 +13,42 @@ export default function OrderStats({ stats }: OrderStatsProps) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-6">
       {/* Total Spent Card */}
-      <div className="group relative overflow-hidden rounded-3xl border border-[#ff950e]/30 bg-[radial-gradient(circle_at_top,_rgba(255,149,14,0.16),_rgba(17,17,17,0.6))] p-6 shadow-[0_20px_60px_-45px_rgba(255,149,14,0.8)] transition-transform duration-300 hover:-translate-y-1 hover:border-[#ff950e]/50">
-        <div className="pointer-events-none absolute -right-12 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full bg-[#ff950e]/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-        <div className="relative flex items-center justify-between">
+      <div className="rounded-3xl border border-[#ff950e]/30 bg-black/30 p-6">
+        <div className="flex items-center justify-between">
           <div>
             <p className="text-xs font-medium uppercase tracking-wider text-[#ffb469]">Total spent</p>
             <p className="mt-2 text-3xl font-bold text-white">${stats.totalSpent.toFixed(2)}</p>
             <p className="mt-1 text-xs text-[#ffb469]/80">Includes platform fees and credits redeemed</p>
           </div>
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-[#ff950e]/50 bg-[#ff950e]/15 text-[#ff950e] transition-transform duration-300 group-hover:scale-105">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-[#ff950e]/50 bg-[#ff950e]/15 text-[#ff950e]">
             <DollarSign className="h-6 w-6" />
           </div>
         </div>
       </div>
 
       {/* Pending Orders Card */}
-      <div className="group relative overflow-hidden rounded-3xl border border-yellow-400/25 bg-[radial-gradient(circle_at_top,_rgba(250,204,21,0.15),_rgba(17,17,17,0.65))] p-6 shadow-[0_20px_60px_-50px_rgba(250,204,21,0.6)] transition-transform duration-300 hover:-translate-y-1 hover:border-yellow-300/50">
-        <div className="pointer-events-none absolute -left-16 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full bg-yellow-300/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-        <div className="relative flex items-center justify-between">
+      <div className="rounded-3xl border border-yellow-400/25 bg-black/30 p-6">
+        <div className="flex items-center justify-between">
           <div>
             <p className="text-xs font-medium uppercase tracking-wider text-yellow-200/80">Pending orders</p>
             <p className="mt-2 text-3xl font-bold text-white">{stats.pendingOrders}</p>
             <p className="mt-1 text-xs text-yellow-100/70">Awaiting seller confirmation or shipment</p>
           </div>
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-yellow-300/50 bg-yellow-300/15 text-yellow-200 transition-transform duration-300 group-hover:scale-105">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-yellow-300/50 bg-yellow-300/15 text-yellow-200">
             <Clock className="h-6 w-6" />
           </div>
         </div>
       </div>
 
       {/* Shipped Orders Card */}
-      <div className="group relative overflow-hidden rounded-3xl border border-sky-400/25 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15),_rgba(17,17,17,0.65))] p-6 shadow-[0_20px_60px_-50px_rgba(56,189,248,0.6)] transition-transform duration-300 hover:-translate-y-1 hover:border-sky-300/50">
-        <div className="pointer-events-none absolute -right-10 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full bg-sky-400/20 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-        <div className="relative flex items-center justify-between">
+      <div className="rounded-3xl border border-sky-400/25 bg-black/30 p-6">
+        <div className="flex items-center justify-between">
           <div>
             <p className="text-xs font-medium uppercase tracking-wider text-sky-200/80">Shipped orders</p>
             <p className="mt-2 text-3xl font-bold text-white">{stats.shippedOrders}</p>
             <p className="mt-1 text-xs text-sky-100/70">In transit and ready for doorstep delivery</p>
           </div>
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-sky-300/50 bg-sky-300/15 text-sky-200 transition-transform duration-300 group-hover:scale-105">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-sky-300/50 bg-sky-300/15 text-sky-200">
             <Truck className="h-6 w-6" />
           </div>
         </div>

--- a/src/components/buyers/my-orders/OrdersHeader.tsx
+++ b/src/components/buyers/my-orders/OrdersHeader.tsx
@@ -6,18 +6,13 @@ import { ShoppingBag, TrendingUp, Package, Sparkles, ShieldCheck } from 'lucide-
 
 export default function OrdersHeader() {
   return (
-    <div className="relative flex flex-col gap-8">
-      {/* Background glows */}
-      <div className="pointer-events-none absolute -top-10 left-0 h-40 w-40 rounded-full bg-[#ff950e]/20 blur-3xl" />
-      <div className="pointer-events-none absolute -bottom-12 right-6 h-48 w-48 rounded-full bg-[#ff7a00]/10 blur-3xl" />
-
-      <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
         {/* Title section */}
         <div className="flex flex-1 flex-col gap-6">
           <div className="flex items-center gap-4">
-            <div className="relative inline-flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border border-[#ff950e]/40 bg-gradient-to-br from-[#ff950e]/40 via-[#ff7a00]/60 to-[#ff6b00]/70 shadow-[0_15px_40px_-25px_rgba(255,149,14,0.9)]">
-              <span className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.25),_transparent_60%)]" />
-              <ShoppingBag className="relative z-10 h-6 w-6 text-white" />
+            <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15">
+              <ShoppingBag className="h-6 w-6 text-white" />
             </div>
             <div>
               <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-gray-200/70">
@@ -29,7 +24,7 @@ export default function OrdersHeader() {
                 </span>
               </h1>
               <p className="mt-2 max-w-xl text-sm text-gray-400 sm:text-base">
-                Track purchases, review deliveries, and stay in sync with every seller you're supporting.
+                Track purchases, review deliveries, and stay in sync with every seller you&apos;re supporting.
               </p>
             </div>
           </div>
@@ -66,7 +61,7 @@ export default function OrdersHeader() {
         </div>
 
         {/* Trust panel */}
-        <div className="relative flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300 shadow-[0_15px_45px_-30px_rgba(255,149,14,0.6)]">
+        <div className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300">
           <div className="flex items-center gap-3">
             <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-[#ff950e]/30 bg-[#ff950e]/10">
               <ShieldCheck className="h-6 w-6 text-[#ff950e]" />
@@ -78,7 +73,7 @@ export default function OrdersHeader() {
           </div>
           <div className="rounded-2xl border border-white/5 bg-black/30 p-4 text-xs text-gray-400">
             <p>
-              Keep an eye on address confirmations for auction wins and leave reviews to unlock loyalty bonuses with your favorite sellers.
+              Keep an eye on address confirmations for auction wins and leave reviews to unlock loyalty bonuses with your favourite sellers.
             </p>
           </div>
         </div>

--- a/src/components/buyers/my-orders/ReviewSection.tsx
+++ b/src/components/buyers/my-orders/ReviewSection.tsx
@@ -17,7 +17,7 @@ interface ReviewSectionProps {
 
 export default function ReviewSection({ order }: ReviewSectionProps) {
   const { user } = useAuth();
-  const { addReview, hasReviewed, isLoading } = useReviews();
+  const { addReview, hasReviewed } = useReviews();
   const { showToast } = useToast();
   
   const [showReviewForm, setShowReviewForm] = useState(false);
@@ -49,7 +49,8 @@ export default function ReviewSection({ order }: ReviewSectionProps) {
 
       // Can review if order is shipped or delivered and not already reviewed
       // FIXED: Cast to any to handle the delivered status that might not be in the type definition
-      const canDoReview = (order.shippingStatus === 'shipped' || (order.shippingStatus as any) === 'delivered') && !reviewed;
+      const status = order.shippingStatus as string | undefined;
+      const canDoReview = (status === 'shipped' || status === 'delivered') && !reviewed;
       setCanReview(canDoReview);
     };
 
@@ -131,7 +132,7 @@ export default function ReviewSection({ order }: ReviewSectionProps) {
         <div className="mt-4 p-3 bg-gray-800/30 border border-gray-700/50 rounded-lg">
           <div className="flex items-center gap-2 text-gray-500">
             <AlertCircle className="w-4 h-4" />
-            <span className="text-xs">You can review this order after it's shipped</span>
+            <span className="text-xs">You can review this order after it&apos;s shipped</span>
           </div>
         </div>
       );
@@ -144,7 +145,7 @@ export default function ReviewSection({ order }: ReviewSectionProps) {
       <div className="mt-4">
         <button
           onClick={() => setShowReviewForm(true)}
-          className="w-full bg-gradient-to-r from-purple-600/20 to-purple-500/20 hover:from-purple-600/30 hover:to-purple-500/30 text-purple-300 py-2.5 px-4 rounded-lg font-medium transition flex items-center justify-center gap-2 border border-purple-600/30 hover:border-purple-500/50"
+          className="w-full rounded-lg border border-purple-600/30 bg-purple-600/20 py-2.5 px-4 font-medium text-purple-300 transition-colors hover:border-purple-500/50 hover:bg-purple-600/25 flex items-center justify-center gap-2"
         >
           <Star className="w-4 h-4" />
           Write a Review
@@ -155,7 +156,7 @@ export default function ReviewSection({ order }: ReviewSectionProps) {
   }
 
   return (
-    <div className="mt-4 p-5 bg-purple-900/10 border border-purple-700/30 rounded-lg">
+    <div className="mt-4 rounded-lg border border-purple-700/30 bg-purple-900/10 p-5">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-base font-bold text-white flex items-center gap-2">
           <Star className="w-4 h-4 text-yellow-500" />
@@ -253,14 +254,14 @@ export default function ReviewSection({ order }: ReviewSectionProps) {
             type="button"
             onClick={() => setShowReviewForm(false)}
             disabled={isSubmitting}
-            className="flex-1 bg-gray-700/50 hover:bg-gray-700/70 text-white py-2 px-3 rounded-lg font-medium transition disabled:opacity-50 text-sm"
+            className="flex-1 rounded-lg bg-gray-700/50 py-2 px-3 text-sm font-medium text-white transition-colors hover:bg-gray-700/70 disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={isSubmitting || !comment || comment.trim().length < 10}
-            className="flex-1 bg-gradient-to-r from-purple-600 to-purple-500 hover:from-purple-500 hover:to-purple-400 text-white py-2 px-3 rounded-lg font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+            className="flex-1 rounded-lg bg-purple-600 py-2 px-3 text-sm font-semibold text-white transition-colors hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? 'Submitting...' : 'Submit Review'}
           </button>

--- a/src/utils/orderUtils.tsx
+++ b/src/utils/orderUtils.tsx
@@ -1,9 +1,9 @@
 // src/utils/orderUtils.tsx
 import React from 'react';
-import { 
-  Clock, 
-  Package, 
-  Truck, 
+import {
+  Clock,
+  Package,
+  Truck,
   CheckCircle,
   Gavel,
   Settings,
@@ -12,7 +12,6 @@ import {
 
 export interface OrderStyles {
   borderStyle: string;
-  gradientStyle: string;
   badgeContent: React.ReactNode | null;
   accentColor: string;
 }
@@ -22,11 +21,10 @@ export function getOrderStyles(type: 'auction' | 'direct' | 'custom'): OrderStyl
     case 'auction':
       return {
         borderStyle: 'border-purple-500/30 hover:border-purple-400/50',
-        gradientStyle: 'from-purple-900/10 via-gray-900/50 to-blue-900/10',
         accentColor: '#a855f7',
         badgeContent: (
-          <span className="absolute -top-2 -right-2 bg-gradient-to-r from-purple-500 to-purple-400 text-white text-xs px-2 py-1 rounded-full font-bold shadow-lg flex items-center">
-            <Gavel className="w-3 h-3 mr-1" />
+          <span className="absolute -top-2 -right-2 rounded-full bg-purple-500 px-2 py-1 text-xs font-bold text-white">
+            <Gavel className="mr-1 h-3 w-3" />
             Auction
           </span>
         ),
@@ -34,11 +32,10 @@ export function getOrderStyles(type: 'auction' | 'direct' | 'custom'): OrderStyl
     case 'custom':
       return {
         borderStyle: 'border-blue-500/30 hover:border-blue-400/50',
-        gradientStyle: 'from-blue-900/10 via-gray-900/50 to-cyan-900/10',
         accentColor: '#3b82f6',
         badgeContent: (
-          <span className="absolute -top-2 -right-2 bg-gradient-to-r from-blue-500 to-cyan-400 text-white text-xs px-2 py-1 rounded-full font-bold shadow-lg flex items-center">
-            <Settings className="w-3 h-3 mr-1" />
+          <span className="absolute -top-2 -right-2 rounded-full bg-sky-500 px-2 py-1 text-xs font-bold text-white">
+            <Settings className="mr-1 h-3 w-3" />
             Custom
           </span>
         ),
@@ -46,7 +43,6 @@ export function getOrderStyles(type: 'auction' | 'direct' | 'custom'): OrderStyl
     default:
       return {
         borderStyle: 'border-gray-700 hover:border-[#ff950e]/50',
-        gradientStyle: 'from-gray-900/50 via-black/30 to-gray-800/50',
         accentColor: '#ff950e',
         badgeContent: null,
       };
@@ -64,27 +60,27 @@ export function formatOrderDate(dateString: string): string {
 export function getShippingStatusBadge(status?: string) {
   if (!status || status === 'pending') {
     return (
-      <div className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-bold bg-yellow-500/20 text-yellow-300 border border-yellow-500/30">
-        <Clock className="w-3 h-3 mr-1" />
+      <div className="inline-flex items-center rounded-lg border border-yellow-500/30 bg-yellow-500/20 px-3 py-1.5 text-xs font-bold text-yellow-300">
+        <Clock className="mr-1 h-3 w-3" />
         Awaiting Shipment
       </div>
     );
   } else if (status === 'processing') {
     return (
-      <div className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-bold bg-blue-500/20 text-blue-300 border border-blue-500/30">
-        <Package className="w-3 h-3 mr-1" />
+      <div className="inline-flex items-center rounded-lg border border-blue-500/30 bg-blue-500/20 px-3 py-1.5 text-xs font-bold text-blue-300">
+        <Package className="mr-1 h-3 w-3" />
         Preparing
       </div>
     );
   } else if (status === 'shipped') {
     return (
-      <div className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-bold bg-green-500/20 text-green-300 border border-green-500/30">
-        <Truck className="w-3 h-3 mr-1" />
+      <div className="inline-flex items-center rounded-lg border border-green-500/30 bg-green-500/20 px-3 py-1.5 text-xs font-bold text-green-300">
+        <Truck className="mr-1 h-3 w-3" />
         Shipped
       </div>
     );
   }
-  
+
   // Add default return
   return null;
 }


### PR DESCRIPTION
## Summary
- remove glow-style gradients and shadows from the buyer My Orders experience, including error/loading states
- simplify section, card, and tab styling across the orders components and supporting utilities
- tidy review logic and address lint findings surfaced by the updates

## Testing
- npm run lint -- --dir src/app/buyers/my-orders --dir src/components/buyers/my-orders

------
https://chatgpt.com/codex/tasks/task_e_68e228149b3c832893ba7543892f0725