### PR TITLE
Adjust message send button styling

### DIFF
--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -210,15 +210,15 @@ const MessageInput: React.FC<MessageInputProps> = ({
             type="button"
             onClick={handleSend}
             disabled={disabled || (!content.trim() && !selectedImage) || isUploading}
-            className={`px-4 py-2 rounded-full flex items-center gap-2 transition-colors ${
+            className={`px-3 py-2 rounded-lg flex items-center justify-center transition-colors text-sm font-medium ${
               disabled || (!content.trim() && !selectedImage) || isUploading
                 ? 'bg-[#333] text-gray-500 cursor-not-allowed'
                 : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
             }`}
             aria-label="Send message"
           >
-            <Send size={18} />
-            Send
+            <Send size={16} />
+            <span className="sr-only">Send</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the shared message input send button to use a smaller, rounded-rectangle style
- ensure the button retains accessibility by keeping an assistive "Send" label for screen readers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2edff219883288e0203913208fc0e