### PR TITLE
Add homepage FAQ content and SEO metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,13 @@ export const metadata: Metadata = {
   authors: [{ name: 'PantyPost' }],
   creator: 'PantyPost',
   publisher: 'PantyPost',
+  alternates: {
+    canonical: '/',
+    languages: {
+      'en-US': '/',
+      'en-GB': '/',
+    },
+  },
   
   // CRITICAL: Enable indexing for production (CHANGED FROM noindex)
   robots: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,34 +10,10 @@ import FeaturesSection from '@/components/homepage/FeaturesSection';
 import CTASection from '@/components/homepage/CTASection';
 import Footer from '@/components/homepage/Footer';
 import FeaturedRandom from '@/components/homepage/FeaturedRandom';
+import FAQSection from '@/components/homepage/FAQSection';
 import Head from 'next/head';
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://pantypost.com';
-
-// Enhanced loading skeleton for Featured Random section
-const FeaturedRandomSkeleton = () => (
-  <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 md:py-16">
-    <div className="flex items-center justify-between mb-8">
-      <div>
-        <div className="h-8 bg-gray-800/50 rounded w-48 animate-pulse mb-2"></div>
-        <div className="h-4 bg-gray-800/30 rounded w-64 animate-pulse"></div>
-      </div>
-      <div className="h-4 bg-gray-800/30 rounded w-20 animate-pulse"></div>
-    </div>
-    <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="bg-[#131313] rounded-xl border border-white/10 overflow-hidden">
-          <div className="aspect-[4/3] bg-gray-800/50 animate-pulse"></div>
-          <div className="p-4 space-y-3">
-            <div className="h-5 bg-gray-800/50 rounded animate-pulse"></div>
-            <div className="h-3 bg-gray-800/30 rounded w-2/3 animate-pulse"></div>
-            <div className="h-6 bg-gray-800/50 rounded w-1/3 animate-pulse"></div>
-          </div>
-        </div>
-      ))}
-    </div>
-  </section>
-);
 
 // Enhanced loading fallback components with pulse animations
 const SectionSkeleton = ({ height = "h-96" }: { height?: string }) => (
@@ -172,6 +148,44 @@ export default function Home() {
             })
           }}
         />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'FAQPage',
+              mainEntity: [
+                {
+                  '@type': 'Question',
+                  name: 'What is PantyPost and how does it work?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text:
+                      'PantyPost (also known as Panty Post) is a discreet marketplace that connects verified sellers with qualified buyers of used panties. Users can create an account, browse curated listings, and checkout securely with anonymous transactions.'
+                  }
+                },
+                {
+                  '@type': 'Question',
+                  name: 'Is PantyPost the same as Panty Post?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text:
+                      'Yes. PantyPost and Panty Post refer to the same privacy-first brand and marketplace for adult panty trading experiences.'
+                  }
+                },
+                {
+                  '@type': 'Question',
+                  name: 'How does PantyPost keep buyers and sellers safe?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text:
+                      'PantyPost protects its community with ID verification, automated moderation, and secure escrow-style payments that keep every transaction anonymous and compliant.'
+                  }
+                }
+              ]
+            })
+          }}
+        />
       </Head>
 
       <BanCheck>
@@ -199,7 +213,12 @@ export default function Home() {
           <SectionWrapper sectionName="Features" fallbackHeight="h-96">
             <FeaturesSection />
           </SectionWrapper>
-          
+
+          {/* FAQ Section with SEO-focused brand reinforcement */}
+          <SectionWrapper sectionName="FAQ" fallbackHeight="h-80">
+            <FAQSection />
+          </SectionWrapper>
+
           {/* CTA Section with Error Boundary */}
           <SectionWrapper sectionName="Call to Action" fallbackHeight="h-80">
             <CTASection />

--- a/src/components/homepage/FAQSection.tsx
+++ b/src/components/homepage/FAQSection.tsx
@@ -1,0 +1,81 @@
+// src/components/homepage/FAQSection.tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import { containerVariants, itemVariants } from '@/utils/motion.config';
+
+const FAQ_ITEMS = [
+  {
+    question: 'What is PantyPost and how does it work?',
+    answer:
+      'PantyPost is a discreet marketplace that connects verified sellers with qualified buyers of used panties. Create a free account, browse curated listings, and complete secure, anonymous transactions backed by our privacy-first platform.'
+  },
+  {
+    question: 'Is PantyPost the same as Panty Post?',
+    answer:
+      'Yes. PantyPost—also known as Panty Post—is our official brand. Using either spelling will bring you to the same trusted community marketplace dedicated to safe, adult-only panty trading experiences.'
+  },
+  {
+    question: 'How does PantyPost keep buyers and sellers safe?',
+    answer:
+      'We combine ID verification, automated moderation, and secure escrow-style payments to keep every PantyPost transaction anonymous and protected. Dedicated support specialists monitor the marketplace around the clock to maintain a compliant environment.'
+  },
+  {
+    question: 'Can I sell other adult content on PantyPost?',
+    answer:
+      'PantyPost focuses on intimate apparel, scent items, and add-on experiences that complement used panty sales. Our team regularly reviews listings to ensure they match what shoppers search for when they look for PantyPost or Panty Post online.'
+  }
+];
+
+export default function FAQSection() {
+  return (
+    <section
+      className="bg-[#0b0b0b] border-t border-white/5"
+      aria-labelledby="homepage-faq-title"
+    >
+      <div className="mx-auto max-w-6xl px-6 py-16 sm:py-20 lg:py-24">
+        <motion.div
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.25 }}
+          variants={containerVariants}
+          className="mx-auto max-w-3xl text-center"
+        >
+          <motion.h2
+            id="homepage-faq-title"
+            className="text-3xl sm:text-4xl font-bold tracking-tight text-white mb-4"
+            variants={itemVariants}
+          >
+            Frequently Asked Questions About PantyPost
+          </motion.h2>
+          <motion.p
+            className="text-base sm:text-lg text-gray-400"
+            variants={itemVariants}
+          >
+            Learn more about the PantyPost marketplace—sometimes called Panty Post—and how we help adult shoppers connect safely with verified sellers.
+          </motion.p>
+        </motion.div>
+
+        <div className="mt-12 grid gap-6 sm:mt-16">
+          {FAQ_ITEMS.map((item) => (
+            <motion.div
+              key={item.question}
+              variants={itemVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.2 }}
+              className="rounded-2xl border border-white/10 bg-black/60 p-6 text-left shadow-[0_10px_40px_rgba(0,0,0,0.35)] backdrop-blur"
+            >
+              <h3 className="text-xl font-semibold text-white mb-3">
+                {item.question}
+              </h3>
+              <p className="text-sm sm:text-base leading-relaxed text-gray-400">
+                {item.answer}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add canonical and language-specific alternates to the global metadata configuration
- introduce a homepage FAQ section with brand-focused copy that reinforces "PantyPost" searches
- embed FAQ structured data on the homepage to support rich results

## Testing
- npx eslint src/app/layout.tsx src/app/page.tsx src/components/homepage/FAQSection.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ee4abe30008328a9bde1739992da1c