### PR TITLE
Fix header profile image resolution

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,6 +33,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { storageService } from '@/services';
 import { SecureMessageDisplay, SecureImage } from '@/components/ui/SecureMessageDisplay';
 import { sanitizeStrict, sanitizeUrl } from '@/utils/security/sanitization';
+import { resolveApiUrl } from '@/utils/url';
 import { isAdmin } from '@/utils/security/permissions';
 import { useNotifications } from '@/context/NotificationContext';
 import { HeaderSearch } from '@/components/HeaderSearch';
@@ -132,7 +133,11 @@ export default function Header(): React.ReactElement | null {
     }
 
     const sanitized = sanitizeUrl(user.profilePicture);
-    return sanitized || null;
+    if (!sanitized) {
+      return null;
+    }
+
+    return resolveApiUrl(sanitized) ?? sanitized;
   }, [user?.profilePicture]);
   const canDisplayUserAvatar = role === 'buyer' || role === 'seller';
   const profileAvatarSrc = canDisplayUserAvatar

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -4,7 +4,8 @@
 import { memo, useState, useRef, useEffect, useCallback } from 'react';
 import { Search, X, Loader2 } from 'lucide-react';
 import { usersService } from '@/services';
-import { sanitizeStrict, sanitizeSearchQuery } from '@/utils/security/sanitization';
+import { sanitizeStrict, sanitizeSearchQuery, sanitizeUrl } from '@/utils/security/sanitization';
+import { resolveApiUrl } from '@/utils/url';
 
 type SearchUserResult = {
   username: string;
@@ -167,8 +168,13 @@ export const HeaderSearch = memo(function HeaderSearch({
                 return null;
               }
 
-              const picture = rawUser.profilePicture ||
+              const pictureRaw = rawUser.profilePicture ||
                 (rawUser as any)?.profilePic || null;
+              const sanitizedPicture =
+                typeof pictureRaw === 'string' ? sanitizeUrl(pictureRaw) : '';
+              const resolvedPicture = sanitizedPicture
+                ? resolveApiUrl(sanitizedPicture) ?? sanitizedPicture
+                : null;
               const pictureUpdatedRaw =
                 (rawUser as any)?.profilePictureUpdatedAt ??
                 (rawUser as any)?.profilePicUpdatedAt ??
@@ -183,7 +189,7 @@ export const HeaderSearch = memo(function HeaderSearch({
               return {
                 username: safeUsername,
                 role: rawUser.role,
-                profilePicture: picture,
+                profilePicture: resolvedPicture,
                 profilePictureUpdatedAt: pictureUpdatedAt,
                 isVerified: verified,
               } as SearchUserResult;


### PR DESCRIPTION
## Summary
- resolve profile avatar URLs in the header so relative uploads render correctly
- sanitize and resolve user avatar URLs in the header search results

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a362f568832887a758df3f3ba71a