### PR TITLE
style: highlight buyer wallet button in purple

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1153,7 +1153,7 @@ export default function Header(): React.ReactElement | null {
 
               <Link
                 href="/wallet/buyer"
-                className="group flex items-center gap-1.5 whitespace-nowrap bg-[#1a1a1a] hover:bg-[#222] text-[#ff950e] px-3 py-1.5 rounded-lg transition-all duration-300 border border-[#333] hover:border-[#ff950e]/50 text-xs"
+                className="group flex items-center gap-1.5 whitespace-nowrap bg-gradient-to-r from-purple-900/30 to-purple-700/30 hover:from-purple-800/40 hover:to-purple-600/40 text-white px-3 py-1.5 rounded-lg transition-all duration-300 border border-purple-500/40 hover:border-purple-400/60 shadow-lg text-xs"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -1161,8 +1161,8 @@ export default function Header(): React.ReactElement | null {
                 }}
                 style={{ touchAction: 'manipulation' }}
               >
-                <WalletIcon className="w-3.5 h-3.5 transition-colors duration-300 group-hover:text-[#ff950e]" />
-                <span className="font-bold">${Math.max(buyerBalance, 0).toFixed(2)}</span>
+                <WalletIcon className="w-3.5 h-3.5 text-purple-200 transition-colors duration-300 group-hover:text-purple-100" />
+                <span className="font-bold text-purple-100">${Math.max(buyerBalance, 0).toFixed(2)}</span>
               </Link>
 
               <Link href="/buyers/messages" className="relative group">


### PR DESCRIPTION
## Summary
- update the buyer wallet link in the header to use a purple gradient background
- switch the wallet icon and balance text to matching purple accents for buyers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e74f0667848328b8ddf608580d9701