### PR TITLE
feat: redesign buyer wallet page to match updated buyer theme

### DIFF
--- a/src/app/wallet/buyer/page.tsx
+++ b/src/app/wallet/buyer/page.tsx
@@ -10,6 +10,7 @@ import BalanceCard from '@/components/wallet/buyer/BalanceCard';
 import AddFundsSection from '@/components/wallet/buyer/AddFundsSection';
 import RecentPurchases from '@/components/wallet/buyer/RecentPurchases';
 import EmptyState from '@/components/wallet/buyer/EmptyState';
+import BackgroundPattern from '@/components/wallet/buyer/BackgroundPattern';
 import { useBuyerWallet } from '@/hooks/useBuyerWallet';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
@@ -40,46 +41,39 @@ function BuyerWalletContent() {
   const recentArray = Array.isArray(recentPurchases) ? recentPurchases : [];
 
   return (
-    <main className="min-h-screen bg-black text-white p-4 md:p-10">
-      {/* Background Pattern - Updated */}
-      <div className="fixed inset-0 opacity-5 pointer-events-none">
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: `radial-gradient(circle at 20% 80%, rgba(255, 149, 14, 0.3) 0%, transparent 50%),
-                          radial-gradient(circle at 80% 20%, rgba(255, 149, 14, 0.2) 0%, transparent 50%),
-                          radial-gradient(circle at 40% 40%, rgba(255, 149, 14, 0.15) 0%, transparent 50%)`,
-          }}
-        />
-      </div>
+    <main className="relative min-h-screen overflow-hidden bg-[#050505] text-white">
+      <BackgroundPattern />
 
-      <div className="max-w-7xl mx-auto relative z-10">
-        {/* Header */}
-        <WalletHeader />
+      <div className="relative z-10 px-4 py-12 sm:px-6 lg:px-10">
+        <div className="mx-auto flex max-w-6xl flex-col gap-10">
+          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 sm:p-8 lg:p-12 shadow-[0_40px_120px_-60px_rgba(255,149,14,0.45)]">
+            <div className="pointer-events-none absolute inset-x-6 inset-y-4 rounded-[2.25rem] border border-white/5 bg-gradient-to-r from-white/[0.04] via-transparent to-white/[0.04] opacity-40 blur-3xl" />
+            <div className="relative">
+              <WalletHeader />
+            </div>
+          </section>
 
-        {/* Balance Card (Total Spent removed for this page) */}
-        <div className="grid grid-cols-1 md:grid-cols-1 gap-6 mb-8">
-          <BalanceCard balance={balance} />
+          <section className="grid gap-6 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1fr)]">
+            <BalanceCard balance={balance} />
+
+            <AddFundsSection
+              amountToAdd={amountToAdd}
+              message={message}
+              messageType={messageType}
+              isLoading={isLoading}
+              onAmountChange={handleAmountChange}
+              onKeyPress={handleKeyPress}
+              onAddFunds={handleAddFunds}
+              onQuickAmountSelect={handleQuickAmountSelect}
+            />
+          </section>
+
+          {purchasesArray.length > 0 ? (
+            <RecentPurchases purchases={recentArray} />
+          ) : (
+            <EmptyState />
+          )}
         </div>
-
-        {/* Add Funds Section */}
-        <AddFundsSection
-          amountToAdd={amountToAdd}
-          message={message}
-          messageType={messageType}
-          isLoading={isLoading}
-          onAmountChange={handleAmountChange}
-          onKeyPress={handleKeyPress}
-          onAddFunds={handleAddFunds}
-          onQuickAmountSelect={handleQuickAmountSelect}
-        />
-
-        {/* Recent Purchases or Empty State */}
-        {purchasesArray.length > 0 ? (
-          <RecentPurchases purchases={recentArray} />
-        ) : (
-          <EmptyState />
-        )}
       </div>
     </main>
   );

