### PR TITLE
style: restyle message send button

### DIFF
--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -459,12 +459,14 @@ export default function ChatContent({
                   onSend();
                 }}
                 disabled={!canSend}
-                className={`flex items-center justify-center px-5 py-2 rounded-full ${
-                  canSend ? 'bg-[#ff950e] text-black hover:bg-[#e88800]' : 'bg-[#c17200] cursor-not-allowed text-gray-300'
-                } transition-colors duration-150 shadow-md`}
+                className={`flex items-center justify-center gap-2 px-4 py-1.5 rounded-2xl transition-colors duration-150 shadow-md text-sm font-semibold ${
+                  canSend
+                    ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
+                    : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
+                }`}
                 type="button"
               >
-                <span className="mr-1">Send</span>
+                <span>Send</span>
                 <ArrowRightCircle size={16} className="flex-shrink-0" />
               </button>
             </div>

--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -804,13 +804,15 @@ export default function ConversationView(props: ConversationViewProps) {
                 setShowEmojiPicker(false);
                 stableHandleReply();
               }}
-              className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
-                canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+              className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
+                canSend
+                  ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                  : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
               }`}
               aria-label="Send message"
               disabled={!canSend}
             >
-              <ArrowUp size={18} strokeWidth={2.5} />
+              <ArrowUp size={16} strokeWidth={2.5} />
             </button>
           </div>
         </div>

--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -137,10 +137,14 @@ export default function MessageInput({
         <button
           onClick={handleReply}
           disabled={!replyMessage.trim() && !selectedImage}
-          className="p-2 bg-[#ff950e] text-black rounded-lg hover:bg-[#e88800] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-2xl transition-colors text-sm font-semibold ${
+            !replyMessage.trim() && !selectedImage
+              ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
+              : 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
+          }`}
           aria-label="Send message"
         >
-          <Send size={20} />
+          <Send size={18} />
         </button>
       </div>
 

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -210,10 +210,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
             type="button"
             onClick={handleSend}
             disabled={disabled || (!content.trim() && !selectedImage) || isUploading}
-            className={`px-3 py-2 rounded-lg flex items-center justify-center transition-colors text-sm font-medium ${
+            className={`flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-2xl transition-colors text-sm font-semibold ${
               disabled || (!content.trim() && !selectedImage) || isUploading
-                ? 'bg-[#333] text-gray-500 cursor-not-allowed'
-                : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
+                ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
+                : 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
             }`}
             aria-label="Send message"
           >

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -186,13 +186,15 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
                   setShowEmojiPicker(false);
                   onReply();
                 }}
-                className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
-                  canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+                className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
+                  canSend
+                    ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                    : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
                 }`}
                 aria-label="Send message"
                 disabled={!canSend}
               >
-                <ArrowUp size={18} strokeWidth={2.5} />
+                <ArrowUp size={16} strokeWidth={2.5} />
               </button>
             </div>
           </div>

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -190,13 +190,15 @@ export default function MessageInputContainer({
                 setShowEmojiPicker(false);
                 handleReply();
               }}
-              className={`flex items-center justify-center h-9 w-9 rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e] ${
-                canSend ? 'bg-[#ff950e] text-black hover:bg-[#ffac3b]' : 'bg-[#333] text-gray-500 cursor-not-allowed'
+              className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
+                canSend
+                  ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                  : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
               }`}
               aria-label="Send message"
               disabled={!canSend}
             >
-              <ArrowUp size={18} strokeWidth={2.5} />
+              <ArrowUp size={16} strokeWidth={2.5} />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle send buttons across messaging flows to use a compact rounded-rectangle shape inspired by iMessage
- align buyer, seller, and admin message controls on the updated blue theme with consistent hover and disabled states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f300dbfb30832895a390820d2d60e8