### PR TITLE
Fix mobile search keyboard dismissal in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -124,6 +124,7 @@ export default function Header(): React.ReactElement | null {
   const [isSearchingUsers, setIsSearchingUsers] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [showSearchDropdown, setShowSearchDropdown] = useState(false);
+  const [isMobileSearchFocused, setIsMobileSearchFocused] = useState(false);
 
   const [clearingNotifications, setClearingNotifications] = useState(false);
   const [deletingNotifications, setDeletingNotifications] = useState(false);
@@ -257,6 +258,7 @@ export default function Header(): React.ReactElement | null {
   useEffect(() => {
     if (!mobileMenuOpen) {
       setShowSearchDropdown(false);
+      setIsMobileSearchFocused(false);
     }
   }, [mobileMenuOpen]);
 
@@ -295,6 +297,15 @@ export default function Header(): React.ReactElement | null {
       setShowSearchDropdown(true);
     }
   }, [searchQuery, canUseSearch]);
+
+  const handleMobileSearchFocus = useCallback(() => {
+    setIsMobileSearchFocused(true);
+    handleSearchFocus();
+  }, [handleSearchFocus]);
+
+  const handleMobileSearchBlur = useCallback(() => {
+    setIsMobileSearchFocused(false);
+  }, []);
 
   const resetSearchState = useCallback(() => {
     setSearchQuery('');
@@ -785,7 +796,7 @@ export default function Header(): React.ReactElement | null {
 
   // Prevent body scroll when mobile menu is open
   useEffect(() => {
-    if (mobileMenuOpen) {
+    if (mobileMenuOpen && !isMobileSearchFocused) {
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = '';
@@ -794,7 +805,7 @@ export default function Header(): React.ReactElement | null {
     return () => {
       document.body.style.overflow = '';
     };
-  }, [mobileMenuOpen]);
+  }, [mobileMenuOpen, isMobileSearchFocused]);
 
   const renderMobileLink = (href: string, icon: React.ReactNode, label: string, badge?: number) => (
     <Link
@@ -926,7 +937,10 @@ export default function Header(): React.ReactElement | null {
         className={`fixed top-0 right-0 w-80 max-w-[85vw] h-full bg-gradient-to-b from-[#1a1a1a] to-[#111] border-l border-[#ff950e]/30 z-50 lg:hidden transform transition-transform duration-300 ease-in-out ${
           mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
-        style={{ touchAction: 'pan-y' }}
+        style={{
+          touchAction: 'pan-y',
+          transform: mobileMenuOpen && isMobileSearchFocused ? 'none' : undefined,
+        }}
       >
         {showMobileNotifications && role === 'seller' ? (
           <MobileNotificationsPanel />
@@ -975,7 +989,8 @@ export default function Header(): React.ReactElement | null {
                       inputMode="text"
                       value={searchQuery}
                       onChange={(event) => handleSearchInputChange(event.target.value)}
-                      onFocus={handleSearchFocus}
+                      onFocus={handleMobileSearchFocus}
+                      onBlur={handleMobileSearchBlur}
                       onKeyDown={handleSearchKeyDown}
                       placeholder="Search buyers and sellers..."
                       className="w-full bg-[#121212] border border-[#2a2a2a] focus:border-[#ff950e] focus:ring-2 focus:ring-[#ff950e]/40 text-sm text-white placeholder-gray-500 rounded-xl py-2.5 pl-11 pr-14 transition-all duration-200"


### PR DESCRIPTION
## Summary
- track when the mobile search input in the mobile menu is focused
- relax the body scroll lock and panel transform while typing so the keyboard stays open
- reset the focus helper state whenever the mobile menu closes

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e65badf17c83288197095a9bf08ff7