### PR TITLE
Move chat image upload controls inline

### DIFF
--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -8,13 +8,13 @@ import {
   X,
   Paperclip,
   Smile,
-  Image as ImageIcon,
   ShieldAlert,
   AlertTriangle,
   Clock,
   BadgeCheck,
   MessageCircle,
-  MessageSquarePlus
+  MessageSquarePlus,
+  Plus
 } from 'lucide-react';
 import ImagePreviewModal from '@/components/messaging/ImagePreviewModal';
 import { Message } from '@/types/message';
@@ -384,28 +384,53 @@ export default function ChatContent({
                 onChange={setContent}
                 onKeyDown={handleKeyDown}
                 placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-                className="w-full p-3 pr-12 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-1 focus:ring-[#ff950e] min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
+                className="w-full p-3 pr-24 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-1 focus:ring-[#ff950e] min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
                 rows={1}
                 maxLength={250}
                 characterCount={false}
                 sanitize
               />
 
-              {/* Emoji button */}
-              <button
-                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-                  setShowEmojiPicker((v) => !v);
-                }}
-                className={`absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center justify-center h-8 w-8 rounded-full ${
-                  showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
-                } transition-colors duration-150`}
-                title="Emoji"
-                type="button"
-                aria-pressed={showEmojiPicker}
-              >
-                <Smile size={20} className="flex-shrink-0" />
-              </button>
+              <input
+                type="file"
+                accept={ALLOWED_IMAGE_TYPES.join(',')}
+                ref={fileInputRef}
+                style={{ display: 'none' }}
+                onChange={handleImageSelect}
+              />
+
+              <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+                <button
+                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                    e.stopPropagation();
+                    if (isImageLoading) return;
+                    triggerFileInput();
+                  }}
+                  className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Attach Image"
+                  aria-label="Attach image"
+                  type="button"
+                  disabled={isImageLoading}
+                >
+                  <Plus size={18} />
+                </button>
+
+                {/* Emoji button */}
+                <button
+                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                    e.stopPropagation();
+                    setShowEmojiPicker((v) => !v);
+                  }}
+                  className={`flex items-center justify-center h-8 w-8 rounded-full ${
+                    showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
+                  } transition-colors duration-150`}
+                  title="Emoji"
+                  type="button"
+                  aria-pressed={showEmojiPicker}
+                >
+                  <Smile size={20} className="flex-shrink-0" />
+                </button>
+              </div>
             </div>
 
             {content.length > 0 && <div className="text-xs text-gray-400 mb-2 text-right">{content.length}/250</div>}
@@ -413,22 +438,6 @@ export default function ChatContent({
             {/* Actions */}
             <div className="flex justify-between items-center">
               <div className="flex items-center gap-4">
-                <button
-                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                    e.stopPropagation();
-                    triggerFileInput();
-                  }}
-                  disabled={isImageLoading}
-                  className={`w-[52px] h-[52px] flex items-center justify-center rounded-full shadow-md ${
-                    isImageLoading ? 'bg-gray-700 text-gray-500 cursor-not-allowed' : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
-                  } transition-colors duration-150`}
-                  title="Attach Image"
-                  aria-label="Attach Image"
-                  type="button"
-                >
-                  <ImageIcon size={26} />
-                </button>
-
                 <button
                   onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                     e.stopPropagation();
