### PR TITLE
Move chat attachment button to the left side of the composer

### DIFF
--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -764,7 +764,30 @@ export default function ConversationView(props: ConversationViewProps) {
 
       {/* Input */}
       <div className="px-4 py-3">
-        <div className="relative mb-2">
+        <div className="flex w-full items-end gap-3 rounded-lg border border-gray-700 bg-[#222] py-2 pl-2 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={stableHandleImageSelect}
+          />
+
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isImageLoading) return;
+              triggerFileInput();
+            }}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+            title="Attach Image"
+            type="button"
+            aria-label="Attach image"
+            disabled={isImageLoading}
+          >
+            <Plus size={18} />
+          </button>
+
           <SecureTextarea
             ref={inputRef}
             value={replyMessage}
@@ -774,7 +797,7 @@ export default function ConversationView(props: ConversationViewProps) {
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="w-full p-3 pr-28 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none py-3 text-white focus:!outline-none focus:!ring-0 min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -782,29 +805,7 @@ export default function ConversationView(props: ConversationViewProps) {
             aria-label="Message"
           />
 
-          <input
-            type="file"
-            accept="image/jpeg,image/png,image/gif,image/webp"
-            ref={fileInputRef}
-            style={{ display: 'none' }}
-            onChange={stableHandleImageSelect}
-          />
-
-          <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                if (isImageLoading) return;
-                triggerFileInput();
-              }}
-              className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-              title="Attach Image"
-              type="button"
-              aria-label="Attach image"
-              disabled={isImageLoading}
-            >
-              <Plus size={18} />
-            </button>
+          <div className="flex items-center gap-2">
             <button
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -159,13 +159,17 @@ const MessageInput: React.FC<MessageInputProps> = ({
       )}
 
       <div className="flex flex-col gap-2">
-        <div className="relative">
+        <div
+          className={`flex w-full items-end gap-3 rounded-lg border border-gray-700 bg-[#222] py-2 ${
+            showAttachmentButton ? 'pl-2 pr-3' : 'px-3'
+          } focus-within:border-transparent focus-within:ring-2 focus-within:ring-[#ff950e]`}
+        >
           {showAttachmentButton && (
             <>
               <button
                 type="button"
                 onClick={triggerFileInput}
-                className="absolute left-3 top-1/2 -translate-y-1/2 flex h-9 w-9 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-white transition-colors hover:bg-[#3a3a3a] focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-white transition-colors hover:bg-[#3a3a3a] focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={disabled || isUploading}
                 title="Attach Image"
                 aria-label="Attach image"
@@ -183,26 +187,26 @@ const MessageInput: React.FC<MessageInputProps> = ({
               />
             </>
           )}
-          <SecureTextarea
-            ref={textareaRef}
-            value={content}
-            onChange={setContent}
-            onKeyDown={handleKeyDown}
-            placeholder={selectedImage ? 'Add a caption...' : placeholder}
-            className={`w-full pr-10 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] min-h-[60px] resize-none ${
-              showAttachmentButton ? 'pl-14 py-3' : 'p-3'
-            }`}
-            rows={1}
-            maxLength={maxLength}
-            characterCount={false}
-            sanitize={true}
-            disabled={disabled}
-            aria-label="Message text"
-          />
-          <div className="absolute bottom-2 right-2">
-            <span className="text-xs text-gray-400">
+          <div className="relative flex-1">
+            <SecureTextarea
+              ref={textareaRef}
+              value={content}
+              onChange={setContent}
+              onKeyDown={handleKeyDown}
+              placeholder={selectedImage ? 'Add a caption...' : placeholder}
+              className={`w-full bg-transparent pr-12 text-white focus:outline-none focus:ring-0 min-h-[60px] resize-none ${
+                showAttachmentButton ? 'py-3' : 'py-3'
+              }`}
+              rows={1}
+              maxLength={maxLength}
+              characterCount={false}
+              sanitize={true}
+              disabled={disabled}
+              aria-label="Message text"
+            />
+            <div className="pointer-events-none absolute bottom-2 right-3 text-xs text-gray-400">
               {content.length}/{maxLength}
-            </span>
+            </div>
           </div>
         </div>
 

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -148,20 +148,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
 
         {/* Message input with security */}
         <div className="px-4 py-3">
-          <div className="relative mb-2">
-            <SecureTextarea
-              ref={ref}
-              value={replyMessage}
-              onChange={setReplyMessage}
-              onKeyDown={onKeyDown}
-              placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-              className="w-full py-3 pr-24 pl-14 rounded-lg bg-[#222] border border-gray-700 text-white focus:outline-none focus:ring-1 focus:ring-[#ff950e] min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
-              rows={1}
-              maxLength={250}
-              characterCount={false}
-              sanitize={true}
-            />
-
+          <div className="flex w-full items-end gap-3 rounded-lg border border-gray-700 bg-[#222] py-2 pl-2 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
             <input
               type="file"
               accept="image/jpeg,image/png,image/gif,image/webp"
@@ -177,7 +164,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
                 if (isImageLoading) return;
                 onImageClick();
               }}
