### PR TITLE
Restyle buyer wallet to match brand palette

### DIFF
--- a/src/app/wallet/buyer/page.tsx
+++ b/src/app/wallet/buyer/page.tsx
@@ -43,10 +43,8 @@ function BuyerWalletContent() {
     <main className="relative min-h-screen overflow-hidden bg-[#050505] text-white">
       <div className="relative z-10 px-4 py-12 sm:px-6 lg:px-10">
         <div className="mx-auto flex max-w-6xl flex-col gap-10">
-          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 sm:p-8 lg:p-12">
-            <div className="relative">
-              <WalletHeader />
-            </div>
+          <section className="rounded-2xl border border-gray-800 bg-[#111] p-6 sm:p-8 lg:p-10">
+            <WalletHeader />
           </section>
 
           <section className="grid gap-6 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1fr)]">
@@ -99,13 +97,13 @@ function BuyerWalletWrapper() {
     return (
       <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex items-center space-x-2">
-          <div className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"></div>
+          <div className="w-4 h-4 rounded-full bg-[#ff950e] animate-pulse"></div>
           <div
-            className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"
+            className="w-4 h-4 rounded-full bg-[#ff950e] animate-pulse"
             style={{ animationDelay: '0.2s' }}
           ></div>
           <div
-            className="w-4 h-4 bg-blue-500 rounded-full animate-pulse"
+            className="w-4 h-4 rounded-full bg-[#ff950e] animate-pulse"
             style={{ animationDelay: '0.4s' }}
           ></div>
         </div>

--- a/src/components/wallet/buyer/AddFundsSection.tsx
+++ b/src/components/wallet/buyer/AddFundsSection.tsx
@@ -67,18 +67,16 @@ export default function AddFundsSection({
       ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
       : messageType === 'error'
       ? 'border-red-500/40 bg-red-500/10 text-red-200'
-      : 'border-white/10 bg-black/40 text-gray-300';
+      : 'border-gray-800 bg-[#0c0c0c] text-gray-300';
 
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 shadow-[0_30px_90px_-70px_rgba(66,153,255,0.6)] transition-colors hover:border-white/20 sm:p-8">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.18),transparent_55%)]" />
-
-      <div className="relative z-10 flex flex-col gap-6">
+    <section className="rounded-2xl border border-gray-800 bg-[#111] p-6 transition-colors sm:p-8">
+      <div className="flex flex-col gap-6">
         {/* Header row */}
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
-            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15">
-              <PlusCircle className="h-5 w-5 text-white" />
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+              <PlusCircle className="h-5 w-5 text-[#ff950e]" />
             </div>
             <div>
               <h2 className="text-xl font-semibold text-white sm:text-2xl">Add Funds</h2>
@@ -86,7 +84,7 @@ export default function AddFundsSection({
             </div>
           </div>
 
-          <span className="inline-flex items-center gap-1.5 self-start rounded-full border border-blue-500/30 bg-blue-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-blue-200 md:self-center">
+          <span className="inline-flex items-center gap-1.5 self-start rounded-full border border-[#ff950e]/40 bg-[#ff950e]/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-[#ff950e] md:self-center">
             <Zap className="h-3.5 w-3.5" />
             Instant processing
           </span>
@@ -124,7 +122,7 @@ export default function AddFundsSection({
                 key={quickAmount}
                 type="button"
                 onClick={() => onQuickAmountSelect(quickAmount.toString())}
-                className="rounded-xl border border-white/10 bg-black/40 py-2.5 text-sm font-semibold text-gray-200 transition-all duration-200 hover:border-blue-400/40 hover:bg-black/60 hover:text-white disabled:opacity-50"
+                className="rounded-xl border border-gray-800 bg-[#0c0c0c] py-2.5 text-sm font-semibold text-gray-200 transition-colors duration-200 hover:border-[#ff950e] hover:text-white disabled:opacity-50"
                 disabled={isLoading}
               >
                 ${quickAmount}
@@ -136,12 +134,7 @@ export default function AddFundsSection({
           <div className="flex justify-center">
             <button
               type="submit"
-              className="relative overflow-hidden px-10 py-3.5 rounded-full font-semibold flex items-center justify-center
-                         bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500
-                         text-white shadow-md shadow-blue-500/30
-                         transition-all duration-300
-                         hover:scale-105 hover:shadow-blue-500/50
-                         disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              className="flex items-center justify-center rounded-full bg-[#ff950e] px-10 py-3.5 font-semibold text-black transition-colors duration-200 hover:bg-[#e0850d] disabled:cursor-not-allowed disabled:opacity-50"
               disabled={
                 isLoading ||
                 !amountToAdd ||
@@ -150,10 +143,6 @@ export default function AddFundsSection({
                 !!amountError
               }
             >
-              {/* Shimmer overlay */}
-              <span className="absolute inset-0 rounded-full bg-gradient-to-r from-white/0 via-white/20 to-white/0 
-                               translate-x-[-100%] animate-[shimmer_2s_infinite] pointer-events-none" />
-
               {isLoading ? (
                 <>
                   <div className="w-4 h-4 border-2 border-black border-t-transparent rounded-full animate-spin mr-2"></div>

--- a/src/components/wallet/buyer/BalanceCard.tsx
+++ b/src/components/wallet/buyer/BalanceCard.tsx
@@ -13,15 +13,12 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
   return (
     <section
       aria-label="Current balance"
-      className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_30px_90px_-60px_rgba(59,130,246,0.35)] transition-colors hover:border-white/20 sm:p-8"
+      className="rounded-2xl border border-gray-800 bg-[#111] p-6 transition-colors sm:p-8"
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_55%)]" />
-      <div className="pointer-events-none absolute -left-20 top-1/2 h-60 w-60 -translate-y-1/2 rounded-full bg-blue-500/20 blur-3xl" />
-
-      <div className="relative z-10 flex flex-col gap-6">
+      <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-gray-300/70">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[#ff950e]/40 bg-[#ff950e]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-[#ff950e]">
               Balance
             </span>
             <div className="flex items-end gap-3">
@@ -32,7 +29,7 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
             </div>
           </div>
 
-          <div className="inline-flex items-center gap-3 rounded-2xl border border-blue-400/40 bg-blue-500/15 px-4 py-2 text-sm font-semibold text-white">
+          <div className="inline-flex items-center gap-3 rounded-2xl border border-[#ff950e]/30 bg-[#ff950e]/10 px-4 py-2 text-sm font-semibold text-[#ff950e]">
             <DollarSign className="h-4 w-4" />
             Available to spend
           </div>
@@ -40,31 +37,31 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
 
         <div className="flex flex-col gap-3 text-sm text-gray-400">
           <div className="flex items-center gap-2">
-            <ShieldCheck className="h-4 w-4 text-emerald-300" />
-            <span>Escrow protection keeps every transaction secure.</span>
+            <ShieldCheck className="h-4 w-4 text-[#ff950e]" />
+            <span>Secure transaction coverage keeps every purchase protected.</span>
           </div>
           <div className="flex items-center gap-2">
-            <Zap className="h-4 w-4 text-sky-300" />
+            <Zap className="h-4 w-4 text-[#ff950e]" />
             <span>Instant reloads mean funds are ready to spend immediately.</span>
           </div>
           <div className="flex items-center gap-2">
-            <Clock className="h-4 w-4 text-indigo-300" />
+            <Clock className="h-4 w-4 text-[#ff950e]" />
             <span>Real-time activity sync keeps your balance up to date.</span>
           </div>
         </div>
 
-        <div className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-black/40 p-4 text-xs text-gray-400 sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+        <div className="flex flex-col gap-3 rounded-2xl border border-gray-800 bg-[#0c0c0c] p-4 text-xs text-gray-400 sm:flex-row sm:items-center sm:justify-between sm:text-sm">
           <p>
             Each transaction includes a <span className="font-semibold text-gray-100">10% platform fee</span> for secure processing and buyer protection.
           </p>
-          <span className="inline-flex items-center gap-2 text-sky-200">
+          <span className="inline-flex items-center gap-2 text-[#ff950e]">
             <ArrowUpRight className="h-4 w-4" />
             Boost your balance to stay checkout-ready.
           </span>
         </div>
 
         {safeBalance < 20 && safeBalance > 0 && (
-          <div className="flex items-start gap-2 rounded-2xl border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200">
+          <div className="flex items-start gap-2 rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10 px-4 py-3 text-sm text-[#ff950e]">
             <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span>Low balance — add funds to continue shopping.</span>
           </div>

--- a/src/components/wallet/buyer/EmptyState.tsx
+++ b/src/components/wallet/buyer/EmptyState.tsx
@@ -4,11 +4,10 @@ import { ShoppingBag, ArrowRight } from 'lucide-react';
 
 export default function EmptyState() {
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-dashed border-white/20 bg-white/[0.015] p-12 text-center shadow-[0_40px_120px_-70px_rgba(59,130,246,0.35)]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.15),transparent_60%)]" />
-      <div className="relative z-10 mx-auto flex max-w-lg flex-col items-center gap-6">
-        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-blue-400/40 bg-blue-500/15 shadow-[0_12px_40px_-20px_rgba(59,130,246,0.45)]">
-          <ShoppingBag className="h-10 w-10 text-sky-200" />
+    <section className="rounded-2xl border border-dashed border-gray-800 bg-[#111] p-12 text-center">
+      <div className="mx-auto flex max-w-lg flex-col items-center gap-6">
+        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+          <ShoppingBag className="h-10 w-10 text-[#ff950e]" />
         </div>
         <div className="space-y-3">
           <h3 className="text-3xl font-semibold text-white">No purchases just yet</h3>
@@ -18,7 +17,7 @@ export default function EmptyState() {
         </div>
         <a
           href="/browse"
-          className="group inline-flex items-center gap-2 rounded-full border border-blue-400/50 bg-blue-500 px-6 py-3 text-sm font-semibold text-white transition-transform duration-300 hover:scale-105 hover:border-blue-300/70"
+          className="group inline-flex items-center gap-2 rounded-full bg-[#ff950e] px-6 py-3 text-sm font-semibold text-black transition-colors duration-200 hover:bg-[#e0850d]"
         >
           Browse listings
           <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />

--- a/src/components/wallet/buyer/RecentPurchases.tsx
+++ b/src/components/wallet/buyer/RecentPurchases.tsx
@@ -22,15 +22,12 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
   }
 
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] p-6 shadow-[0_40px_120px_-70px_rgba(168,85,247,0.6)] transition-colors hover:border-white/20 sm:p-8">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(168,85,247,0.15),transparent_60%)]" />
-      <div className="pointer-events-none absolute -bottom-20 -right-10 h-64 w-64 rounded-full bg-purple-500/20 blur-3xl" />
-
-      <div className="relative z-10 flex flex-col gap-8">
+    <section className="rounded-2xl border border-gray-800 bg-[#111] p-6 transition-colors sm:p-8">
+      <div className="flex flex-col gap-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-purple-400/40 bg-purple-500/20">
-              <ShoppingBag className="h-5 w-5 text-white" />
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+              <ShoppingBag className="h-5 w-5 text-[#ff950e]" />
             </div>
             <div>
               <h2 className="text-2xl font-semibold text-white">Recent Purchases</h2>
@@ -40,7 +37,7 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
 
           <a
             href="/buyers/my-orders"
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-2 text-sm font-medium text-sky-200 transition-colors hover:border-blue-400/40 hover:bg-black/60 hover:text-white"
+            className="inline-flex items-center gap-2 rounded-full border border-gray-800 bg-[#0c0c0c] px-4 py-2 text-sm font-medium text-gray-200 transition-colors hover:border-[#ff950e] hover:text-white"
           >
             View all orders
             <ArrowRight className="h-4 w-4" />
@@ -51,25 +48,21 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
           {purchases.map((purchase, index) => (
             <div
               key={index}
-              className="group/item relative overflow-hidden rounded-2xl border border-white/10 bg-black/40 p-5 transition-all duration-200 hover:border-purple-400/40 hover:bg-black/60"
+              className="group/item rounded-2xl border border-gray-800 bg-[#0c0c0c] p-5 transition-colors duration-200 hover:border-[#ff950e]/60"
             >
-              <div className="absolute inset-0 opacity-0 transition-opacity duration-200 group-hover/item:opacity-100" aria-hidden="true">
-                <div className="h-full w-full bg-gradient-to-r from-purple-500/10 via-transparent to-transparent" />
-              </div>
-
-              <div className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex flex-1 items-start gap-4">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-purple-400/40 bg-purple-500/15">
-                    <Package className="h-5 w-5 text-purple-200" />
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+                    <Package className="h-5 w-5 text-[#ff950e]" />
                   </div>
                   <div className="space-y-2">
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-                      <h3 className="text-base font-semibold text-white transition-colors group-hover/item:text-sky-200">
+                      <h3 className="text-base font-semibold text-white transition-colors group-hover/item:text-[#ff950e]">
                         {purchase.title}
                       </h3>
-                      <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] uppercase tracking-widest text-gray-400">
-                        <Shield className="h-3.5 w-3.5 text-purple-200" />
-                        Protected
+                      <span className="inline-flex items-center gap-2 rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 px-2.5 py-1 text-[11px] uppercase tracking-widest text-[#ff950e]">
+                        <Shield className="h-3.5 w-3.5 text-[#ff950e]" />
+                        Secure transaction
                       </span>
                     </div>
                     <div className="flex flex-wrap items-center gap-3 text-sm text-gray-400">
@@ -83,7 +76,7 @@ export default function RecentPurchases({ purchases }: RecentPurchasesProps) {
                 </div>
 
                 <div className="flex flex-col items-end">
-                  <p className="text-xl font-semibold text-sky-200">
+                  <p className="text-xl font-semibold text-[#ff950e]">
                     ${(purchase.markedUpPrice ?? purchase.price).toFixed(2)}
                   </p>
                   <span className="text-xs uppercase tracking-widest text-gray-500">Paid in wallet</span>

--- a/src/components/wallet/buyer/TotalSpentCard.tsx
+++ b/src/components/wallet/buyer/TotalSpentCard.tsx
@@ -9,18 +9,14 @@ interface TotalSpentCardProps {
 
 export default function TotalSpentCard({ totalSpent, totalOrders }: TotalSpentCardProps) {
   return (
-    <div className="bg-[#1a1a1a] rounded-2xl p-8 border border-gray-800 hover:border-gray-700 transition-all duration-300 relative overflow-hidden group">
-      {/* Background gradient effect */}
-      <div className="absolute inset-0 bg-gradient-to-br from-green-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-
-      <div className="relative z-10">
+    <div className="rounded-2xl border border-gray-800 bg-[#111] p-8 transition-colors duration-200">
         <div className="flex items-center justify-between mb-6">
           <div>
             <h2 className="text-sm font-medium text-gray-400 mb-1">Total Spent</h2>
             <p className="text-xs text-gray-500">Lifetime purchases</p>
           </div>
-          <div className="bg-gradient-to-r from-green-600 to-emerald-500 p-3 rounded-xl shadow-lg shadow-green-500/20">
-            <ShoppingBag className="w-6 h-6 text-white" />
+          <div className="rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10 p-3">
+            <ShoppingBag className="w-6 h-6 text-[#ff950e]" />
           </div>
         </div>
 
@@ -42,7 +38,6 @@ export default function TotalSpentCard({ totalSpent, totalOrders }: TotalSpentCa
             </div>
           </div>
         )}
-      </div>
     </div>
   );
 }

--- a/src/components/wallet/buyer/WalletHeader.tsx
+++ b/src/components/wallet/buyer/WalletHeader.tsx
@@ -7,17 +7,15 @@ export default function WalletHeader() {
     <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
       <div className="flex flex-1 flex-col gap-8">
         <div className="flex items-center gap-5">
-          <div className="inline-flex h-16 w-16 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15 backdrop-blur-sm">
-            <Wallet className="h-7 w-7 text-white" />
+          <div className="inline-flex h-16 w-16 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+            <Wallet className="h-7 w-7 text-[#ff950e]" />
           </div>
           <div>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-gray-300/80">
+            <span className="inline-flex items-center gap-2 rounded-full border border-gray-800 bg-[#0c0c0c] px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-gray-400">
               Buyer hub
             </span>
             <h1 className="mt-3 text-3xl font-bold sm:text-4xl lg:text-5xl">
-              <span className="bg-gradient-to-r from-white via-gray-200 to-gray-500 bg-clip-text text-transparent">
-                Digital Wallet
-              </span>
+              <span className="text-white">Digital Wallet</span>
             </h1>
             <p className="mt-3 max-w-xl text-sm text-gray-300 sm:text-base">
               Top up instantly, keep your payments protected, and stay aligned with the premium aesthetic across your buyer dashboard.
@@ -26,27 +24,27 @@ export default function WalletHeader() {
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-500/15">
-              <ShieldCheck className="h-5 w-5 text-emerald-300" />
+          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+              <ShieldCheck className="h-5 w-5 text-[#ff950e]" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wider text-gray-500">Escrow protected</p>
+              <p className="text-xs uppercase tracking-wider text-gray-500">Secure transaction</p>
               <p className="text-sm font-semibold text-white">Secure transfers</p>
             </div>
           </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-sky-500/20">
-              <Zap className="h-5 w-5 text-sky-200" />
+          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+              <Zap className="h-5 w-5 text-[#ff950e]" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wider text-gray-500">Instant reloads</p>
               <p className="text-sm font-semibold text-white">No waiting period</p>
             </div>
           </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-purple-500/20">
-              <Sparkles className="h-5 w-5 text-purple-300" />
+          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+              <Sparkles className="h-5 w-5 text-[#ff950e]" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wider text-gray-500">Curated perks</p>
@@ -56,10 +54,10 @@ export default function WalletHeader() {
         </div>
       </div>
 
-      <div className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-sm text-gray-300">
+      <div className="flex w-full max-w-sm flex-col gap-4 rounded-2xl border border-gray-800 bg-[#111] p-6 text-sm text-gray-300">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-400/40 bg-blue-500/15">
-            <CreditCard className="h-6 w-6 text-blue-200" />
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#ff950e]/40 bg-[#ff950e]/10">
+            <CreditCard className="h-6 w-6 text-[#ff950e]" />
           </div>
           <div>
             <p className="text-sm font-semibold text-white">Sync with your dashboard</p>
@@ -67,9 +65,9 @@ export default function WalletHeader() {
           </div>
         </div>
 
-        <div className="rounded-2xl border border-white/5 bg-black/30 p-4 text-xs text-gray-400">
+        <div className="rounded-2xl border border-gray-800 bg-[#0c0c0c] p-4 text-xs text-gray-400">
           <p className="flex items-center gap-2">
-            <ArrowUpRight className="h-4 w-4 text-sky-300" />
+            <ArrowUpRight className="h-4 w-4 text-[#ff950e]" />
             Keep purchases flowing—add funds before you check out to skip processing delays.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- replace the buyer wallet hero, balance, add-funds, and recent purchase cards with the site's orange-accent styling and remove glow effects
- update empty state and totals card to the same palette for consistency and swap escrow wording for "secure transaction" copy throughout
- adjust the buyer wallet page wrapper and loading indicator to align with the refreshed theme

## Testing
- npm run lint *(fails: existing lint errors across unrelated admin/context files)*

------
https://chatgpt.com/codex/tasks/task_e_68e86f22f40483288da8b9d856b07d86