--- a/src/components/wallet/buyer/AddFundsSection.tsx
+++ b/src/components/wallet/buyer/AddFundsSection.tsx
@@ -64,40 +64,40 @@ export default function AddFundsSection({
 
   const messageClasses =
     messageType === 'success'
-      ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/30'
+      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
       : messageType === 'error'
-      ? 'bg-red-500/10 text-red-400 border border-red-500/30'
-      : 'bg-gray-700/20 text-gray-300 border border-gray-600/30';
+      ? 'border-red-500/40 bg-red-500/10 text-red-200'
+      : 'border-white/10 bg-black/40 text-gray-300';
 
   return (
-    <section className="bg-[#141414] rounded-2xl border border-gray-800/80 hover:border-gray-700 transition-colors relative overflow-hidden mb-8">
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#ff950e]/5 to-transparent" />
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 shadow-[0_30px_90px_-70px_rgba(66,153,255,0.6)] transition-colors hover:border-white/20 sm:p-8">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.18),transparent_55%)]" />
 
-      <div className="relative z-10 px-5 py-5 md:px-6 md:py-6">
+      <div className="relative z-10 flex flex-col gap-6">
         {/* Header row */}
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-          <h2 className="text-xl font-semibold flex items-center text-white">
-            <div className="bg-gradient-to-r from-[#ff950e] to-orange-600 p-2 rounded-lg mr-2 shadow-md shadow-orange-500/15">
-              <PlusCircle className="w-5 h-5 text-white" />
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15">
+              <PlusCircle className="h-5 w-5 text-white" />
             </div>
-            Add Funds
-          </h2>
+            <div>
+              <h2 className="text-xl font-semibold text-white sm:text-2xl">Add Funds</h2>
+              <p className="text-sm text-gray-400">Choose an amount, confirm, and spend immediately.</p>
+            </div>
+          </div>
 
-          <span className="inline-flex items-center gap-1.5 self-start md:self-center rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs text-blue-300">
-            <Zap className="w-3.5 h-3.5" />
-            Instant Processing
+          <span className="inline-flex items-center gap-1.5 self-start rounded-full border border-blue-500/30 bg-blue-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-blue-200 md:self-center">
+            <Zap className="h-3.5 w-3.5" />
+            Instant processing
           </span>
         </div>
-
-        {/* Divider */}
-        <div className="mt-4 h-px w-full bg-gradient-to-r from-transparent via-gray-800 to-transparent" />
 
         {/* Form */}
         <SecureForm
           onSubmit={handleSubmit}
           rateLimitKey="deposit"
           rateLimitConfig={RATE_LIMITS.DEPOSIT}
-          className="mt-6 space-y-6"
+          className="space-y-6"
         >
           <SecureInput
             id="amount"
@@ -118,13 +118,13 @@ export default function AddFundsSection({
           />
 
           {/* Quick amount buttons */}
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {[25, 50, 100, 200].map((quickAmount) => (
               <button
                 key={quickAmount}
                 type="button"
                 onClick={() => onQuickAmountSelect(quickAmount.toString())}
-                className="py-2.5 px-3 rounded-lg bg-black/40 hover:bg-black/60 border border-gray-700 hover:border-[#ff950e]/50 text-gray-300 hover:text-white transition-all duration-200 text-sm font-medium disabled:opacity-50"
+                className="rounded-xl border border-white/10 bg-black/40 py-2.5 text-sm font-semibold text-gray-200 transition-all duration-200 hover:border-[#ff950e]/40 hover:bg-black/60 hover:text-white disabled:opacity-50"
                 disabled={isLoading}
               >
                 ${quickAmount}
@@ -171,7 +171,7 @@ export default function AddFundsSection({
 
         {/* Message */}
         {message && (
-          <div className={`mt-6 p-4 rounded-lg flex items-start text-sm ${messageClasses}`}>
+          <div className={`mt-2 flex items-start gap-2 rounded-2xl border p-4 text-sm ${messageClasses}`}>
             {messageType === 'success' ? (
               <CheckCircle className="w-4 h-4 mr-2 flex-shrink-0 mt-0.5" />
             ) : messageType === 'error' ? (

--- a/src/components/wallet/buyer/BalanceCard.tsx
+++ b/src/components/wallet/buyer/BalanceCard.tsx
@@ -1,7 +1,7 @@
 // src/components/wallet/buyer/BalanceCard.tsx
 'use client';
 
-import { DollarSign, AlertCircle, ShieldCheck, Zap } from 'lucide-react';
+import { DollarSign, AlertCircle, ShieldCheck, Zap, ArrowUpRight, Clock } from 'lucide-react';
 
 interface BalanceCardProps {
   balance: number;
@@ -13,59 +13,73 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
   return (
     <section
       aria-label="Current balance"
-      className="bg-[#141414] rounded-2xl border border-gray-800/80 hover:border-gray-700 transition-colors relative overflow-hidden"
+      className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_30px_90px_-60px_rgba(255,149,14,0.6)] transition-colors hover:border-white/20 sm:p-8"
     >
-      {/* subtle background wash */}
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#ff950e]/5 to-transparent" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,149,14,0.18),transparent_55%)]" />
+      <div className="pointer-events-none absolute -left-20 top-1/2 h-60 w-60 -translate-y-1/2 rounded-full bg-[#ff950e]/20 blur-3xl" />
 
-      <div className="relative z-10 px-5 py-5 md:px-6 md:py-6">
-        {/* Top row: title + icon */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-baseline gap-2">
-            <h2 className="text-sm font-medium text-gray-300">Current Balance</h2>
-            <span className="text-xs text-gray-500">Available for purchases</span>
+      <div className="relative z-10 flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-gray-300/70">
+              Balance
+            </span>
+            <div className="flex items-end gap-3">
+              <p className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                ${safeBalance.toFixed(2)}
+              </p>
+              <span className="pb-1 text-xs font-medium uppercase tracking-wider text-gray-400">USD</span>
+            </div>
           </div>
 
-          <div className="bg-gradient-to-r from-[#ff950e] to-orange-600 p-2.5 rounded-xl shadow-lg shadow-orange-500/15">
-            <DollarSign className="w-5 h-5 text-white" />
+          <div className="inline-flex items-center gap-3 rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15 px-4 py-2 text-sm font-semibold text-white">
+            <DollarSign className="h-4 w-4" />
+            Available to spend
           </div>
         </div>
 
-        {/* Divider */}
-        <div className="mt-4 h-px w-full bg-gradient-to-r from-transparent via-gray-800 to-transparent" />
-
-        {/* Content grid */}
-        <div className="mt-4 grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6 items-center">
-          {/* Amount */}
-          <div className="flex items-end gap-3">
-            <span className="text-4xl md:text-5xl font-extrabold tracking-tight text-white tabular-nums">
-              ${safeBalance.toFixed(2)}
-            </span>
-            <span className="pb-2 text-xs md:text-sm text-gray-400">USD</span>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/15">
+              <ShieldCheck className="h-5 w-5 text-emerald-300" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">Escrow</p>
+              <p className="text-sm font-semibold text-white">Funds protected</p>
+            </div>
           </div>
-
-          {/* Status / badges */}
-          <div className="flex flex-wrap items-center gap-2 text-xs">
-            <span className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-emerald-300">
-              <Zap className="w-3.5 h-3.5" />
-              Instant deposits
-            </span>
-            <span className="inline-flex items-center gap-1.5 rounded-lg border border-gray-700 px-2.5 py-1 text-gray-400">
-              <ShieldCheck className="w-3.5 h-3.5 text-gray-400" />
-              No waiting period
-            </span>
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#ff950e]/20">
+              <Zap className="h-5 w-5 text-[#ffb347]" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">Processing</p>
+              <p className="text-sm font-semibold text-white">Instant reloads</p>
+            </div>
           </div>
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple-500/20">
+              <Clock className="h-5 w-5 text-purple-200" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-widest text-gray-500">Activity</p>
+              <p className="text-sm font-semibold text-white">Real-time sync</p>
+            </div>
+          </div>
+        </div>
 
-          {/* Meta / fine print */}
-          <p className="text-[11px] md:text-xs text-gray-500 leading-relaxed lg:text-right">
-            Each transaction includes a <span className="text-gray-300 font-medium">10% platform fee</span> for secure
-            processing.
+        <div className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-black/40 p-4 text-xs text-gray-400 sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+          <p>
+            Each transaction includes a <span className="font-semibold text-gray-100">10% platform fee</span> for secure processing and buyer protection.
           </p>
+          <span className="inline-flex items-center gap-2 text-[#ffb347]">
+            <ArrowUpRight className="h-4 w-4" />
+            Boost your balance to stay checkout-ready.
+          </span>
         </div>
 
-        {/* Low balance notice */}
         {safeBalance < 20 && safeBalance > 0 && (
-          <div className="mt-4 flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2.5 text-sm text-yellow-300">
+          <div className="flex items-start gap-2 rounded-2xl border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200">
             <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span>Low balance — add funds to continue shopping.</span>
           </div>

--- a/src/components/wallet/buyer/EmptyState.tsx
+++ b/src/components/wallet/buyer/EmptyState.tsx
@@ -4,33 +4,26 @@ import { ShoppingBag, ArrowRight } from 'lucide-react';
 
 export default function EmptyState() {
   return (
-    <div className="bg-[#1a1a1a] rounded-2xl p-12 border border-gray-800 text-center relative overflow-hidden">
-      {/* Background pattern */}
-      <div className="absolute inset-0 opacity-5">
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: `radial-gradient(circle at 50% 50%, rgba(255, 149, 14, 0.3) 0%, transparent 50%)`,
-          }}
-        />
-      </div>
-
-      <div className="relative z-10">
-        <div className="bg-gradient-to-r from-gray-700 to-gray-600 p-4 rounded-2xl w-20 h-20 mx-auto mb-6 shadow-lg">
-          <ShoppingBag className="w-12 h-12 text-gray-300 mx-auto" />
+    <section className="relative overflow-hidden rounded-3xl border border-dashed border-white/20 bg-white/[0.015] p-12 text-center shadow-[0_40px_120px_-70px_rgba(255,149,14,0.45)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,149,14,0.12),transparent_60%)]" />
+      <div className="relative z-10 mx-auto flex max-w-lg flex-col items-center gap-6">
+        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-[#ff950e]/40 bg-[#ff950e]/15 shadow-[0_12px_40px_-20px_rgba(255,149,14,0.6)]">
+          <ShoppingBag className="h-10 w-10 text-[#ffb347]" />
         </div>
-        <h3 className="text-2xl font-bold text-white mb-3">No Purchases Yet</h3>
-        <p className="text-gray-400 mb-8 max-w-md mx-auto">
-          Start exploring our marketplace to find amazing deals from verified sellers
-        </p>
+        <div className="space-y-3">
+          <h3 className="text-3xl font-semibold text-white">No purchases just yet</h3>
+          <p className="text-sm text-gray-400 sm:text-base">
+            Unlock the full buyer experience by topping up and discovering curated drops from trusted sellers.
+          </p>
+        </div>
         <a
           href="/browse"
-          className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-[#ff950e] to-orange-600 hover:from-[#e88800] hover:to-orange-700 text-black rounded-xl font-semibold transition-all duration-300 shadow-lg shadow-orange-500/25 hover:shadow-orange-500/40 group"
+          className="group inline-flex items-center gap-2 rounded-full border border-[#ff950e]/50 bg-[#ff950e] px-6 py-3 text-sm font-semibold text-black transition-transform duration-300 hover:scale-105 hover:border-[#ffb347]/70"
         >
-          Browse Listings
-          <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
+          Browse listings
+          <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
         </a>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/wallet/buyer/RecentPurchases.tsx
+++ b/src/components/wallet/buyer/RecentPurchases.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ShoppingBag, ArrowRight, Package, Calendar } from 'lucide-react';
+import { ShoppingBag, ArrowRight, Package, Calendar, Shield } from 'lucide-react';
 import { Order } from '@/context/WalletContext';
 
 interface RecentPurchasesProps {
@@ -22,25 +22,28 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
   }
 
   return (
-    <div className="bg-[#1a1a1a] rounded-2xl p-8 border border-gray-800 hover:border-gray-700 transition-all duration-300 relative overflow-hidden group">
-      {/* Background gradient effect */}
-      <div className="absolute inset-0 bg-gradient-to-br from-purple-600/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 shadow-[0_40px_120px_-70px_rgba(168,85,247,0.6)] transition-colors hover:border-white/20 sm:p-8">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(168,85,247,0.15),transparent_60%)]" />
+      <div className="pointer-events-none absolute -bottom-20 -right-10 h-64 w-64 rounded-full bg-purple-500/20 blur-3xl" />
 
-      <div className="relative z-10">
-        <div className="flex justify-between items-center mb-8">
-          <h2 className="text-2xl font-bold flex items-center text-white">
-            <div className="bg-gradient-to-r from-purple-600 to-purple-500 p-2 rounded-lg mr-3 shadow-lg shadow-purple-500/20">
-              <ShoppingBag className="w-6 h-6 text-white" />
+      <div className="relative z-10 flex flex-col gap-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-purple-400/40 bg-purple-500/20">
+              <ShoppingBag className="h-5 w-5 text-white" />
             </div>
-            Recent Purchases
-          </h2>
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Recent Purchases</h2>
+              <p className="text-sm text-gray-400">A snapshot of your latest checkouts across the marketplace.</p>
+            </div>
+          </div>
 
           <a
             href="/buyers/my-orders"
-            className="text-sm text-[#ff950e] hover:text-[#e88800] flex items-center transition-all duration-200 group/link"
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-2 text-sm font-medium text-[#ffb347] transition-colors hover:border-[#ff950e]/50 hover:bg-black/60 hover:text-white"
           >
-            View All Orders
-            <ArrowRight className="w-4 h-4 ml-2 group-hover/link:translate-x-1 transition-transform" />
+            View all orders
+            <ArrowRight className="h-4 w-4" />
           </a>
         </div>
 
@@ -48,36 +51,48 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
           {purchases.map((purchase, index) => (
             <div
               key={index}
-              className="bg-black/30 rounded-xl p-5 border border-gray-800 hover:border-gray-700 hover:bg-black/50 transition-all duration-200 group/item"
+              className="group/item relative overflow-hidden rounded-2xl border border-white/10 bg-black/40 p-5 transition-all duration-200 hover:border-purple-400/40 hover:bg-black/60"
             >
-              <div className="flex items-center justify-between">
-                <div className="flex items-start space-x-4">
-                  <div className="bg-gradient-to-r from-purple-600/20 to-purple-500/20 p-2 rounded-lg group-hover/item:from-purple-600/30 group-hover/item:to-purple-500/30 transition-colors">
-                    <Package className="w-5 h-5 text-purple-400" />
+              <div className="absolute inset-0 opacity-0 transition-opacity duration-200 group-hover/item:opacity-100" aria-hidden="true">
+                <div className="h-full w-full bg-gradient-to-r from-purple-500/10 via-transparent to-transparent" />
+              </div>
+
+              <div className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-1 items-start gap-4">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-purple-400/40 bg-purple-500/15">
+                    <Package className="h-5 w-5 text-purple-200" />
                   </div>
-                  <div>
-                    <h3 className="font-semibold text-white group-hover/item:text-[#ff950e] transition-colors">
-                      {purchase.title}
-                    </h3>
-                    <div className="flex items-center gap-4 mt-1">
-                      <p className="text-sm text-gray-400">From: {purchase.seller}</p>
-                      <div className="flex items-center text-xs text-gray-500">
-                        <Calendar className="w-3 h-3 mr-1" />
+                  <div className="space-y-2">
+                    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+                      <h3 className="text-base font-semibold text-white transition-colors group-hover/item:text-[#ffb347]">
+                        {purchase.title}
+                      </h3>
+                      <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] uppercase tracking-widest text-gray-400">
+                        <Shield className="h-3.5 w-3.5 text-purple-200" />
+                        Protected
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-sm text-gray-400">
+                      <span className="font-medium text-white/80">Seller: {purchase.seller}</span>
+                      <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+                        <Calendar className="h-3 w-3" />
                         {formatDate(purchase.date)}
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </div>
-                <div className="text-right">
-                  <p className="text-xl font-bold text-[#ff950e]">
+
+                <div className="flex flex-col items-end">
+                  <p className="text-xl font-semibold text-[#ffb347]">
                     ${(purchase.markedUpPrice ?? purchase.price).toFixed(2)}
                   </p>
+                  <span className="text-xs uppercase tracking-widest text-gray-500">Paid in wallet</span>
                 </div>
               </div>
             </div>
           ))}
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/wallet/buyer/WalletHeader.tsx
+++ b/src/components/wallet/buyer/WalletHeader.tsx
@@ -1,24 +1,77 @@
 'use client';
 
-import { Wallet, TrendingUp } from 'lucide-react';
+import { Wallet, ShieldCheck, Zap, CreditCard, Sparkles, ArrowUpRight } from 'lucide-react';
 
 export default function WalletHeader() {
   return (
-    <div className="mb-12">
-      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-        <div>
-          <h1 className="text-4xl font-bold text-white mb-2 flex items-center">
-            <div className="bg-gradient-to-r from-[#ff950e] to-orange-600 p-3 rounded-xl mr-4 shadow-lg shadow-orange-500/20">
-              <Wallet className="w-8 h-8 text-white" />
-            </div>
-            Buyer Wallet
-          </h1>
-          <p className="text-gray-400 text-lg">Manage your funds and track your spending</p>
+    <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-1 flex-col gap-8">
+        <div className="flex items-center gap-5">
+          <div className="inline-flex h-16 w-16 items-center justify-center rounded-2xl border border-[#ff950e]/50 bg-[#ff950e]/15 backdrop-blur-sm">
+            <Wallet className="h-7 w-7 text-white" />
+          </div>
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-gray-300/80">
+              Buyer hub
+            </span>
+            <h1 className="mt-3 text-3xl font-bold sm:text-4xl lg:text-5xl">
+              <span className="bg-gradient-to-r from-white via-gray-200 to-gray-500 bg-clip-text text-transparent">
+                Digital Wallet
+              </span>
+            </h1>
+            <p className="mt-3 max-w-xl text-sm text-gray-300 sm:text-base">
+              Top up instantly, keep your payments protected, and stay aligned with the premium aesthetic across your buyer dashboard.
+            </p>
+          </div>
         </div>
 
-        <div className="flex items-center gap-2 text-sm text-gray-400">
-          <TrendingUp className="w-4 h-4" />
-          <span>Secure payments with instant processing</span>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-500/15">
+              <ShieldCheck className="h-5 w-5 text-emerald-300" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wider text-gray-500">Escrow protected</p>
+              <p className="text-sm font-semibold text-white">Secure transfers</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[#ff950e]/20">
+              <Zap className="h-5 w-5 text-[#ffb347]" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wider text-gray-500">Instant reloads</p>
+              <p className="text-sm font-semibold text-white">No waiting period</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-purple-500/20">
+              <Sparkles className="h-5 w-5 text-purple-300" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wider text-gray-500">Curated perks</p>
+              <p className="text-sm font-semibold text-white">Buyer exclusives</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15">
+            <CreditCard className="h-6 w-6 text-[#ffb347]" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-white">Sync with your dashboard</p>
+            <p className="text-xs text-gray-500">Balances update in real-time across every buyer surface.</p>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/5 bg-black/30 p-4 text-xs text-gray-400">
+          <p className="flex items-center gap-2">
+            <ArrowUpRight className="h-4 w-4 text-[#ff950e]" />
+            Keep purchases flowing—add funds before you check out to skip processing delays.
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the buyer wallet page with layered gradients and sectioned cards to align with the refreshed buyer experience
- refresh wallet header, balance overview, add funds form, and recent purchases components with updated theming and layout cues
- update empty state styling to match new buyer dashboard aesthetics

## Testing
- npm run lint *(fails: pre-existing lint issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e867508d3c832883c383ae37b43d88