### PR TITLE
Fix virtualized message heights for seller image threads

### DIFF
--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -30,10 +30,6 @@ export function VirtualList<T>({
     getScrollElement: () => parentRef.current,
     estimateSize: () => safeItemHeight,
     overscan: safeOverscan,
-    measureElement: (element) =>
-      element instanceof HTMLElement
-        ? element.getBoundingClientRect().height
-        : safeItemHeight,
   });
 
   return (


### PR DESCRIPTION
## Summary
- remove the custom `measureElement` override from the shared `VirtualList` component
- rely on the built-in ResizeObserver logic so tall seller messages (such as images) no longer overlap subsequent rows

## Testing
- npm run lint *(fails: existing lint violations across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68f5a81d2a188328bff4a53c65f02b9b