### PR TITLE
Move buyer order total to header top right

### DIFF
--- a/src/components/buyers/my-orders/OrderHeader.tsx
+++ b/src/components/buyers/my-orders/OrderHeader.tsx
@@ -20,9 +20,6 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   const accentColor = styles.accentColor;
   const accentWithAlpha = (alpha: string) => `${accentColor}${alpha}`;
 
-  const accentBorderStyle: React.CSSProperties = {
-    borderColor: `${accentWithAlpha('55')}`,
-  };
   const accentPillStyle: React.CSSProperties = {
     backgroundColor: accentWithAlpha('24'),
     borderColor: `${accentWithAlpha('55')}`,
@@ -103,7 +100,7 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   };
 
   return (
-    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[auto,1fr,auto] lg:items-start lg:gap-5">
+    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[auto,1fr] lg:items-start lg:gap-5">
       {/* Product Image or Custom Request Icon */}
       <div className="flex flex-shrink-0 flex-col items-center gap-2.5 lg:items-start">
         <div className="relative h-20 w-20 overflow-hidden rounded-xl border border-white/10 bg-black/40">
@@ -148,35 +145,34 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
       </div>
 
       {/* Order Title and Price */}
-      <div className="flex min-w-0 flex-1 flex-col gap-2.5 lg:pr-4">
-        <div className="flex min-w-0 flex-col gap-1.5">
-          <h3 className="text-lg font-semibold text-white sm:text-[1.25rem]">
-            <SecureMessageDisplay content={order.title} allowBasicFormatting={false} as="span" />
-          </h3>
-          <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-gray-500 sm:text-xs">
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-medium text-gray-300">
-              Order ID:{' '}
-              <span className="font-mono text-[10px] text-gray-400 sm:text-[11px]">{order.id ? order.id.slice(0, 10) : '—'}</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-3 lg:pr-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <h3 className="text-lg font-semibold text-white sm:text-[1.25rem]">
+              <SecureMessageDisplay content={order.title} allowBasicFormatting={false} as="span" />
+            </h3>
+            <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-gray-500 sm:text-xs">
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-medium text-gray-300">
+                Order ID:{' '}
+                <span className="font-mono text-[10px] text-gray-400 sm:text-[11px]">{order.id ? order.id.slice(0, 10) : '—'}</span>
+              </span>
+              {isAuction && <Star className="h-4 w-4 text-purple-300" />}
+              {isCustom && <Settings className="h-4 w-4 text-sky-300" />}
+            </div>
+          </div>
+
+          <div className="flex flex-shrink-0 flex-col items-end text-right">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
+            <span className="text-xl font-bold" style={{ color: accentColor }}>
+              ${(order.markedUpPrice || order.price).toFixed(2)}
             </span>
-            {isAuction && <Star className="h-4 w-4 text-purple-300" />}
-            {isCustom && <Settings className="h-4 w-4 text-sky-300" />}
+            <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
           </div>
         </div>
 
         <div className="text-[13px] leading-relaxed text-gray-300 sm:text-sm">
           <SecureMessageDisplay content={order.description} allowBasicFormatting={false} />
         </div>
-      </div>
-
-      <div
-        className="flex flex-col rounded-xl border px-3 py-2.5 text-right lg:min-w-[190px] lg:self-start"
-        style={accentBorderStyle}
-      >
-        <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
-        <span className="text-xl font-bold" style={{ color: accentColor }}>
-          ${(order.markedUpPrice || order.price).toFixed(2)}
-        </span>
-        <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- adjust the buyer order header layout to share the title column and keep the image column intact
- align the total paid stack to the top-right of the header while preserving existing typography and supporting wrap on narrow screens

## Testing
- npm run lint *(fails: numerous pre-existing lint violations in various context and util files)*

------
https://chatgpt.com/codex/tasks/task_e_68e24b63ee2c83289e2150eabae3779c