### PR TITLE
Revamp chat input styling

### DIFF
--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -79,7 +79,7 @@ export default function MessageInput({
 
       {imageError && <div className="mb-2 text-red-400 text-sm">{sanitizeStrict(imageError)}</div>}
 
-      <div className="flex items-end gap-2">
+      <div className="flex flex-col gap-1.5">
         <input
           ref={fileInputRef}
           type="file"
@@ -88,64 +88,68 @@ export default function MessageInput({
           className="hidden"
         />
 
-        <div className="flex gap-1">
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isImageLoading}
-            className="p-2 text-gray-400 hover:text-white hover:bg-[#222] rounded-lg transition-colors disabled:opacity-50"
-            title="Attach image"
-            aria-label="Attach image"
-          >
-            <ImageIcon size={20} />
-          </button>
+        <div className="flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#1a1a1a]">
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isImageLoading}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-60"
+              title="Attach image"
+              aria-label="Attach image"
+            >
+              <ImageIcon size={16} />
+            </button>
 
-          <button
-            onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-            className="p-2 text-gray-400 hover:text-white hover:bg-[#222] rounded-lg transition-colors relative"
-            title="Add emoji"
-            aria-label="Add emoji"
-          >
-            <Smile size={20} />
-          </button>
+            <button
+              onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
+              title="Add emoji"
+              aria-label="Add emoji"
+            >
+              <Smile size={16} />
+            </button>
 
-          <button
-            onClick={onCustomRequest}
-            className="p-2 text-gray-400 hover:text-white hover:bg-[#222] rounded-lg transition-colors"
-            title="Send custom request"
-            aria-label="Send custom request"
-          >
-            <Package size={20} />
-          </button>
-        </div>
+            <button
+              onClick={onCustomRequest}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
+              title="Send custom request"
+              aria-label="Send custom request"
+            >
+              <Package size={16} />
+            </button>
+          </div>
 
-        <div className="flex-1">
           <SecureTextarea
             value={replyMessage}
             onChange={setReplyMessage}
             onKeyPress={handleKeyPress}
             placeholder="Type a message..."
             rows={1}
-            className="w-full !bg-[#222] !text-white !border-0 rounded-lg px-3 py-2 resize-none focus:outline-none focus:!ring-2 focus:!ring-[#ff950e] min-h-[40px] max-h-[120px]"
+            className="flex-1 !bg-transparent !text-white !border-0 !shadow-none !px-0 !py-0.5 text-[15px] placeholder:text-gray-500 resize-none focus:!outline-none focus:!ring-0 min-h-[34px] max-h-[120px]"
             style={{ height: 'auto', overflowY: replyMessage.split('\n').length > 3 ? 'auto' : 'hidden' }}
             sanitizer={messageSanitizer}
             maxLength={1000}
             characterCount={false}
             aria-label="Message"
           />
+
+          <button
+            onClick={handleReply}
+            disabled={!replyMessage.trim() && !selectedImage}
+            className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
+              !replyMessage.trim() && !selectedImage
+                ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
+                : 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
+            }`}
+            aria-label="Send message"
+          >
+            <Send size={16} />
+          </button>
         </div>
 
-        <button
-          onClick={handleReply}
-          disabled={!replyMessage.trim() && !selectedImage}
-          className={`flex items-center justify-center gap-1 px-3.5 py-1.5 rounded-2xl transition-colors text-sm font-semibold ${
-            !replyMessage.trim() && !selectedImage
-              ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed'
-              : 'bg-[#ff950e] text-black hover:bg-[#e88800]'
-          }`}
-          aria-label="Send message"
-        >
-          <Send size={18} />
-        </button>
+        {replyMessage.length > 0 && (
+          <div className="text-[11px] text-gray-500 text-right pr-1">{replyMessage.length}/1000</div>
+        )}
       </div>
 
       {showEmojiPicker && (

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -121,7 +121,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
   };
 
   return (
-    <div className={`px-4 py-3 border-t border-[#1f1f24] bg-[#111214] ${className}`}>
+    <div className={`px-4 py-2.5 border-t border-[#1f1f24] bg-[#111214] ${className}`}>
       {isUploading && (
         <div className="mb-2 flex items-center text-sm text-[#ff950e]">
           <div className="w-4 h-4 mr-2 border-2 border-[#ff950e] border-t-transparent rounded-full animate-spin"></div>
@@ -162,9 +162,9 @@ const MessageInput: React.FC<MessageInputProps> = ({
         </div>
       )}
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5">
         <div
-          className={`flex w-full items-center gap-2 rounded-[22px] border border-[#2b2d31] bg-[#1c1d22] px-3 py-2.5 transition-all duration-150 focus-within:border-[#4752e2] focus-within:ring-2 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-2 focus-within:ring-offset-[#111214] ${
+          className={`flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 transition-all duration-150 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#111214] ${
             disabled ? 'opacity-90' : ''
           }`}
         >
@@ -173,12 +173,12 @@ const MessageInput: React.FC<MessageInputProps> = ({
               <button
                 type="button"
                 onClick={triggerFileInput}
-                className="flex h-10 w-10 items-center justify-center rounded-full border border-[#3a3b42] bg-[#23242b] text-gray-300 transition-colors duration-150 hover:border-[#4a4b55] hover:bg-[#2d2e36] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={disabled || isUploading}
                 title="Attach Image"
                 aria-label="Attach image"
               >
-                <Plus size={18} />
+                <Plus size={16} />
               </button>
               <input
                 type="file"
@@ -198,7 +198,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
               onChange={setContent}
               onKeyDown={handleKeyDown}
               placeholder={selectedImage ? 'Add a caption...' : placeholder}
-              className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-0 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[40px] resize-none flex items-center"
+              className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-0.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[34px] resize-none flex items-center"
               rows={1}
               maxLength={maxLength}
               characterCount={false}
@@ -216,12 +216,12 @@ const MessageInput: React.FC<MessageInputProps> = ({
                 onEmojiClick?.();
                 textareaRef.current?.focus();
               }}
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#2d2f36] focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
               disabled={disabled}
               title="Add emoji"
               aria-label="Add emoji"
             >
-              <Smile size={18} />
+              <Smile size={16} />
             </button>
           )}
 
@@ -230,19 +230,19 @@ const MessageInput: React.FC<MessageInputProps> = ({
               type="button"
               onClick={handleSend}
               disabled={disabled || (!content.trim() && !selectedImage) || isUploading}
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#111214] ${
+              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#111214] ${
                 disabled || (!content.trim() && !selectedImage) || isUploading
                   ? 'bg-[#2b2c31] text-gray-500 cursor-not-allowed focus:ring-[#2b2c31]'
                   : 'bg-[#5865f2] text-white hover:bg-[#4752e2] focus:ring-[#5865f2]'
               }`}
               aria-label="Send message"
             >
-              <Send size={18} />
+              <Send size={16} />
             </button>
           </div>
         </div>
 
-        <div className="self-end text-xs text-gray-500 text-right pr-1">{content.length}/{maxLength}</div>
+        <div className="self-end text-[11px] text-gray-500 text-right pr-1">{content.length}/{maxLength}</div>
       </div>
     </div>
   );

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -148,8 +148,8 @@ export default function MessageInputContainer({
       )}
 
       {/* Input area */}
-      <div className="px-4 py-3">
-        <div className="flex w-full items-center gap-3 rounded-2xl border border-[#2f3036] bg-[#1f1f24] px-3 py-2.5 focus-within:border-transparent focus-within:ring-2 focus-within:ring-[#4752e2] focus-within:ring-offset-2 focus-within:ring-offset-[#16161a]">
+      <div className="px-4 py-2.5">
+        <div className="flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
           <input
             type="file"
             accept="image/jpeg,image/png,image/gif,image/webp"
@@ -165,12 +165,12 @@ export default function MessageInputContainer({
               if (isImageLoading) return;
               triggerFileInput();
             }}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-[#3b3c43] bg-[#272830] text-gray-300 transition-colors duration-150 hover:border-[#4a4b55] hover:bg-[#30313a] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Attach image"
             title="Attach Image"
             disabled={isImageLoading}
           >
-            <Plus size={18} />
+            <Plus size={16} />
           </button>
 
           <SecureTextarea
@@ -182,7 +182,7 @@ export default function MessageInputContainer({
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-1.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[44px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-1 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[34px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -196,16 +196,16 @@ export default function MessageInputContainer({
                 e.stopPropagation();
                 setShowEmojiPicker(!showEmojiPicker);
               }}
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 showEmojiPicker
                   ? 'bg-[#ff950e] text-black focus:ring-[#ff950e]'
-                  : 'border border-[#3b3c43] bg-[#272830] text-gray-300 hover:border-[#4a4b55] hover:bg-[#30313a] hover:text-white focus:ring-[#4752e2]'
+                  : 'border border-transparent text-gray-300 hover:text-white hover:bg-[#272a2f] focus:ring-[#4752e2]'
               }`}
               title="Emoji"
               type="button"
               aria-label="Toggle emoji picker"
             >
-              <Smile size={20} className="flex-shrink-0" />
+              <Smile size={18} className="flex-shrink-0" />
             </button>
             <button
               type="button"
@@ -215,7 +215,7 @@ export default function MessageInputContainer({
                 setShowEmojiPicker(false);
                 handleReply();
               }}
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 canSend
                   ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
@@ -223,13 +223,13 @@ export default function MessageInputContainer({
               aria-label="Send message"
               disabled={!canSend}
             >
-              <ArrowUp size={16} strokeWidth={2.5} />
+              <ArrowUp size={14} strokeWidth={2.5} />
             </button>
           </div>
         </div>
 
         {replyMessage.length > 0 && (
-          <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
+          <div className="text-[11px] text-gray-500 mb-1 text-right">{replyMessage.length}/250</div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- restyle the shared messaging input wrapper to use a slimmer, more compact layout
- align seller and buyer message inputs with the updated compact styling for consistency

## Testing
- npm run lint *(fails: existing lint issues throughout the repo unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f564e1b504832889fb2d0df3f602cc