@@ -443,14 +452,6 @@ export default function ChatContent({
                 >
                   <Smile size={26} />
                 </button>
-
-                <input
-                  type="file"
-                  accept={ALLOWED_IMAGE_TYPES.join(',')}
-                  ref={fileInputRef}
-                  style={{ display: 'none' }}
-                  onChange={handleImageSelect}
-                />
               </div>
 
               <button

--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -21,7 +21,8 @@ import {
   MoreVertical,
   Ban,
   Flag,
-  ArrowUp
+  ArrowUp,
+  Plus
 } from 'lucide-react';
 import MessageItem from './MessageItem';
 import TypingIndicator from '@/components/messaging/TypingIndicator';
@@ -781,7 +782,29 @@ export default function ConversationView(props: ConversationViewProps) {
             aria-label="Message"
           />
 
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={stableHandleImageSelect}
+          />
+
           <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (isImageLoading) return;
+                triggerFileInput();
+              }}
+              className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Attach Image"
+              type="button"
+              aria-label="Attach image"
+              disabled={isImageLoading}
+            >
+              <Plus size={18} />
+            </button>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -834,20 +857,6 @@ export default function ConversationView(props: ConversationViewProps) {
             />
 
             <img
-              src="/Attach_Image_Icon.png"
-              alt="Attach Image"
-              className={`w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity ${
-                isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              onClick={(e) => {
-                if (isImageLoading) return;
-                e.stopPropagation();
-                triggerFileInput();
-              }}
-              title="Attach Image"
-            />
-
-            <img
               src="/Custom_Request_Icon.png"
               alt="Custom Request"
               className="w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity"
@@ -859,13 +868,6 @@ export default function ConversationView(props: ConversationViewProps) {
             />
 
             {/* Hidden file input with strict types */}
-            <input
-              type="file"
-              accept="image/jpeg,image/png,image/gif,image/webp"
-              ref={fileInputRef}
-              style={{ display: 'none' }}
-              onChange={stableHandleImageSelect}
-            />
         </div>
       </div>
 

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { forwardRef, useState, useCallback } from 'react';
-import { AlertTriangle, X, Smile, ShieldAlert, ArrowUp } from 'lucide-react';
+import { AlertTriangle, X, Smile, ShieldAlert, ArrowUp, Plus } from 'lucide-react';
 import { SecureTextarea } from '@/components/ui/SecureInput';
 import { securityService } from '@/services/security.service';
 import { sanitizeStrict } from '@/utils/security/sanitization';
@@ -162,7 +162,29 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               sanitize={true}
             />
 
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/gif,image/webp"
+              ref={fileInputRef}
+              style={{ display: 'none' }}
+              onChange={handleSecureImageSelect}
+            />
+
             <div className="absolute right-3 top-1/2 transform -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (isImageLoading) return;
+                  onImageClick();
+                }}
+                className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Attach image"
+                title="Attach Image"
+                disabled={isImageLoading}
+              >
+                <Plus size={18} />
+              </button>
               {/* Emoji button */}
               <button
                 onClick={(e) => {
@@ -203,33 +225,6 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
           {replyMessage.length > 0 && (
             <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
           )}
-
-          {/* Bottom row with attachment and send buttons */}
-          <div className="flex items-center gap-0">
-            {/* Attachment button */}
-            <img
-              src="/Attach_Image_Icon.png"
-              alt="Attach Image"
-              className={`w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity ${
-                isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              onClick={(e) => {
-                if (isImageLoading) return;
-                e.stopPropagation();
-                onImageClick();
-              }}
-              title="Attach Image"
-            />
-
-            {/* Hidden file input with secure constraints */}
-            <input
-              type="file"
-              accept="image/jpeg,image/png,image/gif,image/webp"
-              ref={fileInputRef}
-              style={{ display: 'none' }}
-              onChange={handleSecureImageSelect}
-            />
-          </div>
         </div>
       </div>
     );

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { X, Smile, AlertTriangle, ShieldAlert, ArrowUp } from 'lucide-react';
+import { X, Smile, AlertTriangle, ShieldAlert, ArrowUp, Plus } from 'lucide-react';
 import { SecureTextarea } from '@/components/ui/SecureInput';
 import { SecureImage } from '@/components/ui/SecureMessageDisplay';
 import { sanitizeStrict } from '@/utils/security/sanitization';
@@ -166,7 +166,28 @@ export default function MessageInputContainer({
             characterCount={false}
             aria-label="Message"
           />
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={handleImageSelectFromInput}
+          />
           <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (isImageLoading) return;
+                triggerFileInput();
+              }}
+              className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Attach image"
+              title="Attach Image"
+              disabled={isImageLoading}
+            >
+              <Plus size={18} />
+            </button>
             {/* Emoji button integrated in textarea */}
             <button
               onClick={(e) => {
@@ -206,32 +227,6 @@ export default function MessageInputContainer({
         {replyMessage.length > 0 && (
           <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
         )}
-
-        <div className="flex items-center gap-0">
-            {/* Attach image button */}
-            <img
-              src="/Attach_Image_Icon.png"
-              alt="Attach Image"
-              className={`w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity ${
-                isImageLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              onClick={(e) => {
-                if (isImageLoading) return;
-                e.stopPropagation();
-                triggerFileInput();
-              }}
-              title="Attach Image"
-            />
-
-            {/* Hidden file input */}
-            <input
-              type="file"
-              accept="image/jpeg,image/png,image/gif,image/webp"
-              ref={fileInputRef}
-              style={{ display: 'none' }}
-              onChange={handleImageSelectFromInput}
-            />
-        </div>
       </div>
 
       {/* Inline emoji picker */}


### PR DESCRIPTION
## Summary
- replace the external camera attachment icon with an inline grey plus button across seller, buyer, and admin message inputs
- connect the new inline button to existing image upload logic while keeping hidden file inputs within each message composer
- adjust spacing to accommodate the new control without affecting emoji or send actions

## Testing
- npm run lint *(fails: existing lint violations in unrelated context and util files)*

------
https://chatgpt.com/codex/tasks/task_e_68f45e71ed14832884b8020089a44ce2