### PR TITLE
Adjust spacing for shipping status on buyer order card

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -76,7 +76,7 @@ export default function OrderCard({
           <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
         </div>
 
-        <div className="flex flex-col items-end gap-2 text-right text-[10px] text-gray-400 sm:text-xs">
+        <div className="mt-4 flex flex-col items-end gap-2 text-right text-[10px] text-gray-400 sm:mt-6 sm:text-xs">
           {getShippingStatusBadge(order.shippingStatus)}
 
           <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">


### PR DESCRIPTION
## Summary
- add vertical margin to the shipping status/date block so it sits lower on the order card

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25501e3c88328be0af541982052b2