### PR TITLE
Update buyer wallet visuals to cool-toned theme

### DIFF
--- a/src/app/wallet/buyer/page.tsx
+++ b/src/app/wallet/buyer/page.tsx
@@ -46,7 +46,7 @@ function BuyerWalletContent() {
 
       <div className="relative z-10 px-4 py-12 sm:px-6 lg:px-10">
         <div className="mx-auto flex max-w-6xl flex-col gap-10">
-          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 sm:p-8 lg:p-12 shadow-[0_40px_120px_-60px_rgba(255,149,14,0.45)]">
+          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 sm:p-8 lg:p-12 shadow-[0_40px_120px_-60px_rgba(59,130,246,0.35)]">
             <div className="pointer-events-none absolute inset-x-6 inset-y-4 rounded-[2.25rem] border border-white/5 bg-gradient-to-r from-white/[0.04] via-transparent to-white/[0.04] opacity-40 blur-3xl" />
             <div className="relative">
               <WalletHeader />
@@ -103,13 +103,13 @@ function BuyerWalletWrapper() {
     return (
       <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex items-center space-x-2">
-          <div className="w-4 h-4 bg-[#ff950e] rounded-full animate-pulse"></div>
+          <div className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"></div>
           <div
-            className="w-4 h-4 bg-[#ff950e] rounded-full animate-pulse"
+            className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"
             style={{ animationDelay: '0.2s' }}
           ></div>
           <div
-            className="w-4 h-4 bg-[#ff950e] rounded-full animate-pulse"
+            className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"
             style={{ animationDelay: '0.4s' }}
           ></div>
         </div>

--- a/src/components/wallet/buyer/AddFundsSection.tsx
+++ b/src/components/wallet/buyer/AddFundsSection.tsx
@@ -77,7 +77,7 @@ export default function AddFundsSection({
         {/* Header row */}
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
-            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15">
               <PlusCircle className="h-5 w-5 text-white" />
             </div>
             <div>
@@ -124,7 +124,7 @@ export default function AddFundsSection({
                 key={quickAmount}
                 type="button"
                 onClick={() => onQuickAmountSelect(quickAmount.toString())}
-                className="rounded-xl border border-white/10 bg-black/40 py-2.5 text-sm font-semibold text-gray-200 transition-all duration-200 hover:border-[#ff950e]/40 hover:bg-black/60 hover:text-white disabled:opacity-50"
+                className="rounded-xl border border-white/10 bg-black/40 py-2.5 text-sm font-semibold text-gray-200 transition-all duration-200 hover:border-blue-400/40 hover:bg-black/60 hover:text-white disabled:opacity-50"
                 disabled={isLoading}
               >
                 ${quickAmount}
@@ -137,10 +137,10 @@ export default function AddFundsSection({
             <button
               type="submit"
               className="relative overflow-hidden px-10 py-3.5 rounded-full font-semibold flex items-center justify-center
-                         bg-gradient-to-r from-[#ff950e] via-orange-500 to-orange-600
-                         text-black shadow-md shadow-orange-500/30
+                         bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500
+                         text-white shadow-md shadow-blue-500/30
                          transition-all duration-300
-                         hover:scale-105 hover:shadow-orange-500/50
+                         hover:scale-105 hover:shadow-blue-500/50
                          disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
               disabled={
                 isLoading ||

--- a/src/components/wallet/buyer/BackgroundPattern.tsx
+++ b/src/components/wallet/buyer/BackgroundPattern.tsx
@@ -6,9 +6,9 @@ export default function BackgroundPattern() {
       <div
         className="absolute inset-0"
         style={{
-          backgroundImage: `radial-gradient(circle at 20% 80%, rgba(255, 149, 14, 0.3) 0%, transparent 50%),
-                        radial-gradient(circle at 80% 20%, rgba(255, 149, 14, 0.2) 0%, transparent 50%),
-                        radial-gradient(circle at 40% 40%, rgba(255, 149, 14, 0.15) 0%, transparent 50%)`,
+          backgroundImage: `radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.3) 0%, transparent 50%),
+                        radial-gradient(circle at 80% 20%, rgba(14, 165, 233, 0.25) 0%, transparent 50%),
+                        radial-gradient(circle at 40% 40%, rgba(37, 99, 235, 0.2) 0%, transparent 50%)`,
         }}
       />
     </div>

--- a/src/components/wallet/buyer/BalanceCard.tsx
+++ b/src/components/wallet/buyer/BalanceCard.tsx
@@ -13,10 +13,10 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
   return (
     <section
       aria-label="Current balance"
-      className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_30px_90px_-60px_rgba(255,149,14,0.6)] transition-colors hover:border-white/20 sm:p-8"
+      className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_30px_90px_-60px_rgba(59,130,246,0.35)] transition-colors hover:border-white/20 sm:p-8"
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,149,14,0.18),transparent_55%)]" />
-      <div className="pointer-events-none absolute -left-20 top-1/2 h-60 w-60 -translate-y-1/2 rounded-full bg-[#ff950e]/20 blur-3xl" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_55%)]" />
+      <div className="pointer-events-none absolute -left-20 top-1/2 h-60 w-60 -translate-y-1/2 rounded-full bg-blue-500/20 blur-3xl" />
 
       <div className="relative z-10 flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
@@ -32,39 +32,24 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
             </div>
           </div>
 
-          <div className="inline-flex items-center gap-3 rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15 px-4 py-2 text-sm font-semibold text-white">
+          <div className="inline-flex items-center gap-3 rounded-2xl border border-blue-400/40 bg-blue-500/15 px-4 py-2 text-sm font-semibold text-white">
             <DollarSign className="h-4 w-4" />
             Available to spend
           </div>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-3">
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/15">
-              <ShieldCheck className="h-5 w-5 text-emerald-300" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-widest text-gray-500">Escrow</p>
-              <p className="text-sm font-semibold text-white">Funds protected</p>
-            </div>
+        <div className="flex flex-col gap-3 text-sm text-gray-400">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-emerald-300" />
+            <span>Escrow protection keeps every transaction secure.</span>
           </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#ff950e]/20">
-              <Zap className="h-5 w-5 text-[#ffb347]" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-widest text-gray-500">Processing</p>
-              <p className="text-sm font-semibold text-white">Instant reloads</p>
-            </div>
+          <div className="flex items-center gap-2">
+            <Zap className="h-4 w-4 text-sky-300" />
+            <span>Instant reloads mean funds are ready to spend immediately.</span>
           </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/30 p-4">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple-500/20">
-              <Clock className="h-5 w-5 text-purple-200" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-widest text-gray-500">Activity</p>
-              <p className="text-sm font-semibold text-white">Real-time sync</p>
-            </div>
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-indigo-300" />
+            <span>Real-time activity sync keeps your balance up to date.</span>
           </div>
         </div>
 
@@ -72,7 +57,7 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
           <p>
             Each transaction includes a <span className="font-semibold text-gray-100">10% platform fee</span> for secure processing and buyer protection.
           </p>
-          <span className="inline-flex items-center gap-2 text-[#ffb347]">
+          <span className="inline-flex items-center gap-2 text-sky-200">
             <ArrowUpRight className="h-4 w-4" />
             Boost your balance to stay checkout-ready.
           </span>

--- a/src/components/wallet/buyer/EmptyState.tsx
+++ b/src/components/wallet/buyer/EmptyState.tsx
@@ -4,11 +4,11 @@ import { ShoppingBag, ArrowRight } from 'lucide-react';
 
 export default function EmptyState() {
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-dashed border-white/20 bg-white/[0.015] p-12 text-center shadow-[0_40px_120px_-70px_rgba(255,149,14,0.45)]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,149,14,0.12),transparent_60%)]" />
+    <section className="relative overflow-hidden rounded-3xl border border-dashed border-white/20 bg-white/[0.015] p-12 text-center shadow-[0_40px_120px_-70px_rgba(59,130,246,0.35)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.15),transparent_60%)]" />
       <div className="relative z-10 mx-auto flex max-w-lg flex-col items-center gap-6">
-        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-[#ff950e]/40 bg-[#ff950e]/15 shadow-[0_12px_40px_-20px_rgba(255,149,14,0.6)]">
-          <ShoppingBag className="h-10 w-10 text-[#ffb347]" />
+        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-blue-400/40 bg-blue-500/15 shadow-[0_12px_40px_-20px_rgba(59,130,246,0.45)]">
+          <ShoppingBag className="h-10 w-10 text-sky-200" />
         </div>
         <div className="space-y-3">
           <h3 className="text-3xl font-semibold text-white">No purchases just yet</h3>
@@ -18,7 +18,7 @@ export default function EmptyState() {
         </div>
         <a
           href="/browse"
-          className="group inline-flex items-center gap-2 rounded-full border border-[#ff950e]/50 bg-[#ff950e] px-6 py-3 text-sm font-semibold text-black transition-transform duration-300 hover:scale-105 hover:border-[#ffb347]/70"
+          className="group inline-flex items-center gap-2 rounded-full border border-blue-400/50 bg-blue-500 px-6 py-3 text-sm font-semibold text-white transition-transform duration-300 hover:scale-105 hover:border-blue-300/70"
         >
           Browse listings
           <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />

--- a/src/components/wallet/buyer/RecentPurchases.tsx
+++ b/src/components/wallet/buyer/RecentPurchases.tsx
@@ -40,7 +40,7 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
 
           <a
             href="/buyers/my-orders"
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-2 text-sm font-medium text-[#ffb347] transition-colors hover:border-[#ff950e]/50 hover:bg-black/60 hover:text-white"
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-2 text-sm font-medium text-sky-200 transition-colors hover:border-blue-400/40 hover:bg-black/60 hover:text-white"
           >
             View all orders
             <ArrowRight className="h-4 w-4" />
@@ -64,7 +64,7 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
                   </div>
                   <div className="space-y-2">
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-                      <h3 className="text-base font-semibold text-white transition-colors group-hover/item:text-[#ffb347]">
+                      <h3 className="text-base font-semibold text-white transition-colors group-hover/item:text-sky-200">
                         {purchase.title}
                       </h3>
                       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] uppercase tracking-widest text-gray-400">
@@ -83,7 +83,7 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
                 </div>
 
                 <div className="flex flex-col items-end">
-                  <p className="text-xl font-semibold text-[#ffb347]">
+                  <p className="text-xl font-semibold text-sky-200">
                     ${(purchase.markedUpPrice ?? purchase.price).toFixed(2)}
                   </p>
                   <span className="text-xs uppercase tracking-widest text-gray-500">Paid in wallet</span>

--- a/src/components/wallet/buyer/WalletHeader.tsx
+++ b/src/components/wallet/buyer/WalletHeader.tsx
@@ -7,7 +7,7 @@ export default function WalletHeader() {
     <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
       <div className="flex flex-1 flex-col gap-8">
         <div className="flex items-center gap-5">
-          <div className="inline-flex h-16 w-16 items-center justify-center rounded-2xl border border-[#ff950e]/50 bg-[#ff950e]/15 backdrop-blur-sm">
+          <div className="inline-flex h-16 w-16 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15 backdrop-blur-sm">
             <Wallet className="h-7 w-7 text-white" />
           </div>
           <div>
@@ -36,8 +36,8 @@ export default function WalletHeader() {
             </div>
           </div>
           <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[#ff950e]/20">
-              <Zap className="h-5 w-5 text-[#ffb347]" />
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-sky-500/20">
+              <Zap className="h-5 w-5 text-sky-200" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wider text-gray-500">Instant reloads</p>
@@ -58,8 +58,8 @@ export default function WalletHeader() {
 
       <div className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/15">
-            <CreditCard className="h-6 w-6 text-[#ffb347]" />
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15">
+            <CreditCard className="h-6 w-6 text-blue-200" />
           </div>
           <div>
             <p className="text-sm font-semibold text-white">Sync with your dashboard</p>
@@ -69,7 +69,7 @@ export default function WalletHeader() {
 
         <div className="rounded-2xl border border-white/5 bg-black/30 p-4 text-xs text-gray-400">
           <p className="flex items-center gap-2">
-            <ArrowUpRight className="h-4 w-4 text-[#ff950e]" />
+            <ArrowUpRight className="h-4 w-4 text-sky-300" />
             Keep purchases flowing—add funds before you check out to skip processing delays.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- restyle the buyer wallet header and background to remove orange glow and align with the blue accent palette
- simplify the balance card by replacing the boxed highlights with inline callouts and updating supporting components to match the cool-toned theme
- refresh empty state and recent purchases styling so all wallet surfaces share the new blue focus while keeping the add funds glow

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e86aa2b7ec832883b339c3a9c1bef1