### PR TITLE
Adjust seller wallet badge alignment

### DIFF
--- a/src/components/wallet/seller/WithdrawSection.tsx
+++ b/src/components/wallet/seller/WithdrawSection.tsx
@@ -99,7 +99,7 @@ export default function WithdrawSection({
       <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex flex-col gap-2">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[#ff950e]">
+            <span className="inline-flex items-center gap-2 self-start rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[#ff950e]">
               Withdraw
             </span>
             <h2 className="text-2xl font-semibold text-white">Move earnings to your account</h2>


### PR DESCRIPTION
## Summary
- prevent the withdraw badge from stretching across the seller wallet card by aligning it to the start

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68eba2720d508328963d29dc903078ad