### PR TITLE
Align shipping info with total on buyer order cards

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -67,22 +67,22 @@ export default function OrderCard({
         }`}
       />
 
-      <div className="absolute right-4 top-4 z-20 flex flex-col items-end gap-3 text-right sm:top-1/2 sm:-translate-y-1/2">
-        <div className="flex flex-col items-end text-right">
-          <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
-          <span className="text-xl font-bold" style={{ color: styles.accentColor }}>
-            ${totalPaid}
-          </span>
-          <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
-        </div>
-
-        <div className="mt-4 flex flex-col items-end gap-2 text-right text-[10px] text-gray-400 sm:mt-6 sm:text-xs">
+      <div className="absolute right-4 top-1/2 z-20 flex -translate-y-1/2 flex-col items-end gap-4 text-right sm:gap-5">
+        <div className="flex flex-col items-end gap-2 text-right text-[10px] text-gray-400 sm:text-xs">
           {getShippingStatusBadge(order.shippingStatus)}
 
           <div className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2 py-1">
             <Calendar className="h-3.5 w-3.5 text-white/60" />
             <span>{formatOrderDate(order.date)}</span>
           </div>
+        </div>
+
+        <div className="flex flex-col items-end text-right">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">Total paid</span>
+          <span className="text-xl font-bold" style={{ color: styles.accentColor }}>
+            ${totalPaid}
+          </span>
+          <span className="text-[10px] text-gray-500">Includes seller payout & platform fee</span>
         </div>
 
         {/* Auction action badge */}


### PR DESCRIPTION
## Summary
- reposition the order card metadata stack so shipping status and date sit above the total paid
- center the metadata column vertically within the card for a tighter grouped layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e27db504fc8328923ea7454d4fca07