### PR TITLE
Handle Safari page restores for message refresh

### DIFF
--- a/src/hooks/useBuyerMessages.ts
+++ b/src/hooks/useBuyerMessages.ts
@@ -180,8 +180,8 @@ export const useBuyerMessages = () => {
     let isRefreshing = false;
     let lastRefresh = 0;
 
-    const refreshIfVisible = async () => {
-      if (document.visibilityState !== 'visible') {
+    const refreshIfVisible = async (force = false) => {
+      if (!force && document.visibilityState !== 'visible') {
         return;
       }
 
@@ -209,12 +209,18 @@ export const useBuyerMessages = () => {
       void refreshIfVisible();
     };
 
+    const handlePageShow = () => {
+      void refreshIfVisible(true);
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('focus', handleFocus);
+    window.addEventListener('pageshow', handlePageShow);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('pageshow', handlePageShow);
     };
   }, [mounted, refreshMessages]);
   

--- a/src/hooks/useSellerMessages.ts
+++ b/src/hooks/useSellerMessages.ts
@@ -161,8 +161,8 @@ export function useSellerMessages() {
     let isRefreshing = false;
     let lastRefresh = 0;
 
-    const refreshIfVisible = async () => {
-      if (document.visibilityState !== 'visible') {
+    const refreshIfVisible = async (force = false) => {
+      if (!force && document.visibilityState !== 'visible') {
         return;
       }
 
@@ -190,12 +190,18 @@ export function useSellerMessages() {
       void refreshIfVisible();
     };
 
+    const handlePageShow = () => {
+      void refreshIfVisible(true);
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('focus', handleFocus);
+    window.addEventListener('pageshow', handlePageShow);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('pageshow', handlePageShow);
     };
   }, [mounted, refreshMessages]);
   


### PR DESCRIPTION
## Summary
- refresh buyer and seller messaging hooks when Safari restores the tab from the background
- allow the visibility refresh helper to force a fetch so bfcache restores bypass visibility throttling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3262bfc0c8328b80d86c30c17ca84