### PR TITLE
Render buyer message button label in true black

### DIFF
--- a/src/app/buyers/[username]/page.tsx
+++ b/src/app/buyers/[username]/page.tsx
@@ -446,7 +446,7 @@ export default function BuyerProfilePage() {
                           className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#ffb347] via-[#ff950e] to-[#ff7b1f] px-5 py-2.5 text-sm font-semibold text-neutral-950 shadow-lg shadow-[#ff950e]/15 transition hover:shadow-[#ff950e]/30 focus:outline-none focus:ring-2 focus:ring-[#ff950e]/60 focus:ring-offset-2 focus:ring-offset-black"
                         >
                           <MessageCircle size={18} className="text-neutral-950" />
-                          Message
+                          <span className="text-black">Message</span>
                         </Link>
 
                         {isOwner && (


### PR DESCRIPTION
## Summary
- switch the buyer profile message button label to use Tailwind's `text-black` class so it renders as black instead of the neutral palette

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e281c18cb88328b3ed685dbcab73cb