### PR TITLE
Fix buyer country flag display on profile pages

### DIFF
--- a/src/app/buyers/[username]/page.tsx
+++ b/src/app/buyers/[username]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { CalendarDays, MapPin, MessageCircle } from 'lucide-react';
 import { getGlobalAuthToken } from '@/context/AuthContext';
 import { API_BASE_URL } from '@/services/api.config';
+import { flagFromCountryName } from '@/constants/countries';
 
 /* ==== Types ==== */
 type NormalizedBuyerProfile = {
@@ -164,34 +165,6 @@ function resolveAvatarUrl(raw?: string | null): string | null {
     }
   }
   return null;
-}
-
-/** Minimal map for flag emoji */
-const COUNTRY_TO_CODE: Record<string, string> = {
-  Australia: 'AU',
-  Canada: 'CA',
-  'United States': 'US',
-  'United Kingdom': 'GB',
-  Germany: 'DE',
-  France: 'FR',
-  Japan: 'JP',
-  India: 'IN',
-  'New Zealand': 'NZ',
-};
-
-function flagFromIso2(code?: string | null): string {
-  if (!code || code.length !== 2) return '🌐';
-  const base = 0x1f1e6;
-  const A = 'A'.charCodeAt(0);
-  const chars = code.toUpperCase().split('');
-  const cps = chars.map((c) => base + (c.charCodeAt(0) - A));
-  return String.fromCodePoint(...cps);
-}
-
-function flagFromCountryName(name?: string | null): string {
-  if (!name) return '🌐';
-  const code = COUNTRY_TO_CODE[name] || null;
-  return flagFromIso2(code);
 }
 
 function isRegionalIndicator(cp?: number | null): boolean {

--- a/src/app/buyers/profile/page.tsx
+++ b/src/app/buyers/profile/page.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import BanCheck from '@/components/BanCheck';
 import { getGlobalAuthToken } from '@/context/AuthContext';
 import { buildApiUrl, API_BASE_URL } from '@/services/api.config';
+import { COUNTRY_TO_CODE, flagFromCountryName } from '@/constants/countries';
 import { AlertTriangle, Loader2, MapPin, ShieldCheck, Upload } from 'lucide-react';
 
 type MeProfile = {
@@ -85,67 +86,7 @@ function getToken(): string {
 }
 
 /* Country helpers */
-const COUNTRY_TO_CODE: Record<string, string> = {
-  Australia: 'AU',
-  Canada: 'CA',
-  'United States': 'US',
-  'United Kingdom': 'GB',
-  Ireland: 'IE',
-  Germany: 'DE',
-  France: 'FR',
-  Spain: 'ES',
-  Italy: 'IT',
-  Netherlands: 'NL',
-  Belgium: 'BE',
-  Switzerland: 'CH',
-  Austria: 'AT',
-  Sweden: 'SE',
-  Norway: 'NO',
-  Denmark: 'DK',
-  Finland: 'FI',
-  Poland: 'PL',
-  Portugal: 'PT',
-  Greece: 'GR',
-  Brazil: 'BR',
-  Mexico: 'MX',
-  Argentina: 'AR',
-  Chile: 'CL',
-  Colombia: 'CO',
-  Peru: 'PE',
-  Japan: 'JP',
-  'South Korea': 'KR',
-  China: 'CN',
-  India: 'IN',
-  Indonesia: 'ID',
-  Philippines: 'PH',
-  Thailand: 'TH',
-  Vietnam: 'VN',
-  Singapore: 'SG',
-  Malaysia: 'MY',
-  'New Zealand': 'NZ',
-  'South Africa': 'ZA',
-  Nigeria: 'NG',
-  Egypt: 'EG',
-  Turkey: 'TR',
-  Israel: 'IL',
-  'United Arab Emirates': 'AE',
-  'Saudi Arabia': 'SA',
-  Ukraine: 'UA',
-  Russia: 'RU',
-};
 const COUNTRY_OPTIONS = Object.keys(COUNTRY_TO_CODE).sort((a, b) => a.localeCompare(b));
-function flagFromIso2(code?: string | null): string {
-  if (!code || code.length !== 2) return '🌐';
-  const base = 0x1f1e6;
-  const A = 'A'.charCodeAt(0);
-  const cps = code.toUpperCase().split('').map((c) => base + (c.charCodeAt(0) - A));
-  return String.fromCodePoint(...cps);
-}
-function flagFromCountryName(name?: string | null): string {
-  if (!name) return '🌐';
-  const code = COUNTRY_TO_CODE[name] || null;
-  return flagFromIso2(code);
-}
 
 export default function BuyerSelfProfilePage() {
   const [loading, setLoading] = useState(true);

--- a/src/constants/countries.ts
+++ b/src/constants/countries.ts
@@ -1,0 +1,80 @@
+// src/constants/countries.ts
+// Shared utilities for mapping country names to ISO codes and flag emoji.
+// Keep this list in sync across any feature that allows buyers to pick a country.
+
+export const COUNTRY_TO_CODE: Record<string, string> = {
+  Australia: 'AU',
+  Canada: 'CA',
+  'United States': 'US',
+  'United Kingdom': 'GB',
+  Germany: 'DE',
+  France: 'FR',
+  Italy: 'IT',
+  Spain: 'ES',
+  Ireland: 'IE',
+  Netherlands: 'NL',
+  Belgium: 'BE',
+  Switzerland: 'CH',
+  Austria: 'AT',
+  Sweden: 'SE',
+  Norway: 'NO',
+  Denmark: 'DK',
+  Finland: 'FI',
+  Poland: 'PL',
+  Portugal: 'PT',
+  Greece: 'GR',
+  Brazil: 'BR',
+  Mexico: 'MX',
+  Argentina: 'AR',
+  Chile: 'CL',
+  Colombia: 'CO',
+  Peru: 'PE',
+  Japan: 'JP',
+  'South Korea': 'KR',
+  China: 'CN',
+  India: 'IN',
+  Indonesia: 'ID',
+  Philippines: 'PH',
+  Thailand: 'TH',
+  Vietnam: 'VN',
+  Singapore: 'SG',
+  Malaysia: 'MY',
+  'New Zealand': 'NZ',
+  'South Africa': 'ZA',
+  Nigeria: 'NG',
+  Egypt: 'EG',
+  Turkey: 'TR',
+  Israel: 'IL',
+  'United Arab Emirates': 'AE',
+  'Saudi Arabia': 'SA',
+  Ukraine: 'UA',
+  Russia: 'RU',
+};
+
+export function flagFromIso2(code?: string | null): string {
+  if (!code || code.length !== 2) return '🌐';
+  const base = 0x1f1e6;
+  const A = 'A'.charCodeAt(0);
+  const characters = code.toUpperCase().split('');
+  const cps = characters.map((c) => base + (c.charCodeAt(0) - A));
+  return String.fromCodePoint(...cps);
+}
+
+export function flagFromCountryName(name?: string | null): string {
+  if (!name) return '🌐';
+  const normalized = name.trim();
+  if (!normalized) return '🌐';
+
+  const direct = COUNTRY_TO_CODE[normalized];
+  if (direct) {
+    return flagFromIso2(direct);
+  }
+
+  // Allow users to type ISO codes directly.
+  const isoCandidate = normalized.toUpperCase();
+  if (/^[A-Z]{2}$/.test(isoCandidate)) {
+    return flagFromIso2(isoCandidate);
+  }
+
+  return '🌐';
+}


### PR DESCRIPTION
## Summary
- extract a shared country-to-ISO lookup and flag helper so both buyer profile pages use the same data
- update the public buyer profile page to rely on the shared helper and show the correct emoji for more countries
- refactor the buyer profile settings page to consume the shared helper instead of maintaining a duplicate list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6ddfdc71c8328a233e738dcdeb995