### PR TITLE
Adjust buyer message button text color for readability

### DIFF
--- a/src/app/buyers/[username]/page.tsx
+++ b/src/app/buyers/[username]/page.tsx
@@ -443,9 +443,9 @@ export default function BuyerProfilePage() {
                       <div className="flex flex-wrap gap-3">
                         <Link
                           href={`/buyers/messages`}
-                          className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#ffb347] via-[#ff950e] to-[#ff7b1f] px-5 py-2.5 text-sm font-semibold text-black shadow-lg shadow-[#ff950e]/15 transition hover:shadow-[#ff950e]/30 focus:outline-none focus:ring-2 focus:ring-[#ff950e]/60 focus:ring-offset-2 focus:ring-offset-black"
+                          className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#ffb347] via-[#ff950e] to-[#ff7b1f] px-5 py-2.5 text-sm font-semibold text-neutral-950 shadow-lg shadow-[#ff950e]/15 transition hover:shadow-[#ff950e]/30 focus:outline-none focus:ring-2 focus:ring-[#ff950e]/60 focus:ring-offset-2 focus:ring-offset-black"
                         >
-                          <MessageCircle size={18} />
+                          <MessageCircle size={18} className="text-neutral-950" />
                           Message
                         </Link>
 


### PR DESCRIPTION
## Summary
- ensure the buyer profile message button uses a darker text color for improved contrast
- match the message icon color to the button label for consistent styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e27e7db1c083288222e1b36c61aa9d