### PR TITLE
Move order total to card header

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -33,6 +33,7 @@ export default function OrderCard({
   const sellerUser = users?.[order.seller ?? ''];
   const isSellerVerified = sellerUser?.verified || sellerUser?.verificationStatus === 'verified';
   const hasDeliveryAddress = !!order.deliveryAddress;
+  const totalPaid = (order.markedUpPrice ?? order.price ?? 0).toFixed(2);
 
   useEffect(() => {
     const loadProfilePic = async () => {
@@ -65,15 +66,23 @@ export default function OrderCard({
         }`}
       />
 
-      {/* Auction action badge */}
-      {order.wasAuction && needsAddress && (
-        <div className="absolute right-6 top-6 z-10">
+      <div className="absolute right-4 top-4 z-20 flex flex-col items-end gap-2 text-right">
+        <div className="flex flex-col items-end text-right">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
+          <span className="text-xl font-bold" style={{ color: styles.accentColor }}>
+            ${totalPaid}
+          </span>
+          <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
+        </div>
+
+        {/* Auction action badge */}
+        {order.wasAuction && needsAddress && (
           <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/50 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-200">
             <span className="text-base">🏆</span>
             <span>Confirm address</span>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       <div className="relative z-10 p-4 sm:p-5">
         <OrderHeader order={order} type={type} styles={styles} />

--- a/src/components/buyers/my-orders/OrderHeader.tsx
+++ b/src/components/buyers/my-orders/OrderHeader.tsx
@@ -100,7 +100,7 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
   };
 
   return (
-    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[auto,1fr,auto] lg:items-start lg:gap-5">
+    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[auto,1fr] lg:items-start lg:gap-5">
       {/* Product Image or Custom Request Icon */}
       <div className="flex flex-shrink-0 flex-col items-center gap-2.5 lg:items-start">
         <div className="relative h-20 w-20 overflow-hidden rounded-xl border border-white/10 bg-black/40">
@@ -165,13 +165,6 @@ export default function OrderHeader({ order, type, styles }: OrderHeaderProps) {
         </div>
       </div>
 
-      <div className="flex flex-col items-end text-right lg:min-w-[190px] lg:self-start">
-        <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
-        <span className="text-xl font-bold" style={{ color: accentColor }}>
-          ${(order.markedUpPrice || order.price).toFixed(2)}
-        </span>
-        <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- relocate the total paid display to the top-right corner of order cards
- group the confirm address badge beneath the total when required
- simplify the order header layout now that the price column is removed

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e24eace858832880391efa678755c6