### PR TITLE
Update message send button to themed arrow icon

### DIFF
--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -20,7 +20,8 @@ import {
   User,
   MoreVertical,
   Ban,
-  Flag
+  Flag,
+  ArrowUp
 } from 'lucide-react';
 import MessageItem from './MessageItem';
 import TypingIndicator from '@/components/messaging/TypingIndicator';
@@ -726,6 +727,8 @@ export default function ConversationView(props: ConversationViewProps) {
     </>
   );
 
+  const canSend = (!!replyMessage.trim() || !!selectedImage) && !isImageLoading;
+
   // Render composer
   const renderComposer = () => (
     <>
@@ -770,7 +773,7 @@ export default function ConversationView(props: ConversationViewProps) {
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="w-full p-3 pr-12 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="w-full p-3 pr-28 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -778,31 +781,48 @@ export default function ConversationView(props: ConversationViewProps) {
             aria-label="Message"
           />
 
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowEmojiPicker(!showEmojiPicker);
-            }}
-            className={`absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center justify-center h-8 w-8 rounded-full ${
-              showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
-            } transition-colors duration-150`}
-            title="Emoji"
-            type="button"
-            aria-label="Toggle emoji picker"
-          >
-            <Smile size={20} className="flex-shrink-0" />
-          </button>
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowEmojiPicker(!showEmojiPicker);
+              }}
+              className={`flex items-center justify-center h-8 w-8 rounded-full ${
+                showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
+              } transition-colors duration-150`}
+              title="Emoji"
+              type="button"
+              aria-label="Toggle emoji picker"
+            >
+              <Smile size={20} className="flex-shrink-0" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!canSend) return;
+                setShowEmojiPicker(false);
+                stableHandleReply();
+              }}
+              className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
+                canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+              }`}
+              aria-label="Send message"
+              disabled={!canSend}
+            >
+              <ArrowUp size={18} strokeWidth={2.5} />
+            </button>
+          </div>
         </div>
 
         {replyMessage.length > 0 && (
           <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
         )}
 
-        <div className="flex justify-between items-center">
-          <div className="flex items-center gap-0">
-            <img
-              src="/Send_Tip_Icon.png"
-              alt="Send Tip"
+        <div className="flex items-center gap-0">
+          <img
+            src="/Send_Tip_Icon.png"
+            alt="Send Tip"
               className="w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity"
               onClick={(e) => {
                 e.stopPropagation();
@@ -844,20 +864,6 @@ export default function ConversationView(props: ConversationViewProps) {
               style={{ display: 'none' }}
               onChange={stableHandleImageSelect}
             />
-          </div>
-
-          <img
-            src="/Send_Button.png"
-            alt="Send"
-            onClick={(e) => {
-              e.stopPropagation();
-              stableHandleReply();
-            }}
-            className={`cursor-pointer hover:opacity-90 transition-opacity h-11 ${
-              (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-            }`}
-            style={{ pointerEvents: (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'none' : 'auto' }}
-          />
         </div>
       </div>
 

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { forwardRef, useState, useCallback } from 'react';
-import { AlertTriangle, X, Smile, ShieldAlert } from 'lucide-react';
+import { AlertTriangle, X, Smile, ShieldAlert, ArrowUp } from 'lucide-react';
 import { SecureTextarea } from '@/components/ui/SecureInput';
 import { securityService } from '@/services/security.service';
 import { sanitizeStrict } from '@/utils/security/sanitization';
@@ -49,6 +49,8 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
     },
     ref
   ) => {
+    const canSend = (!!replyMessage.trim() || !!selectedImage) && !isImageLoading;
+
     const [validationError, setValidationError] = useState<string | null>(null);
 
     // Secure image selection with validation
@@ -153,28 +155,46 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               onChange={setReplyMessage}
               onKeyDown={onKeyDown}
               placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-              className="w-full p-3 pr-12 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-1 focus:ring-[#ff950e] min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
+              className="w-full p-3 pr-28 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-1 focus:ring-[#ff950e] min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
               rows={1}
               maxLength={250}
               characterCount={false}
               sanitize={true}
             />
 
-            {/* Emoji button */}
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowEmojiPicker(!showEmojiPicker);
-              }}
-              className={`absolute right-3 top-1/2 transform -translate-y-1/2 mt-[-4px] flex items-center justify-center h-8 w-8 rounded-full ${
-                showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
-              } transition-colors duration-150`}
-              title="Emoji"
-              type="button"
-              aria-pressed={showEmojiPicker}
-            >
-              <Smile size={20} className="flex-shrink-0" />
-            </button>
+            <div className="absolute right-3 top-1/2 transform -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+              {/* Emoji button */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowEmojiPicker(!showEmojiPicker);
+                }}
+                className={`flex items-center justify-center h-8 w-8 rounded-full ${
+                  showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
+                } transition-colors duration-150`}
+                title="Emoji"
+                type="button"
+                aria-pressed={showEmojiPicker}
+              >
+                <Smile size={20} className="flex-shrink-0" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!canSend) return;
+                  setShowEmojiPicker(false);
+                  onReply();
+                }}
+                className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
+                  canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+                }`}
+                aria-label="Send message"
+                disabled={!canSend}
+              >
+                <ArrowUp size={18} strokeWidth={2.5} />
+              </button>
+            </div>
           </div>
 
           {/* Character count */}
