### PR TITLE
Fix header hover layout shift

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -853,9 +853,11 @@ export default function Header(): React.ReactElement | null {
           <nav className={`${isMobile ? 'hidden' : 'flex'} items-center gap-x-2`}>
           <Link
             href="/browse"
-            className="group flex items-center gap-1.5 bg-gradient-to-r from-[#1a1a1a] to-[#222] hover:from-[#ff950e]/20 hover:to-[#ff6b00]/20 text-[#ff950e] px-3 py-1.5 rounded-lg transition-all duration-300 border border-[#333] hover:border-[#ff950e]/50 shadow-lg hover:shadow-[#ff950e]/20 text-xs"
+            className="group inline-flex items-center gap-1.5 bg-gradient-to-r from-[#1a1a1a] to-[#222] hover:from-[#ff950e]/20 hover:to-[#ff6b00]/20 text-[#ff950e] px-3 py-1.5 rounded-lg transition-colors duration-300 border border-[#333] hover:border-[#ff950e]/50 shadow-lg hover:shadow-[#ff950e]/20 text-xs"
           >
-            <ShoppingBag className="w-3.5 h-3.5 group-hover:scale-110 transition-transform" />
+            <span className="flex h-5 w-5 items-center justify-center">
+              <ShoppingBag className="h-3.5 w-3.5 transition-transform duration-300 group-hover:scale-110" />
+            </span>
             <span className="font-medium">Browse</span>
           </Link>
 
@@ -1153,7 +1155,7 @@ export default function Header(): React.ReactElement | null {
 
               <Link
                 href="/wallet/buyer"
-                className="group flex items-center gap-1.5 bg-gradient-to-r from-purple-600/20 to-purple-700/20 hover:from-purple-600/30 hover:to-purple-700/30 text-white px-3 py-1.5 rounded-lg transition-all duration-300 border border-purple-500/30 hover:border-purple-500/50 shadow-lg text-xs"
+                className="group inline-flex items-center gap-1.5 bg-gradient-to-r from-purple-600/20 to-purple-700/20 hover:from-purple-600/30 hover:to-purple-700/30 text-white px-3 py-1.5 rounded-lg transition-colors duration-300 border border-purple-500/30 hover:border-purple-500/50 shadow-lg text-xs"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -1161,7 +1163,9 @@ export default function Header(): React.ReactElement | null {
                 }}
                 style={{ touchAction: 'manipulation' }}
               >
-                <WalletIcon className="w-3.5 h-3.5 text-purple-400" />
+                <span className="flex h-5 w-5 items-center justify-center">
+                  <WalletIcon className="h-3.5 w-3.5 text-purple-400" />
+                </span>
                 <span className="font-bold text-purple-400">${Math.max(buyerBalance, 0).toFixed(2)}</span>
               </Link>
 


### PR DESCRIPTION
## Summary
- keep the header browse button from shifting by constraining the icon width and limiting the transition scope
- apply the same fixed icon container to the buyer wallet button to prevent hover jitter when the balance is shown

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e6e0b68fdc83288458e7a25cdb5728