### PR TITLE
Fix VirtualList item measurement

### DIFF
--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -30,6 +30,10 @@ export function VirtualList<T>({
     getScrollElement: () => parentRef.current,
     estimateSize: () => safeItemHeight,
     overscan: safeOverscan,
+    measureElement: (element) =>
+      element instanceof HTMLElement
+        ? element.getBoundingClientRect().height
+        : safeItemHeight,
   });
 
   return (
@@ -44,6 +48,7 @@ export function VirtualList<T>({
         {virtualizer.getVirtualItems().map((virtualItem) => (
           <div
             key={virtualItem.key}
+            ref={virtualizer.measureElement}
             style={{
               position: 'absolute',
               top: 0,


### PR DESCRIPTION
## Summary
- ensure the shared VirtualList measures each rendered element so taller items reserve the correct space
- attach the virtualizer measurement ref to every row to prevent message bubbles with images from overlapping

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f5a5bfacfc8328a3b2e41d3cf969d1