### PR TITLE
Ensure header search shows updated profile pictures

### DIFF
--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -11,6 +11,7 @@ export type SellerTier = 'Tease' | 'Flirt' | 'Obsession' | 'Desire' | 'Goddess';
 export interface UserProfile {
   bio: string;
   profilePic: string | null;
+  profilePicUpdatedAt?: string | null;
   subscriptionPrice: string;
   lastUpdated?: string;
   galleryImages?: string[];


### PR DESCRIPTION
## Summary
- add cache-busting metadata to header search results so avatars update immediately after profile changes
- persist profile picture update timestamps in cached user data to keep search results in sync
- extend user profile typing to carry the new profile picture update marker

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68eaf93244d083289b69ff4f2d3149e2