### PR TITLE
Apply orange theme to messaging send buttons

### DIFF
--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -461,7 +461,7 @@ export default function ChatContent({
                 disabled={!canSend}
                 className={`flex items-center justify-center gap-2 px-4 py-1.5 rounded-2xl transition-colors duration-150 shadow-md text-sm font-semibold ${
                   canSend
-                    ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
+                    ? 'bg-[#ff950e] text-black hover:bg-[#e88800]'
                     : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
                 }`}
                 type="button"

--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -806,7 +806,7 @@ export default function ConversationView(props: ConversationViewProps) {
               }}
               className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
                 canSend
-                  ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                  ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
               }`}
               aria-label="Send message"

--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -140,7 +140,7 @@ export default function MessageInput({
           className={`flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-2xl transition-colors text-sm font-semibold ${
             !replyMessage.trim() && !selectedImage
               ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
-              : 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
+              : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
           }`}
           aria-label="Send message"
         >

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -213,7 +213,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
             className={`flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-2xl transition-colors text-sm font-semibold ${
               disabled || (!content.trim() && !selectedImage) || isUploading
                 ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
-                : 'bg-[#0a84ff] text-white hover:bg-[#0071e3]'
+                : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
             }`}
             aria-label="Send message"
           >

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -188,7 +188,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
                 }}
                 className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
                   canSend
-                    ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                    ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                     : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
                 }`}
                 aria-label="Send message"

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -192,7 +192,7 @@ export default function MessageInputContainer({
               }}
               className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
                 canSend
-                  ? 'bg-[#0a84ff] text-white hover:bg-[#0071e3] focus:ring-[#0a84ff]'
+                  ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
               }`}
               aria-label="Send message"


### PR DESCRIPTION
## Summary
- update send button styling across messaging inputs to use the site's orange color scheme
- ensure hover and focus states reflect the orange theme for admin, buyer, and seller messaging views

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4583f91bc832886b1faded6bd0645