@@ -183,7 +203,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
           )}
 
           {/* Bottom row with attachment and send buttons */}
-          <div className="flex justify-between items-center">
+          <div className="flex items-center gap-0">
             {/* Attachment button */}
             <img
               src="/Attach_Image_Icon.png"
@@ -206,21 +226,6 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               ref={fileInputRef}
               style={{ display: 'none' }}
               onChange={handleSecureImageSelect}
-            />
-
-            {/* Send Button */}
-            <img
-              src="/Send_Button.png"
-              alt="Send"
-              onClick={(e) => {
-                e.stopPropagation();
-                onReply();
-              }}
-              className={`cursor-pointer hover:opacity-90 transition-opacity h-11 ${
-                (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              style={{ pointerEvents: (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'none' : 'auto' }}
-              title="Send message"
             />
           </div>
         </div>

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { X, Smile, AlertTriangle, ShieldAlert } from 'lucide-react';
+import { X, Smile, AlertTriangle, ShieldAlert, ArrowUp } from 'lucide-react';
 import { SecureTextarea } from '@/components/ui/SecureInput';
 import { SecureImage } from '@/components/ui/SecureMessageDisplay';
 import { sanitizeStrict } from '@/utils/security/sanitization';
@@ -90,6 +90,8 @@ export default function MessageInputContainer({
     handleImageSelect(file);
   }, [handleImageSelect, setImageError]);
 
+  const canSend = (!!replyMessage.trim() || !!selectedImage) && !isImageLoading;
+
   if (isUserBlocked) {
     return (
       <div className="p-4 text-center text-sm text-red-400 flex items-center justify-center">
@@ -157,37 +159,53 @@ export default function MessageInputContainer({
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="w-full p-3 pr-12 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="w-full p-3 pr-28 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
             characterCount={false}
             aria-label="Message"
           />
-
-          {/* Emoji button integrated in textarea */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowEmojiPicker(!showEmojiPicker);
-            }}
-            className={`absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center justify-center h-8 w-8 rounded-full ${
-              showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
-            } transition-colors duration-150`}
-            title="Emoji"
-            type="button"
-            aria-label="Toggle emoji picker"
-          >
-            <Smile size={20} className="flex-shrink-0" />
-          </button>
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+            {/* Emoji button integrated in textarea */}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowEmojiPicker(!showEmojiPicker);
+              }}
+              className={`flex items-center justify-center h-8 w-8 rounded-full ${
+                showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
+              } transition-colors duration-150`}
+              title="Emoji"
+              type="button"
+              aria-label="Toggle emoji picker"
+            >
+              <Smile size={20} className="flex-shrink-0" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!canSend) return;
+                setShowEmojiPicker(false);
+                handleReply();
+              }}
+              className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
+                canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+              }`}
+              aria-label="Send message"
+              disabled={!canSend}
+            >
+              <ArrowUp size={18} strokeWidth={2.5} />
+            </button>
+          </div>
         </div>
 
         {replyMessage.length > 0 && (
           <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
         )}
 
-        <div className="flex justify-between items-center">
-          <div className="flex items-center gap-0">
+        <div className="flex items-center gap-0">
             {/* Attach image button */}
             <img
               src="/Attach_Image_Icon.png"
@@ -211,21 +229,6 @@ export default function MessageInputContainer({
               style={{ display: 'none' }}
               onChange={handleImageSelectFromInput}
             />
-          </div>
-
-          {/* Send button */}
-          <img
-            src="/Send_Button.png"
-            alt="Send"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleReply();
-            }}
-            className={`cursor-pointer hover:opacity-90 transition-opacity h-11 ${
-              (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-            }`}
-            style={{ pointerEvents: (!replyMessage.trim() && !selectedImage) || isImageLoading ? 'none' : 'auto' }}
-          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- replace the legacy image-based send button with an arrow icon styled to match the site theme
- embed the new send control next to the emoji toggle inside the chat input for buyers and sellers
- reuse the same inline send control in the seller message container component for consistency

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f2e8a1a30c832892e32deef0229ecb