### PR TITLE
Add remember me option to login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -44,6 +44,7 @@ export default function LoginPage() {
   const [step, setStep] = useState(1);
   const [mounted, setMounted] = useState(false);
   const [showAdminMode, setShowAdminMode] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
 
   // Rate limiting
   const [isRateLimited, setIsRateLimited] = useState(false);
@@ -247,7 +248,7 @@ export default function LoginPage() {
       clearError?.();
       
       try {
-        const success = await login(username.trim(), password, role);
+        const success = await login(username.trim(), password, role, rememberMe);
         
         if (isDev) console.log('[Login] Login result:', success);
         
@@ -268,7 +269,7 @@ export default function LoginPage() {
         setIsLoading(false);
       }
     },
-    [username, password, role, login, isRateLimited, authError, clearError]
+    [username, password, role, rememberMe, login, isRateLimited, authError, clearError]
   );
 
   const handleKeyPress = useCallback(
@@ -384,6 +385,8 @@ export default function LoginPage() {
                   role={role}
                   roleOptions={roleOptions}
                   onRoleSelect={(selectedRole) => setRole(selectedRole as 'buyer' | 'seller' | 'admin')}
+                  rememberMe={rememberMe}
+                  onRememberMeChange={setRememberMe}
                 />
               )}
             </div>

--- a/src/components/login/PasswordStep.tsx
+++ b/src/components/login/PasswordStep.tsx
@@ -23,6 +23,8 @@ interface PasswordStepProps {
     icon: any;
   }>;
   onRoleSelect: (role: string) => void;
+  rememberMe: boolean;
+  onRememberMeChange: (remember: boolean) => void;
 }
 
 export default function PasswordStep({
@@ -38,7 +40,9 @@ export default function PasswordStep({
   rateLimitWaitTime = 0,
   role,
   roleOptions,
-  onRoleSelect
+  onRoleSelect,
+  rememberMe,
+  onRememberMeChange
 }: PasswordStepProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
@@ -226,6 +230,20 @@ export default function PasswordStep({
               );
             })}
           </div>
+        </div>
+
+        <div className="mb-6 flex items-center justify-between text-sm text-gray-300">
+          <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={rememberMe}
+              onChange={(event) => onRememberMeChange(event.target.checked)}
+              disabled={isLoading || isRateLimited}
+              className="h-4 w-4 rounded border-gray-600 bg-black text-[#ff950e] focus:ring-[#ff950e]"
+            />
+            <span>Keep me signed in</span>
+          </label>
+          <span className="text-xs text-gray-500">Use on trusted devices only</span>
         </div>
 
         <button


### PR DESCRIPTION
## Summary
- add a "keep me signed in" option to the password step of the login flow
- persist authentication tokens to localStorage when the option is selected so sessions survive browser restarts
- ensure global token helpers and auth storage logic understand the new persistence option

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ce76e2f88328be80374cbbf9e301