### PR TITLE
Adjust buyer order cards for a more compact layout

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -50,8 +50,8 @@ export default function OrderCard({
 
   return (
     <div
-      className={`relative overflow-hidden rounded-2xl border bg-black/30 transition-colors duration-300 ${
-        isExpanded ? 'bg-black/45' : 'hover:bg-black/40'
+      className={`relative overflow-hidden rounded-xl border bg-black/25 transition-colors duration-300 ${
+        isExpanded ? 'bg-black/40' : 'hover:bg-black/35'
       } ${styles.borderStyle}`}
     >
       {/* Action indicator */}
@@ -75,7 +75,7 @@ export default function OrderCard({
         </div>
       )}
 
-      <div className="relative z-10 p-5 sm:p-6">
+      <div className="relative z-10 p-4 sm:p-5">
         <OrderHeader order={order} type={type} styles={styles} />
 
         <OrderDetails

--- a/src/components/buyers/my-orders/OrderDetails.tsx
+++ b/src/components/buyers/my-orders/OrderDetails.tsx
@@ -29,14 +29,14 @@ export default function OrderDetails({
   return (
     <>
       {/* Streamlined Meta Info */}
-      <div className="mt-4 flex flex-wrap items-center gap-2 text-[11px] text-gray-400 sm:text-xs">
-        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1.5">
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-gray-400 sm:text-xs">
+        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
           <Calendar className="h-4 w-4 text-white/60" />
           <span>{formatOrderDate(order.date)}</span>
         </div>
 
         {order.tags && order.tags.length > 0 && (
-          <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1.5">
+          <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
             <Tag className="h-4 w-4 text-white/60" />
             <span className="opacity-80">
               {order.tags.slice(0, 2).join(', ')}
@@ -45,44 +45,44 @@ export default function OrderDetails({
           </div>
         )}
 
-        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1.5">
+        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
           {getShippingStatusBadge(order.shippingStatus)}
         </div>
       </div>
 
       {/* Type-specific highlight - More subtle */}
       {isAuction && (
-        <div className="mt-4 rounded-xl border border-purple-500/30 bg-purple-500/10 px-4 py-3 text-sm text-purple-100">
+        <div className="mt-3 rounded-xl border border-purple-500/30 bg-purple-500/10 px-4 py-2.5 text-sm text-purple-100">
           Winning bid
           <span className="ml-2 font-semibold text-white">${order.finalBid?.toFixed(2) || order.price.toFixed(2)}</span>
         </div>
       )}
 
       {isCustom && order.originalRequestId && (
-        <div className="mt-4 rounded-xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-100">
+        <div className="mt-3 rounded-xl border border-sky-500/30 bg-sky-500/10 px-4 py-2.5 text-sm text-sky-100">
           Custom Request •
           <span className="ml-2 font-mono text-xs text-sky-200/80">#{order.originalRequestId.slice(0, 8)}</span>
         </div>
       )}
 
-      <div className="mt-6 flex flex-col gap-2.5 rounded-xl border border-white/5 bg-black/30 px-4 py-3.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+      <div className="mt-4 flex flex-col gap-2 rounded-xl border border-white/5 bg-black/30 px-4 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
         {!hasDeliveryAddress ? (
           <button
             onClick={() => onOpenAddressModal(order.id)}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition-colors hover:border-amber-300/60 hover:bg-amber-500/15 sm:w-auto sm:justify-start"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-400/40 bg-amber-500/10 px-3.5 py-1.5 text-sm font-semibold text-amber-200 transition-colors hover:border-amber-300/60 hover:bg-amber-500/15 sm:w-auto sm:justify-start"
           >
             <MapPin className="h-4 w-4" />
             Confirm delivery address
           </button>
         ) : (
-          <div className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 sm:w-auto sm:justify-start">
+          <div className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-3.5 py-1.5 text-sm font-semibold text-emerald-200 sm:w-auto sm:justify-start">
             <CheckCircle className="h-4 w-4" />
             Address confirmed
           </div>
         )}
 
         <button
-          className={`inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors sm:w-auto sm:justify-start ${
+          className={`inline-flex w-full items-center justify-center gap-2 rounded-xl px-3.5 py-1.5 text-sm font-semibold transition-colors sm:w-auto sm:justify-start ${
             isExpanded
               ? 'text-gray-300 hover:text-white'
               : 'bg-[#ff950e]/15 text-[#ffb469] hover:bg-[#ff950e]/25'

--- a/src/components/buyers/my-orders/OrderHeader.tsx
+++ b/src/components/buyers/my-orders/OrderHeader.tsx
@@ -103,10 +103,10 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   };
 
   return (
-    <div className="flex flex-col gap-5 lg:grid lg:grid-cols-[auto,1fr,auto] lg:items-start lg:gap-6">
+    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[auto,1fr,auto] lg:items-start lg:gap-5">
       {/* Product Image or Custom Request Icon */}
-      <div className="flex flex-shrink-0 flex-col items-center gap-3 lg:items-start">
-        <div className="relative h-24 w-24 overflow-hidden rounded-xl border border-white/10 bg-black/40">
+      <div className="flex flex-shrink-0 flex-col items-center gap-2.5 lg:items-start">
+        <div className="relative h-20 w-20 overflow-hidden rounded-xl border border-white/10 bg-black/40">
           {isCustom ? (
             <div className="flex h-full w-full items-center justify-center bg-black/40">
               <Settings className="h-10 w-10 text-sky-300" />
@@ -114,7 +114,7 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
           ) : (
             <>
               {!imageLoaded && !imageError && imageSrc && !imageSrc.startsWith('data:') && (
-                <div className="absolute inset-0 animate-pulse rounded-2xl bg-white/5" />
+                <div className="absolute inset-0 animate-pulse rounded-xl bg-white/5" />
               )}
               {imageSrc ? (
                 <img
@@ -138,7 +138,7 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
 
         <div className="flex justify-center lg:justify-start">
           <span
-            className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-widest"
+            className="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest"
             style={accentPillStyle}
           >
             <TypeIcon className="h-3.5 w-3.5" />
@@ -148,27 +148,28 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
       </div>
 
       {/* Order Title and Price */}
-      <div className="flex min-w-0 flex-1 flex-col gap-3 lg:pr-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-2.5 lg:pr-4">
         <div className="flex min-w-0 flex-col gap-1.5">
-          <h3 className="text-xl font-semibold text-white sm:text-[1.35rem]">
+          <h3 className="text-lg font-semibold text-white sm:text-[1.25rem]">
             <SecureMessageDisplay content={order.title} allowBasicFormatting={false} as="span" />
           </h3>
-          <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-500 sm:text-xs">
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 font-medium text-gray-300">
-              Order ID: <span className="font-mono text-[10px] text-gray-400 sm:text-[11px]">{order.id ? order.id.slice(0, 10) : '—'}</span>
+          <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-gray-500 sm:text-xs">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-medium text-gray-300">
+              Order ID:{' '}
+              <span className="font-mono text-[10px] text-gray-400 sm:text-[11px]">{order.id ? order.id.slice(0, 10) : '—'}</span>
             </span>
             {isAuction && <Star className="h-4 w-4 text-purple-300" />}
             {isCustom && <Settings className="h-4 w-4 text-sky-300" />}
           </div>
         </div>
 
-        <div className="text-sm text-gray-300 sm:text-[0.95rem]">
+        <div className="text-[13px] leading-relaxed text-gray-300 sm:text-sm">
           <SecureMessageDisplay content={order.description} allowBasicFormatting={false} />
         </div>
       </div>
 
       <div
-        className="flex flex-col rounded-xl border px-3.5 py-3 text-right lg:min-w-[200px] lg:self-start"
+        className="flex flex-col rounded-xl border px-3 py-2.5 text-right lg:min-w-[190px] lg:self-start"
         style={accentBorderStyle}
       >
         <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>


### PR DESCRIPTION
## Summary
- tighten spacing and padding on buyer order cards to reduce vertical footprint
- scale down order header media, chips, and typography for a more compact presentation
- adjust action bar styles so controls remain balanced within the slimmer layout

## Testing
- npm run lint *(fails: existing lint violations throughout repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e247e75c988328b18ea2a7d6a502da