### PR TITLE
Ensure guest homepage users poll for real-time stats

### DIFF
--- a/pantypost-backend/routes/auth.routes.js
+++ b/pantypost-backend/routes/auth.routes.js
@@ -9,6 +9,7 @@ const authMiddleware = require('../middleware/auth.middleware');
 const { ERROR_CODES } = require('../utils/constants');
 const { sendEmail, emailTemplates } = require('../config/email');
 const webSocketService = require('../config/websocket');
+const { getUserStats } = require('../services/userStatsService');
 
 // Get JWT secret from environment
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
@@ -150,41 +151,21 @@ router.post('/signup', async (req, res) => {
     // ========== NEW: WEBSOCKET INTEGRATION FOR USER STATS ==========
     // Emit new user registration event
     if (webSocketService && webSocketService.io) {
-      // Emit to all connected clients about new user
-      webSocketService.io.emit('user:registered', {
+      const payload = {
         userId: newUser._id.toString(),
         username: newUser.username,
         role: newUser.role,
         timestamp: new Date().toISOString()
-      });
+      };
+
+      // Emit to all connected clients about new user
+      webSocketService.broadcast('user:registered', payload);
 
       // Calculate and broadcast updated user statistics
       try {
-        const [totalUsers, newUsersToday] = await Promise.all([
-          User.countDocuments(),
-          User.countDocuments({ 
-            createdAt: { 
-              $gte: new Date(new Date().setHours(0, 0, 0, 0)) 
-            } 
-          })
-        ]);
-
-        const [totalBuyers, totalSellers, verifiedSellers] = await Promise.all([
-          User.countDocuments({ role: 'buyer' }),
-          User.countDocuments({ role: 'seller' }),
-          User.countDocuments({ role: 'seller', isVerified: true })
-        ]);
-
-        webSocketService.io.emit('stats:users', {
-          totalUsers,
-          totalBuyers,
-          totalSellers,
-          verifiedSellers,
-          newUsersToday,
-          timestamp: new Date().toISOString()
-        });
-        
-        console.log(`📊 Broadcasted user stats - Total: ${totalUsers}, New today: ${newUsersToday}`);
+        const stats = await getUserStats();
+        webSocketService.broadcast('stats:users', stats);
+        console.log(`📊 Broadcasted user stats - Total: ${stats.totalUsers}, New today: ${stats.newUsersToday}`);
       } catch (statsError) {
         console.error('Failed to broadcast user stats:', statsError);
       }

--- a/pantypost-backend/routes/user.routes.js
+++ b/pantypost-backend/routes/user.routes.js
@@ -6,44 +6,18 @@ const Ban = require('../models/Ban');
 const authMiddleware = require('../middleware/auth.middleware');
 const { ERROR_CODES } = require('../utils/constants');
 const jwt = require('jsonwebtoken');
+const { getUserStats } = require('../services/userStatsService');
 
 // ============= USER ROUTES =============
 
 // GET /api/users/stats - Get user statistics (PUBLIC)
 router.get('/stats', async (req, res) => {
   try {
-    const [totalUsers, totalBuyers, totalSellers, verifiedSellers] = await Promise.all([
-      User.countDocuments(),
-      User.countDocuments({ role: 'buyer' }),
-      User.countDocuments({ role: 'seller' }),
-      User.countDocuments({ role: 'seller', isVerified: true })
-    ]);
-
-    // Get users joined in last 24 hours
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    const newUsersToday = await User.countDocuments({ 
-      createdAt: { $gte: yesterday } 
-    });
-
-    // Get users joined today (from midnight)
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
-    const newUsersTodayActual = await User.countDocuments({ 
-      createdAt: { $gte: todayStart } 
-    });
+    const stats = await getUserStats();
 
     res.json({
       success: true,
-      data: {
-        totalUsers,
-        totalBuyers,
-        totalSellers,
-        verifiedSellers,
-        newUsersToday: newUsersTodayActual,
-        newUsers24Hours: newUsersToday,
-        timestamp: new Date().toISOString()
-      }
+      data: stats
     });
   } catch (error) {
     console.error('Error fetching user stats:', error);

--- a/pantypost-backend/services/userStatsService.js
+++ b/pantypost-backend/services/userStatsService.js
@@ -1,0 +1,43 @@
+// pantypost-backend/services/userStatsService.js
+const User = require('../models/User');
+
+/**
+ * Fetch aggregated user statistics for public display
+ * This helper is shared between API routes and WebSocket broadcasts
+ */
+async function getUserStats() {
+  const now = new Date();
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const last24Hours = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const [
+    totalUsers,
+    totalBuyers,
+    totalSellers,
+    verifiedSellers,
+    newUsersToday,
+    newUsers24Hours
+  ] = await Promise.all([
+    User.countDocuments(),
+    User.countDocuments({ role: 'buyer' }),
+    User.countDocuments({ role: 'seller' }),
+    User.countDocuments({ role: 'seller', isVerified: true }),
+    User.countDocuments({ createdAt: { $gte: startOfToday } }),
+    User.countDocuments({ createdAt: { $gte: last24Hours } })
+  ]);
+
+  return {
+    totalUsers,
+    totalBuyers,
+    totalSellers,
+    verifiedSellers,
+    newUsersToday,
+    newUsers24Hours,
+    timestamp: now.toISOString()
+  };
+}
+
+module.exports = {
+  getUserStats
+};

--- a/src/components/homepage/AnimatedUserCounter.tsx
+++ b/src/components/homepage/AnimatedUserCounter.tsx
@@ -6,6 +6,7 @@ import { motion, useSpring, useTransform } from 'framer-motion';
 import { CheckCircle, Users, TrendingUp } from 'lucide-react';
 import { userStatsService } from '@/services/userStats.service';
 import { useWebSocket } from '@/context/WebSocketContext';
+import { WebSocketState } from '@/types/websocket';
 
 interface AnimatedUserCounterProps {
   className?: string;
@@ -23,6 +24,9 @@ export default function AnimatedUserCounter({
   const [isLoading, setIsLoading] = useState(true);
   const [showUpdateAnimation, setShowUpdateAnimation] = useState(false);
   const webSocket = useWebSocket();
+  const isWebSocketReady =
+    webSocket?.connectionState === WebSocketState.CONNECTED &&
+    webSocket?.isConnected;
   const mountedRef = useRef(true);
 
   // Spring animation for smooth counting
@@ -74,8 +78,8 @@ export default function AnimatedUserCounter({
 
   // WebSocket real-time updates (for authenticated users)
   useEffect(() => {
-    if (!webSocket) {
-      console.log('[AnimatedUserCounter] WebSocket not available - user is likely a guest');
+    if (!webSocket || !isWebSocketReady) {
+      console.log('[AnimatedUserCounter] WebSocket not ready - falling back to polling');
       return;
     }
 
@@ -132,14 +136,14 @@ export default function AnimatedUserCounter({
       unsubscribeNewUser();
       unsubscribeStatsUpdate();
     };
-  }, [webSocket, springValue]);
+  }, [webSocket, isWebSocketReady, springValue]);
 
   // Polling for guests (when WebSocket not available)
   useEffect(() => {
     // Only poll if:
     // 1. Not loading initial data
     // 2. No WebSocket (guest user)
-    if (isLoading || webSocket) {
+    if (isLoading || isWebSocketReady) {
       return;
     }
 
@@ -175,7 +179,7 @@ export default function AnimatedUserCounter({
       console.log('[AnimatedUserCounter] Stopping polling');
       clearInterval(pollInterval);
     };
-  }, [webSocket, isLoading, targetCount, springValue]);
+  }, [isWebSocketReady, isLoading, targetCount, springValue]);
 
   if (compact) {
     return (

--- a/src/components/homepage/TrustSignalsSection.tsx
+++ b/src/components/homepage/TrustSignalsSection.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { Shield, CreditCard, Users } from 'lucide-react';
 import { itemVariants, containerVariants, shapeVariants, VIEWPORT_CONFIG } from '@/utils/motion.config';
 import { sanitizeStrict } from '@/utils/security/sanitization';
+import AnimatedUserCounter from './AnimatedUserCounter';
 
 // Define trust signals directly here with the verification badge
 const TRUST_SIGNALS = [
@@ -57,9 +58,13 @@ export default function TrustSignalsSection() {
         viewport={VIEWPORT_CONFIG} 
         variants={containerVariants}
       >
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
-          {TRUST_SIGNALS.map((item, index) => (
-            <motion.div key={index} className="flex flex-col items-center" variants={itemVariants}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-center">
+          <motion.div className="sm:col-span-2 lg:col-span-2" variants={itemVariants}>
+            <AnimatedUserCounter className="h-full" showNewUsersToday />
+          </motion.div>
+
+          {TRUST_SIGNALS.map((item) => (
+            <motion.div key={item.title} className="flex flex-col items-center" variants={itemVariants}>
               {item.iconType === 'image' ? (
                 <div className="h-7 w-7 mb-3 transition-transform duration-300 hover:scale-110 relative">
                   <Image

--- a/src/services/api.config.ts
+++ b/src/services/api.config.ts
@@ -52,6 +52,7 @@ export const API_ENDPOINTS = {
     VERIFICATION: '/users/:username/verification',
     SETTINGS: '/users/:username/settings',
     LIST: '/users',
+    STATS: '/users/stats',
   },
   
   // Listing endpoints

--- a/src/services/userStats.service.ts
+++ b/src/services/userStats.service.ts
@@ -1,6 +1,6 @@
 // src/services/userStats.service.ts
 
-import { apiCall, API_BASE_URL } from './api.config';
+import { apiCall, API_ENDPOINTS } from './api.config';
 
 export interface UserStats {
   totalUsers: number;
@@ -42,7 +42,7 @@ class UserStatsService {
       console.log('[UserStatsService] Fetching user stats from API');
       
       // Use apiCall - the generic type should be the data type, not the response wrapper
-      const response = await apiCall<UserStats>('/users/stats');
+      const response = await apiCall<UserStats>(API_ENDPOINTS.USERS.STATS);
       
       console.log('[UserStatsService] Response:', response);
 


### PR DESCRIPTION
## Summary
- guard AnimatedUserCounter subscriptions so they only run when the WebSocket is connected and fall back to polling when it is not
- expose the `/users/stats` path via API_ENDPOINTS and reuse it inside the shared user stats service

## Testing
- npm run lint *(fails: existing lint errors across multiple context and utility files)*

------
https://chatgpt.com/codex/tasks/task_e_68ea830552f48328a55ee6ee120c65b8