### PR TITLE
Align buyer header button icon sizing

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -855,9 +855,7 @@ export default function Header(): React.ReactElement | null {
             href="/browse"
             className="group flex items-center gap-1.5 whitespace-nowrap bg-gradient-to-r from-[#1a1a1a] to-[#222] hover:from-[#ff950e]/20 hover:to-[#ff6b00]/20 text-[#ff950e] px-3 py-1.5 rounded-lg transition-colors duration-300 border border-[#333] hover:border-[#ff950e]/50 shadow-lg hover:shadow-[#ff950e]/20 text-xs"
           >
-            <span className="flex h-5 w-5 items-center justify-center">
-              <ShoppingBag className="h-3.5 w-3.5 transition-transform duration-300 group-hover:scale-110" />
-            </span>
+            <ShoppingBag className="w-3.5 h-3.5 transition-transform duration-300 group-hover:scale-110" />
             <span className="font-medium">Browse</span>
           </Link>
 
@@ -1163,9 +1161,7 @@ export default function Header(): React.ReactElement | null {
                 }}
                 style={{ touchAction: 'manipulation' }}
               >
-                <span className="flex h-5 w-5 items-center justify-center">
-                  <WalletIcon className="h-3.5 w-3.5 text-purple-400" />
-                </span>
+                <WalletIcon className="w-3.5 h-3.5 text-purple-400" />
                 <span className="font-bold text-purple-400">${Math.max(buyerBalance, 0).toFixed(2)}</span>
               </Link>
 


### PR DESCRIPTION
## Summary
- adjust the browse navigation icon markup so it matches the sizing of adjacent buttons
- update the buyer wallet link icon sizing to align with other header buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e748b2b2ac8328b399b0967c3e1e65