### PR TITLE
Remove buyer welcome message from membership card

### DIFF
--- a/src/app/buyers/[username]/page.tsx
+++ b/src/app/buyers/[username]/page.tsx
@@ -474,9 +474,6 @@ export default function BuyerProfilePage() {
                           <p className="mt-2 text-lg font-semibold text-white">
                             {formatDate(profileData?.user?.joinedAt || profileData?.user?.createdAt)}
                           </p>
-                          <p className="mt-1 text-sm text-neutral-400">
-                            Welcome aboard! Thanks for being part of the community.
-                          </p>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove the extra welcome text from the buyer member-since card on the profile page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2fcc7cf08832887899c4dc599f61c