### PR TITLE
Remove wallet badges from buyer wallet page

### DIFF
--- a/src/components/wallet/buyer/AddFundsSection.tsx
+++ b/src/components/wallet/buyer/AddFundsSection.tsx
@@ -1,7 +1,7 @@
 // src/components/wallet/buyer/AddFundsSection.tsx
 'use client';
 
-import { PlusCircle, CreditCard, CheckCircle, AlertCircle, Zap } from 'lucide-react';
+import { PlusCircle, CreditCard, CheckCircle, AlertCircle } from 'lucide-react';
 import { SecureInput } from '@/components/ui/SecureInput';
 import { SecureForm } from '@/components/ui/SecureForm';
 import { SecureMessageDisplay } from '@/components/ui/SecureMessageDisplay';
@@ -83,11 +83,6 @@ export default function AddFundsSection({
               <p className="text-sm text-gray-400">Choose an amount, confirm, and spend immediately.</p>
             </div>
           </div>
-
-          <span className="inline-flex items-center gap-1.5 self-start rounded-full border border-[#ff950e]/40 bg-[#ff950e]/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-[#ff950e] md:self-center">
-            <Zap className="h-3.5 w-3.5" />
-            Instant processing
-          </span>
         </div>
 
         {/* Form */}

--- a/src/components/wallet/buyer/BalanceCard.tsx
+++ b/src/components/wallet/buyer/BalanceCard.tsx
@@ -18,9 +18,6 @@ export default function BalanceCard({ balance }: BalanceCardProps) {
       <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[#ff950e]/40 bg-[#ff950e]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-[#ff950e]">
-              Balance
-            </span>
             <div className="flex items-end gap-3">
               <p className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
                 ${safeBalance.toFixed(2)}

--- a/src/components/wallet/buyer/WalletHeader.tsx
+++ b/src/components/wallet/buyer/WalletHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Wallet, ShieldCheck, Zap, CreditCard, Sparkles, ArrowUpRight } from 'lucide-react';
+import { Wallet, CreditCard, ArrowUpRight } from 'lucide-react';
 
 export default function WalletHeader() {
   return (
@@ -23,35 +23,6 @@ export default function WalletHeader() {
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
-              <ShieldCheck className="h-5 w-5 text-[#ff950e]" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-wider text-gray-500">Secure transaction</p>
-              <p className="text-sm font-semibold text-white">Secure transfers</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
-              <Zap className="h-5 w-5 text-[#ff950e]" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-wider text-gray-500">Instant reloads</p>
-              <p className="text-sm font-semibold text-white">No waiting period</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-gray-800 bg-[#111] p-4">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/10">
-              <Sparkles className="h-5 w-5 text-[#ff950e]" />
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-wider text-gray-500">Curated perks</p>
-              <p className="text-sm font-semibold text-white">Buyer exclusives</p>
-            </div>
-          </div>
-        </div>
       </div>
 
       <div className="flex w-full max-w-sm flex-col gap-4 rounded-2xl border border-gray-800 bg-[#111] p-6 text-sm text-gray-300">


### PR DESCRIPTION
## Summary
- remove the balance badge from the buyer wallet balance card
- strip the promotional badges from the wallet header hero
- drop the instant processing badge from the add funds section

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68eaf44627b0832893e619edab7f5444