### PR TITLE
Revamp admin verification requests UI

### DIFF
--- a/src/app/admin/verification-requests/page.tsx
+++ b/src/app/admin/verification-requests/page.tsx
@@ -16,7 +16,6 @@ import type { PendingVerification, VerificationStats as StatsType } from '@/serv
 import type { VerificationUser, SortOption, ImageViewData } from '@/types/verification';
 import { sanitizeStrict } from '@/utils/security/sanitization';
 import { Shield, AlertCircle, Loader2 } from 'lucide-react';
-import { FEATURES } from '@/services/api.config';
 
 // Get backend URL from environment
 const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
@@ -295,7 +294,7 @@ export default function AdminVerificationRequestsPage() {
   // Loading state
   if (!isAuthReady || loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-black to-[#0a0a0a] text-white flex items-center justify-center">
+      <div className="min-h-screen bg-[#050505] text-gray-100 flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin mx-auto mb-4 text-[#ff950e]" />
           <p className="text-gray-400">Loading verification requests...</p>
@@ -307,14 +306,14 @@ export default function AdminVerificationRequestsPage() {
   // Error state
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-black to-[#0a0a0a] text-white flex items-center justify-center">
+      <div className="min-h-screen bg-[#050505] text-gray-100 flex items-center justify-center">
         <div className="text-center max-w-md">
           <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
           <h2 className="text-xl font-bold mb-2">Error Loading Verifications</h2>
           <p className="text-gray-400 mb-4">{error}</p>
           <button
             onClick={refreshData}
-            className="px-4 py-2 bg-[#ff950e] text-black font-bold rounded-lg hover:bg-[#e88800] transition"
+            className="px-4 py-2 rounded-xl bg-[#ff950e] text-black font-semibold hover:bg-[#e88800] transition"
           >
             Retry
           </button>
@@ -325,38 +324,42 @@ export default function AdminVerificationRequestsPage() {
 
   return (
     <RequireAuth role="admin">
-      <div className="min-h-screen bg-gradient-to-b from-black to-[#0a0a0a] text-white">
+      <div className="relative min-h-screen bg-[#050505] text-gray-100">
         <VerificationHeader onRefresh={refreshData} />
 
-        <VerificationSearch
-          searchTerm={searchTerm}
-          onSearchChange={handleSearchTermChange}
-          sortBy={sortBy}
-          onSortChange={setSortBy}
-          pendingCount={filteredUsers.length}
-        />
+        <main className="relative z-0 pb-16">
+          <section className="pt-10 space-y-10">
+            <VerificationSearch
+              searchTerm={searchTerm}
+              onSearchChange={handleSearchTermChange}
+              sortBy={sortBy}
+              onSortChange={setSortBy}
+              pendingCount={filteredUsers.length}
+            />
 
-        <VerificationStats stats={filteredStats} />
+            <VerificationStats stats={filteredStats} />
 
-        {filteredUsers.length === 0 ? (
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <div className="bg-[#121212] rounded-xl border border-gray-800 p-12 text-center">
-              <Shield className="w-16 h-16 text-gray-600 mx-auto mb-4" />
-              <h3 className="text-xl font-bold mb-2">No Pending Verifications</h3>
-              <p className="text-gray-400">
-                {searchTerm 
-                  ? `No verification requests found matching "${searchTerm}"`
-                  : 'There are no verification requests awaiting review'}
-              </p>
-            </div>
-          </div>
-        ) : (
-          <VerificationList
-            users={filteredUsers}
-            searchTerm={searchTerm}
-            onSelectUser={setSelected}
-          />
-        )}
+            {filteredUsers.length === 0 ? (
+              <div className="max-w-7xl mx-auto px-4 md:px-6">
+                <div className="rounded-2xl border border-white/5 bg-black/40 px-8 py-14 text-center">
+                  <Shield className="w-14 h-14 text-white/20 mx-auto mb-4" />
+                  <h3 className="text-2xl font-semibold text-white">No Pending Verifications</h3>
+                  <p className="mt-3 text-sm text-gray-400">
+                    {searchTerm
+                      ? `No verification requests found matching "${searchTerm}"`
+                      : 'Everything looks good — there are no verification requests awaiting review.'}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <VerificationList
+                users={filteredUsers}
+                searchTerm={searchTerm}
+                onSelectUser={setSelected}
+              />
+            )}
+          </section>
+        </main>
 
         {selected && (
           <ReviewModal
@@ -379,10 +382,10 @@ export default function AdminVerificationRequestsPage() {
 
         {/* Processing overlay */}
         {isProcessing && (
-          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
-            <div className="bg-[#121212] rounded-xl border border-gray-800 p-6">
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center">
+            <div className="rounded-2xl border border-white/10 bg-[#0a0a0a] px-6 py-8 text-center">
               <Loader2 className="w-8 h-8 animate-spin mx-auto mb-4 text-[#ff950e]" />
-              <p className="text-gray-400">Processing verification...</p>
+              <p className="text-sm text-gray-400">Processing verification...</p>
             </div>
           </div>
         )}

--- a/src/components/admin/verification/VerificationCard.tsx
+++ b/src/components/admin/verification/VerificationCard.tsx
@@ -16,9 +16,9 @@ export default function VerificationCard({
     (!!user.verificationDocs.idFront || !!user.verificationDocs.passport);
 
   return (
-    <div
+    <article
       onClick={onSelect}
-      className="bg-[#0e0e0e] border border-[#222] rounded-xl p-4 hover:border-[#ff950e] transition-all duration-200 cursor-pointer group"
+      className="group relative overflow-hidden rounded-2xl border border-white/5 bg-black/40 p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-[#ff950e]/60 hover:shadow-[0_30px_60px_-45px_rgba(255,149,14,0.55)] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
       role="button"
       aria-label={`Open verification for ${user.username}`}
       tabIndex={0}
@@ -26,39 +26,37 @@ export default function VerificationCard({
         if (e.key === 'Enter' || e.key === ' ') onSelect();
       }}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <div className="w-12 h-12 bg-[#1a1a1a] rounded-full flex items-center justify-center border border-[#333] group-hover:border-[#ff950e] transition-colors">
-            <Shield className="w-6 h-6 text-[#ff950e]" />
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-4">
+          <div className="relative flex h-12 w-12 items-center justify-center rounded-xl border border-white/10 bg-white/5">
+            <Shield className="h-6 w-6 text-[#ff950e]" />
+            <span className="absolute -bottom-1 -right-1 h-4 w-4 rounded-full border border-[#ff950e]/40 bg-[#ff950e]/20" />
           </div>
           <div>
-            <h3 className="font-bold text-white text-lg group-hover:text-[#ff950e] transition-colors">
+            <h3 className="text-lg font-semibold text-white transition-colors group-hover:text-[#ff950e]">
               <SecureMessageDisplay content={user.username} allowBasicFormatting={false} />
             </h3>
-            <div className="flex items-center gap-2 mt-1">
-              <Clock className="w-3 h-3 text-gray-500" />
-              <span className="text-xs text-gray-400">
-                Requested {getTimeAgo(user.verificationRequestedAt)}
-              </span>
+            <div className="mt-2 flex items-center gap-2 text-xs text-white/60">
+              <Clock className="h-4 w-4 text-white/35" />
+              <span>Requested {getTimeAgo(user.verificationRequestedAt)}</span>
             </div>
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          {hasAllDocs ? (
-            <div className="flex items-center gap-2 text-green-500">
-              <Upload className="w-4 h-4" />
-              <span className="text-xs font-medium">Docs Complete</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-2 text-yellow-500">
-              <Upload className="w-4 h-4" />
-              <span className="text-xs font-medium">Docs Incomplete</span>
-            </div>
-          )}
-          <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-[#ff950e] transition-colors" />
+        <div className="flex items-center gap-4">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] transition ${
+              hasAllDocs
+                ? 'border-emerald-400/40 bg-emerald-400/10 text-emerald-200'
+                : 'border-amber-400/40 bg-amber-400/10 text-amber-200'
+            }`}
+          >
+            <Upload className="h-4 w-4" />
+            {hasAllDocs ? 'Docs Complete' : 'Docs Pending'}
+          </span>
+          <ChevronRight className="h-5 w-5 text-white/40 transition-colors group-hover:text-[#ff950e]" />
         </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/src/components/admin/verification/VerificationHeader.tsx
+++ b/src/components/admin/verification/VerificationHeader.tsx
@@ -6,17 +6,22 @@ import type { VerificationHeaderProps } from '@/types/verification';
 
 export default function VerificationHeader({ onRefresh }: VerificationHeaderProps) {
   return (
-    <header className="sticky top-0 z-30 bg-black bg-opacity-90 backdrop-blur-sm border-b border-[#2a2a2a] shadow-md">
-      <div className="max-w-7xl mx-auto px-4 md:px-6 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div className="flex items-center">
-          <Shield className="w-6 h-6 text-[#ff950e] mr-3" />
-          <h1 className="text-xl font-bold text-white">Verification Center</h1>
+    <header className="sticky top-0 z-30 border-b border-white/5 bg-[#050505]/95 backdrop-blur">
+      <div className="max-w-7xl mx-auto flex flex-col gap-4 px-4 md:px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/15">
+            <Shield className="h-5 w-5 text-[#ff950e]" />
+          </div>
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.35em] text-white/40">Admin</p>
+            <h1 className="text-2xl font-semibold text-white">Verification Center</h1>
+          </div>
         </div>
         {typeof onRefresh === 'function' && (
           <button
             type="button"
             onClick={() => { onRefresh(); }}
-            className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white hover:bg-[#222] transition flex items-center gap-2"
+            className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-[#ff950e]/60 hover:text-[#ff950e]"
             aria-label="Refresh verification list"
           >
             <RefreshCw size={16} />

--- a/src/components/admin/verification/VerificationList.tsx
+++ b/src/components/admin/verification/VerificationList.tsx
@@ -34,12 +34,12 @@ export default function VerificationList({
 
   if (!Array.isArray(users) || users.length === 0) {
     return (
-      <div className="max-w-7xl mx-auto px-4 md:px-6">
-        <div className="bg-[#0e0e0e] border border-[#222] rounded-xl p-8 text-center">
+      <section className="max-w-7xl mx-auto px-4 md:px-6">
+        <div className="rounded-2xl border border-white/5 bg-black/40 px-8 py-12 text-center">
           {searchTerm ? (
             <>
-              <AlertCircle className="w-12 h-12 text-gray-500 mx-auto mb-3" />
-              <p className="text-gray-400">
+              <AlertCircle className="mx-auto mb-4 h-12 w-12 text-white/30" />
+              <p className="text-sm text-white/60">
                 No pending verification requests found for "
                 <SecureMessageDisplay
                   content={searchTerm}
@@ -51,20 +51,20 @@ export default function VerificationList({
             </>
           ) : (
             <>
-              <Shield className="w-12 h-12 text-gray-500 mx-auto mb-3" />
-              <p className="text-gray-400">
+              <Shield className="mx-auto mb-4 h-12 w-12 text-white/30" />
+              <p className="text-sm text-white/60">
                 No pending verification requests at the moment
               </p>
             </>
           )}
         </div>
-      </div>
+      </section>
     );
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 md:px-6">
-      <div className="space-y-4">
+    <section className="max-w-7xl mx-auto px-4 md:px-6">
+      <div className="space-y-3">
         {users.map((user) => (
           <VerificationCard
             key={user.username}
@@ -74,6 +74,6 @@ export default function VerificationList({
           />
         ))}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/admin/verification/VerificationSearch.tsx
+++ b/src/components/admin/verification/VerificationSearch.tsx
@@ -33,59 +33,54 @@ export default function VerificationSearch({
   }, [pendingCount]);
 
   return (
-    <div className="max-w-7xl mx-auto px-4 md:px-6 py-6">
-      {/* Search Bar */}
-      <div className="mb-6">
-        <div className="relative max-w-md">
-          <Search className="absolute left-3 top-3 text-gray-500 w-4 h-4 z-10" aria-hidden="true" />
-          <SecureInput
-            type="text"
-            placeholder="Search username..."
-            aria-label="Search username"
-            value={searchTerm}
-            onChange={handleSearchChange}
-            className="w-full bg-[#121212] border border-[#2a2a2a] text-white rounded-lg pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-[#ff950e] focus:border-[#ff950e] transition-all"
-            maxLength={100}
-            sanitize={true}
-            sanitizer={sanitizeSearchQuery}
-          />
-        </div>
-      </div>
+    <section className="max-w-7xl mx-auto px-4 md:px-6">
+      <div className="rounded-2xl border border-white/5 bg-black/40 px-6 py-6 shadow-[0_18px_36px_-28px_rgba(0,0,0,0.8)] md:px-8 md:py-8">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="w-full lg:max-w-xl">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" aria-hidden="true" />
+              <SecureInput
+                type="text"
+                placeholder="Search by username"
+                aria-label="Search username"
+                value={searchTerm}
+                onChange={handleSearchChange}
+                className="w-full rounded-xl border border-white/10 bg-black/60 py-3 pl-11 pr-4 text-sm text-gray-100 placeholder:text-white/35 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40 transition"
+                maxLength={100}
+                sanitize={true}
+                sanitizer={sanitizeSearchQuery}
+              />
+            </div>
+          </div>
 
-      {/* Control Panel */}
-      <div className="mb-6 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <div>
-          <h2 className="text-2xl font-bold text-[#ff950e] flex items-center">
-            <UserCheck className="mr-2 h-6 w-6" aria-hidden="true" />
-            Pending Verifications
-            <span
-              className="ml-3 text-sm bg-[#1f1f1f] text-gray-300 rounded-full px-3 py-1 font-normal"
-              aria-label={`${safePending} ${safePending === 1 ? 'request' : 'requests'}`}
-            >
-              {safePending} {safePending === 1 ? 'request' : 'requests'}
-            </span>
-          </h2>
-          <p className="text-gray-400 text-sm mt-1">
-            Review and validate seller identity documents
-          </p>
+          <div className="flex flex-col items-start gap-4 text-left sm:flex-row sm:items-center sm:gap-6">
+            <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.18em] text-white/70">
+              <UserCheck className="h-4 w-4 text-[#ff950e]" aria-hidden="true" />
+              {safePending} {safePending === 1 ? 'Request' : 'Requests'}
+            </div>
+            <div className="flex items-center gap-3">
+              <label htmlFor="verification-sort" className="text-xs font-medium uppercase tracking-[0.2em] text-white/40">
+                Sort
+              </label>
+              <select
+                id="verification-sort"
+                value={sortBy}
+                onChange={handleSortChange}
+                className="rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-sm text-white/80 transition focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
+                aria-label="Sort pending verifications"
+              >
+                <option value="newest">Newest first</option>
+                <option value="oldest">Oldest first</option>
+                <option value="alphabetical">Alphabetical</option>
+              </select>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-3">
-          <label htmlFor="verification-sort" className="text-gray-400 text-sm">
-            Sort by:
-          </label>
-          <select
-            id="verification-sort"
-            value={sortBy}
-            onChange={handleSortChange}
-            className="bg-[#1a1a1a] border border-[#2a2a2a] text-white rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-[#ff950e] cursor-pointer"
-            aria-label="Sort pending verifications"
-          >
-            <option value="newest">Newest first</option>
-            <option value="oldest">Oldest first</option>
-            <option value="alphabetical">Alphabetical</option>
-          </select>
-        </div>
+
+        <p className="mt-6 max-w-2xl text-sm text-white/50">
+          Review and validate documentation quickly. Use search and sorting to prioritise the requests that need your attention first.
+        </p>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/admin/verification/VerificationStats.tsx
+++ b/src/components/admin/verification/VerificationStats.tsx
@@ -19,32 +19,55 @@ export default function VerificationStats({ stats }: VerificationStatsProps) {
   }), [stats]);
 
   return (
-    <div className="max-w-7xl mx-auto px-4 md:px-6 mb-6">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-          <FileCheck className="mx-auto mb-2 text-[#ff950e]" size={20} aria-hidden="true" />
-          <div className="text-2xl font-bold text-white">{totals.total}</div>
-          <div className="text-xs text-gray-400">Total Pending</div>
-        </div>
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-          <Clock className="mx-auto mb-2 text-blue-400" size={20} aria-hidden="true" />
-          <div className="text-2xl font-bold text-blue-400">{totals.today}</div>
-          <div className="text-xs text-gray-400">Today</div>
-        </div>
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-          <Calendar className="mx-auto mb-2 text-purple-400" size={20} aria-hidden="true" />
-          <div className="text-2xl font-bold text-purple-400">{totals.thisWeek}</div>
-          <div className="text-xs text-gray-400">This Week</div>
-        </div>
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-          <Timer className="mx-auto mb-2 text-green-400" size={20} aria-hidden="true" />
-          <div className="text-2xl font-bold text-green-400">
-            {totals.avgHours}
-            <span className="text-sm ml-1">h</span>
+    <section className="max-w-7xl mx-auto px-4 md:px-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="group rounded-2xl border border-white/5 bg-black/40 p-5 transition hover:border-[#ff950e]/50">
+          <div className="flex items-center justify-between">
+            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/40">Total</span>
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-[#ff950e]/40 bg-[#ff950e]/15 text-[#ff950e]">
+              <FileCheck className="h-4 w-4" aria-hidden="true" />
+            </span>
           </div>
-          <div className="text-xs text-gray-400">Avg Processing</div>
+          <p className="mt-4 text-3xl font-semibold text-white">{totals.total}</p>
+          <p className="mt-2 text-sm text-white/50">Pending verifications</p>
+        </div>
+
+        <div className="group rounded-2xl border border-white/5 bg-black/40 p-5 transition hover:border-sky-400/60">
+          <div className="flex items-center justify-between">
+            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/40">Today</span>
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-sky-400/40 bg-sky-400/10 text-sky-400">
+              <Clock className="h-4 w-4" aria-hidden="true" />
+            </span>
+          </div>
+          <p className="mt-4 text-3xl font-semibold text-sky-300">{totals.today}</p>
+          <p className="mt-2 text-sm text-white/50">Requests received</p>
+        </div>
+
+        <div className="group rounded-2xl border border-white/5 bg-black/40 p-5 transition hover:border-purple-400/60">
+          <div className="flex items-center justify-between">
+            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/40">This week</span>
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-purple-400/40 bg-purple-400/10 text-purple-300">
+              <Calendar className="h-4 w-4" aria-hidden="true" />
+            </span>
+          </div>
+          <p className="mt-4 text-3xl font-semibold text-purple-200">{totals.thisWeek}</p>
+          <p className="mt-2 text-sm text-white/50">Submitted in the last 7 days</p>
+        </div>
+
+        <div className="group rounded-2xl border border-white/5 bg-black/40 p-5 transition hover:border-emerald-400/60">
+          <div className="flex items-center justify-between">
+            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/40">Average time</span>
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-emerald-400/40 bg-emerald-400/10 text-emerald-300">
+              <Timer className="h-4 w-4" aria-hidden="true" />
+            </span>
+          </div>
+          <p className="mt-4 text-3xl font-semibold text-emerald-200">
+            {totals.avgHours}
+            <span className="ml-1 text-base font-medium text-emerald-200/70">h</span>
+          </p>
+          <p className="mt-2 text-sm text-white/50">To approve or reject</p>
         </div>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the admin verification requests page container with simplified dark background and refined empty, loading, and processing states
- update the verification header, search controls, stats tiles, list, and cards with a more modern minimal treatment that matches the site aesthetic

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated context files)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d32ca4608328bffcc9e826d9bae4