### PR TITLE
Adjust order card meta layout

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -8,7 +8,8 @@ import { getUserProfilePic } from '@/utils/profileUtils';
 import OrderHeader from './OrderHeader';
 import OrderDetails from './OrderDetails';
 import ExpandedOrderContent from './ExpandedOrderContent';
-import { getOrderStyles } from '@/utils/orderUtils';
+import { formatOrderDate, getOrderStyles, getShippingStatusBadge } from '@/utils/orderUtils';
+import { Calendar } from 'lucide-react';
 
 interface OrderCardProps {
   order: Order;
@@ -66,13 +67,22 @@ export default function OrderCard({
         }`}
       />
 
-      <div className="absolute right-4 top-4 z-20 flex flex-col items-end gap-2 text-right">
+      <div className="absolute right-4 top-4 z-20 flex flex-col items-end gap-3 text-right">
         <div className="flex flex-col items-end text-right">
           <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
           <span className="text-xl font-bold" style={{ color: styles.accentColor }}>
             ${totalPaid}
           </span>
           <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2 text-[10px] text-gray-400 sm:text-xs">
+          <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
+            <Calendar className="h-3.5 w-3.5 text-white/60" />
+            <span>{formatOrderDate(order.date)}</span>
+          </div>
+
+          {getShippingStatusBadge(order.shippingStatus)}
         </div>
 
         {/* Auction action badge */}

--- a/src/components/buyers/my-orders/OrderDetails.tsx
+++ b/src/components/buyers/my-orders/OrderDetails.tsx
@@ -2,9 +2,8 @@
 'use client';
 
 import React from 'react';
-import { Calendar, Tag, MapPin, CheckCircle, ChevronDown, ChevronUp } from 'lucide-react';
+import { Tag, MapPin, CheckCircle, ChevronDown, ChevronUp } from 'lucide-react';
 import { Order } from '@/context/WalletContext';
-import { formatOrderDate, getShippingStatusBadge } from '@/utils/orderUtils';
 
 interface OrderDetailsProps {
   order: Order;
@@ -28,14 +27,8 @@ export default function OrderDetails({
 
   return (
     <>
-      {/* Streamlined Meta Info */}
-      <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-gray-400 sm:text-xs">
-        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
-          <Calendar className="h-4 w-4 text-white/60" />
-          <span>{formatOrderDate(order.date)}</span>
-        </div>
-
-        {order.tags && order.tags.length > 0 && (
+      {order.tags && order.tags.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-gray-400 sm:text-xs">
           <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
             <Tag className="h-4 w-4 text-white/60" />
             <span className="opacity-80">
@@ -43,12 +36,8 @@ export default function OrderDetails({
               {order.tags.length > 2 && ` +${order.tags.length - 2}`}
             </span>
           </div>
-        )}
-
-        <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
-          {getShippingStatusBadge(order.shippingStatus)}
         </div>
-      </div>
+      )}
 
       {/* Type-specific highlight - More subtle */}
       {isAuction && (


### PR DESCRIPTION
## Summary
- move the order date and shipping status badges beneath the total paid on buyer order cards
- simplify the order details meta row so tags remain the only badge in the main content area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2509d699883289bee0d204a6ae3f6