### PR TITLE
Reduce message input height and remove character counters

### DIFF
--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -79,7 +79,7 @@ export default function MessageInput({
 
       {imageError && <div className="mb-2 text-red-400 text-sm">{sanitizeStrict(imageError)}</div>}
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <input
           ref={fileInputRef}
           type="file"
@@ -88,12 +88,12 @@ export default function MessageInput({
           className="hidden"
         />
 
-        <div className="flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#1a1a1a]">
-          <div className="flex items-center gap-1.5">
+        <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#1a1a1a]">
+          <div className="flex items-center gap-1">
             <button
               onClick={() => fileInputRef.current?.click()}
               disabled={isImageLoading}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-60"
               title="Attach image"
               aria-label="Attach image"
             >
@@ -102,7 +102,7 @@ export default function MessageInput({
 
             <button
               onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
               title="Add emoji"
               aria-label="Add emoji"
             >
@@ -111,7 +111,7 @@ export default function MessageInput({
 
             <button
               onClick={onCustomRequest}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
               title="Send custom request"
               aria-label="Send custom request"
             >
@@ -125,7 +125,7 @@ export default function MessageInput({
             onKeyPress={handleKeyPress}
             placeholder="Type a message..."
             rows={1}
-            className="flex-1 !bg-transparent !text-white !border-0 !shadow-none !px-0 !py-0.5 text-[15px] placeholder:text-gray-500 resize-none focus:!outline-none focus:!ring-0 min-h-[34px] max-h-[120px]"
+            className="flex-1 !bg-transparent !text-white !border-0 !shadow-none !px-0 !py-0 text-[15px] placeholder:text-gray-500 resize-none focus:!outline-none focus:!ring-0 min-h-[30px] max-h-[120px]"
             style={{ height: 'auto', overflowY: replyMessage.split('\n').length > 3 ? 'auto' : 'hidden' }}
             sanitizer={messageSanitizer}
             maxLength={1000}
@@ -136,7 +136,7 @@ export default function MessageInput({
           <button
             onClick={handleReply}
             disabled={!replyMessage.trim() && !selectedImage}
-            className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
+            className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
               !replyMessage.trim() && !selectedImage
                 ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
                 : 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
@@ -146,10 +146,6 @@ export default function MessageInput({
             <Send size={16} />
           </button>
         </div>
-
-        {replyMessage.length > 0 && (
-          <div className="text-[11px] text-gray-500 text-right pr-1">{replyMessage.length}/1000</div>
-        )}
       </div>
 
       {showEmojiPicker && (

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -121,7 +121,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
   };
 
   return (
-    <div className={`px-4 py-2.5 border-t border-[#1f1f24] bg-[#111214] ${className}`}>
+    <div className={`px-4 py-2 border-t border-[#1f1f24] bg-[#111214] ${className}`}>
       {isUploading && (
         <div className="mb-2 flex items-center text-sm text-[#ff950e]">
           <div className="w-4 h-4 mr-2 border-2 border-[#ff950e] border-t-transparent rounded-full animate-spin"></div>
@@ -162,9 +162,9 @@ const MessageInput: React.FC<MessageInputProps> = ({
         </div>
       )}
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <div
-          className={`flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 transition-all duration-150 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#111214] ${
+          className={`flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 transition-all duration-150 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#111214] ${
             disabled ? 'opacity-90' : ''
           }`}
         >
@@ -173,7 +173,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
               <button
                 type="button"
                 onClick={triggerFileInput}
-                className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
+                className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={disabled || isUploading}
                 title="Attach Image"
                 aria-label="Attach image"
@@ -198,7 +198,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
               onChange={setContent}
               onKeyDown={handleKeyDown}
               placeholder={selectedImage ? 'Add a caption...' : placeholder}
-              className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-0.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[34px] resize-none flex items-center"
+              className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-0 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[30px] resize-none flex items-center"
               rows={1}
               maxLength={maxLength}
               characterCount={false}
@@ -216,7 +216,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
                 onEmojiClick?.();
                 textareaRef.current?.focus();
               }}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-[#4752e2] focus:ring-offset-2 focus:ring-offset-[#111214] disabled:cursor-not-allowed disabled:opacity-60"
               disabled={disabled}
               title="Add emoji"
               aria-label="Add emoji"
@@ -225,12 +225,12 @@ const MessageInput: React.FC<MessageInputProps> = ({
             </button>
           )}
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <button
               type="button"
               onClick={handleSend}
               disabled={disabled || (!content.trim() && !selectedImage) || isUploading}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#111214] ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#111214] ${
                 disabled || (!content.trim() && !selectedImage) || isUploading
                   ? 'bg-[#2b2c31] text-gray-500 cursor-not-allowed focus:ring-[#2b2c31]'
                   : 'bg-[#5865f2] text-white hover:bg-[#4752e2] focus:ring-[#5865f2]'
@@ -241,8 +241,6 @@ const MessageInput: React.FC<MessageInputProps> = ({
             </button>
           </div>
         </div>
-
-        <div className="self-end text-[11px] text-gray-500 text-right pr-1">{content.length}/{maxLength}</div>
       </div>
     </div>
   );

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -147,8 +147,8 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
         )}
 
         {/* Message input with security */}
-        <div className="px-4 py-3">
-          <div className="flex w-full items-center gap-3 rounded-lg border border-gray-700 bg-[#222] py-1.5 pl-2 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
+        <div className="px-4 py-2.5">
+          <div className="flex w-full items-center gap-2.5 rounded-lg border border-gray-700 bg-[#222] py-1 pl-2.5 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
             <input
               type="file"
               accept="image/jpeg,image/png,image/gif,image/webp"
@@ -164,7 +164,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
                 if (isImageLoading) return;
                 onImageClick();
               }}
-              className="flex h-9 w-9 aspect-square items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex h-8 w-8 aspect-square items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Attach image"
               title="Attach Image"
               disabled={isImageLoading}
@@ -178,14 +178,14 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               onChange={setReplyMessage}
               onKeyDown={onKeyDown}
               placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-              className="flex-1 bg-transparent py-2 text-white focus:outline-none focus:ring-0 min-h-[36px] max-h-20 resize-none overflow-auto leading-tight"
+              className="flex-1 bg-transparent py-1.5 text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-tight"
               rows={1}
               maxLength={250}
               characterCount={false}
               sanitize={true}
             />
 
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -208,7 +208,7 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
                   setShowEmojiPicker(false);
                   onReply();
                 }}
-                className={`flex items-center justify-center px-3.5 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
+                className={`flex items-center justify-center px-3 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
                   canSend
                     ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                     : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
@@ -221,10 +221,6 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
             </div>
           </div>
 
-          {/* Character count */}
-          {replyMessage.length > 0 && (
-            <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
-          )}
         </div>
       </div>
     );

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -148,8 +148,8 @@ export default function MessageInputContainer({
       )}
 
       {/* Input area */}
-      <div className="px-4 py-2.5">
-        <div className="flex w-full items-center gap-2 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3.5 py-2 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
+      <div className="px-4 py-2">
+        <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
           <input
             type="file"
             accept="image/jpeg,image/png,image/gif,image/webp"
@@ -165,7 +165,7 @@ export default function MessageInputContainer({
               if (isImageLoading) return;
               triggerFileInput();
             }}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Attach image"
             title="Attach Image"
             disabled={isImageLoading}
@@ -182,7 +182,7 @@ export default function MessageInputContainer({
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-1 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[34px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-0.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[30px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -190,13 +190,13 @@ export default function MessageInputContainer({
             aria-label="Message"
           />
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 setShowEmojiPicker(!showEmojiPicker);
               }}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 showEmojiPicker
                   ? 'bg-[#ff950e] text-black focus:ring-[#ff950e]'
                   : 'border border-transparent text-gray-300 hover:text-white hover:bg-[#272a2f] focus:ring-[#4752e2]'
@@ -215,7 +215,7 @@ export default function MessageInputContainer({
                 setShowEmojiPicker(false);
                 handleReply();
               }}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 canSend
                   ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
@@ -227,10 +227,6 @@ export default function MessageInputContainer({
             </button>
           </div>
         </div>
-
-        {replyMessage.length > 0 && (
-          <div className="text-[11px] text-gray-500 mb-1 text-right">{replyMessage.length}/250</div>
-        )}
       </div>
 
       {/* Inline emoji picker */}


### PR DESCRIPTION
## Summary
- tighten spacing and button sizing in buyer, seller, and shared message input components
- remove message length counters from chat composers to declutter the interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5a8d8b4808328b8fe658f45a9da19