### PR TITLE
Fix header search dropdown closing on interaction

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1011,7 +1011,6 @@ export default function Header(): React.ReactElement | null {
                   {isSearchingUsers && hasMinimumSearchTerm && (
                     <Loader2 className="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-[#ff950e]" />
                   )}
-                </div>
                   {renderSearchDropdown('mobile')}
                 </div>
               </div>
@@ -1177,8 +1176,7 @@ export default function Header(): React.ReactElement | null {
               {isSearchingUsers && hasMinimumSearchTerm && (
                 <Loader2 className="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-[#ff950e]" />
               )}
-            </div>
-                {renderSearchDropdown('desktop')}
+              {renderSearchDropdown('desktop')}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- keep the desktop search dropdown inside the tracked container so outside-click detection doesn’t instantly close it
- apply the same containment fix for the mobile search dropdown to maintain touch usability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fdcfbb748328860082f76126a1a6