-              className="absolute left-3 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Attach image"
               title="Attach Image"
               disabled={isImageLoading}
@@ -185,8 +172,20 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               <Plus size={18} />
             </button>
 
-            <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
-              {/* Emoji button */}
+            <SecureTextarea
+              ref={ref}
+              value={replyMessage}
+              onChange={setReplyMessage}
+              onKeyDown={onKeyDown}
+              placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
+              className="flex-1 bg-transparent py-3 text-white focus:outline-none focus:ring-0 min-h-[40px] max-h-20 resize-none overflow-auto leading-tight"
+              rows={1}
+              maxLength={250}
+              characterCount={false}
+              sanitize={true}
+            />
+
+            <div className="flex items-center gap-2">
               <button
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -149,7 +149,30 @@ export default function MessageInputContainer({
 
       {/* Input area */}
       <div className="px-4 py-3">
-        <div className="relative mb-2">
+        <div className="flex w-full items-end gap-3 rounded-lg border border-gray-700 bg-[#222] py-2 pl-2 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={handleImageSelectFromInput}
+          />
+
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isImageLoading) return;
+              triggerFileInput();
+            }}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Attach image"
+            title="Attach Image"
+            disabled={isImageLoading}
+          >
+            <Plus size={18} />
+          </button>
+
           <SecureTextarea
             ref={inputRef}
             value={replyMessage}
@@ -159,36 +182,15 @@ export default function MessageInputContainer({
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="w-full p-3 pr-28 !bg-[#222] !border-gray-700 !text-white focus:!outline-none focus:!ring-1 focus:!ring-[#ff950e] min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none py-3 text-white focus:!outline-none focus:!ring-0 min-h-[40px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
             characterCount={false}
             aria-label="Message"
           />
-          <input
-            type="file"
-            accept="image/jpeg,image/png,image/gif,image/webp"
-            ref={fileInputRef}
-            style={{ display: 'none' }}
-            onChange={handleImageSelectFromInput}
-          />
-          <div className="absolute right-3 top-1/2 -translate-y-1/2 mt-[-4px] flex items-center gap-2">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (isImageLoading) return;
-                triggerFileInput();
-              }}
-              className="flex items-center justify-center h-8 w-8 rounded-full bg-[#2b2b2b] text-gray-300 hover:text-white hover:bg-[#333] transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Attach image"
-              title="Attach Image"
-              disabled={isImageLoading}
-            >
-              <Plus size={18} />
-            </button>
-            {/* Emoji button integrated in textarea */}
+
+          <div className="flex items-center gap-2">
             <button
               onClick={(e) => {
                 e.stopPropagation();


### PR DESCRIPTION
## Summary
- reposition the attachment button to the left of the message textarea across chat inputs
- refactor the composer layout to use a shared flex arrangement and preserve focus styling
- keep accessory controls grouped on the right while maintaining character counts and accessibility hooks

## Testing
- npm run lint *(fails: numerous pre-existing lint errors across context and utils files)*

------
https://chatgpt.com/codex/tasks/task_e_68f46a9751f08328bb8daa9a48b12e36