### PR TITLE
Align buyer message composer with seller UI

### DIFF
--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -9,13 +9,11 @@ import {
   ShieldAlert,
   X,
   Smile,
-  Sparkles,
   Clock,
   CheckCircle2,
   XCircle,
   Edit3,
   ShoppingBag,
-  Package,
   ChevronLeft,
   User,
   MoreVertical,
@@ -763,8 +761,8 @@ export default function ConversationView(props: ConversationViewProps) {
       )}
 
       {/* Input */}
-      <div className="px-4 py-3">
-        <div className="flex w-full items-center gap-3 rounded-2xl border border-[#2f3036] bg-[#1f1f24] px-3 py-2.5 focus-within:border-transparent focus-within:ring-2 focus-within:ring-[#4752e2] focus-within:ring-offset-2 focus-within:ring-offset-[#16161a]">
+      <div className="px-4 py-2.5">
+        <div className="flex w-full items-center gap-2.5 rounded-lg border border-gray-700 bg-[#222] py-1 pl-2.5 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
           <input
             type="file"
             accept="image/jpeg,image/png,image/gif,image/webp"
@@ -779,7 +777,7 @@ export default function ConversationView(props: ConversationViewProps) {
               if (isImageLoading) return;
               triggerFileInput();
             }}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-[#3b3c43] bg-[#272830] text-gray-300 transition-colors duration-150 hover:border-[#4a4b55] hover:bg-[#30313a] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-8 w-8 aspect-square items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
             title="Attach Image"
             type="button"
             aria-label="Attach image"
@@ -792,12 +790,12 @@ export default function ConversationView(props: ConversationViewProps) {
             ref={inputRef}
             value={replyMessage}
             onChange={handleTypingChange}
-            onKeyPress={handleKeyDown}
+            onKeyDown={handleKeyDown}
             onFocus={(e) => {
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-1.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[44px] max-h-20 !resize-none overflow-auto leading-tight"
+            className="flex-1 bg-transparent py-1.5 text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -805,22 +803,47 @@ export default function ConversationView(props: ConversationViewProps) {
             aria-label="Message"
           />
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 setShowEmojiPicker(!showEmojiPicker);
               }}
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex items-center justify-center h-8 w-8 rounded-full ${
                 showEmojiPicker
-                  ? 'bg-[#ff950e] text-black focus:ring-[#ff950e]'
-                  : 'border border-[#3b3c43] bg-[#272830] text-gray-300 hover:border-[#4a4b55] hover:bg-[#30313a] hover:text-white focus:ring-[#4752e2]'
-              }`}
+                  ? 'bg-[#ff950e] text-black'
+                  : 'text-[#ff950e] hover:bg-[#333]'
+              } transition-colors duration-150`}
               title="Emoji"
               type="button"
               aria-label="Toggle emoji picker"
+              aria-pressed={showEmojiPicker}
             >
               <Smile size={20} className="flex-shrink-0" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowTipModal(true);
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e]"
+              aria-label="Send tip"
+              title="Send Tip"
+            >
+              <img src="/Send_Tip_Icon.png" alt="Send tip" className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowCustomRequestModal(true);
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e]"
+              aria-label="Send custom request"
+              title="Send Custom Request"
+            >
+              <img src="/Custom_Request_Icon.png" alt="Custom request" className="w-4 h-4" />
             </button>
             <button
               type="button"
@@ -830,7 +853,7 @@ export default function ConversationView(props: ConversationViewProps) {
                 setShowEmojiPicker(false);
                 stableHandleReply();
               }}
-              className={`flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+              className={`flex items-center justify-center px-3 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
                 canSend
                   ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
@@ -841,36 +864,6 @@ export default function ConversationView(props: ConversationViewProps) {
               <ArrowUp size={16} strokeWidth={2.5} />
             </button>
           </div>
-        </div>
-
-        {replyMessage.length > 0 && (
-          <div className="text-xs text-gray-400 mb-2 text-right">{replyMessage.length}/250</div>
-        )}
-
-        <div className="flex items-center gap-0">
-          <img
-            src="/Send_Tip_Icon.png"
-            alt="Send Tip"
-              className="w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowTipModal(true);
-              }}
-              title="Send Tip"
-            />
-
-            <img
-              src="/Custom_Request_Icon.png"
-              alt="Custom Request"
-              className="w-14 h-14 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowCustomRequestModal(true);
-              }}
-              title="Send Custom Request"
-            />
-
-            {/* Hidden file input with strict types */}
         </div>
       </div>
 

--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -1,10 +1,12 @@
 // src/components/buyers/messages/MessageInput.tsx
+
 'use client';
 
 import React from 'react';
-import { Send, Image as ImageIcon, Smile, X, Package } from 'lucide-react';
+import { AlertTriangle, X, Smile, ArrowUp, Plus, ShieldAlert } from 'lucide-react';
 import EmojiPicker from './EmojiPicker';
 import { SecureTextarea } from '@/components/ui/SecureInput';
+import { SecureImage } from '@/components/ui/SecureMessageDisplay';
 import { sanitizeStrict } from '@/utils/security/sanitization';
 
 interface MessageInputProps {
@@ -44,112 +46,152 @@ export default function MessageInput({
   isBlocked,
   onCustomRequest,
 }: MessageInputProps) {
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleReply();
     }
   };
 
+  const canSend = (!!replyMessage.trim() || !!selectedImage) && !isImageLoading;
+
   const messageSanitizer = (value: string): string =>
-    value.replace(/<[^>]*>/g, '').replace(/[^\w\s\n\r.,!?'"()-]/g, '').slice(0, 1000);
+    value.replace(/<[^>]*>/g, '').replace(/[^\w\s\n\r.,!?'"()-]/g, '').slice(0, 250);
 
   if (isBlocked) {
     return (
-      <div className="bg-[#1a1a1a] border-t border-gray-800 p-4">
-        <div className="text-center text-gray-400 text-sm">You have blocked this seller. Unblock to send messages.</div>
+      <div className="p-4 border-t border-gray-800 text-center text-sm text-red-400 bg-[#1a1a1a] flex items-center justify-center">
+        <ShieldAlert size={16} className="mr-2" />
+        You have blocked this seller. Unblock to send messages.
       </div>
     );
   }
 
   return (
-    <div className="bg-[#1a1a1a] border-t border-gray-800 p-4">
+    <div className="relative border-t border-gray-800 bg-[#1a1a1a]">
       {selectedImage && (
-        <div className="mb-3 relative inline-block">
-          <img src={selectedImage} alt="Selected" className="max-h-20 rounded-lg shadow-md" />
-          <button
-            onClick={() => setSelectedImage(null)}
-            className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600 transition-colors"
-            aria-label="Remove attached image"
-          >
-            <X size={14} />
-          </button>
+        <div className="px-4 pt-3 pb-2">
+          <div className="relative inline-block">
+            <SecureImage src={selectedImage} alt="Selected" className="max-h-20 rounded shadow-md" />
+            <button
+              onClick={() => {
+                setSelectedImage(null);
+                if (fileInputRef.current) {
+                  fileInputRef.current.value = '';
+                }
+              }}
+              className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 text-xs shadow-md transform transition-transform hover:scale-110"
+              style={{ width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+              aria-label="Remove attached image"
+            >
+              <X size={14} />
+            </button>
+          </div>
         </div>
       )}
 
-      {imageError && <div className="mb-2 text-red-400 text-sm">{sanitizeStrict(imageError)}</div>}
+      {isImageLoading && <div className="px-4 pt-3 pb-0 text-sm text-gray-400">Loading image...</div>}
 
-      <div className="flex flex-col gap-1">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/gif,image/webp"
-          onChange={handleImageSelect}
-          className="hidden"
-        />
+      {imageError && (
+        <div className="px-4 pt-3 pb-0 text-sm text-red-400 flex items-center">
+          <AlertTriangle size={14} className="mr-1" />
+          {sanitizeStrict(imageError)}
+        </div>
+      )}
 
-        <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#1a1a1a]">
-          <div className="flex items-center gap-1">
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isImageLoading}
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-60"
-              title="Attach image"
-              aria-label="Attach image"
-            >
-              <ImageIcon size={16} />
-            </button>
+      <div className="px-4 py-2.5">
+        <div className="flex w-full items-center gap-2.5 rounded-lg border border-gray-700 bg-[#222] py-1 pl-2.5 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            onChange={handleImageSelect}
+            className="hidden"
+          />
 
-            <button
-              onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
-              title="Add emoji"
-              aria-label="Add emoji"
-            >
-              <Smile size={16} />
-            </button>
-
-            <button
-              onClick={onCustomRequest}
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-transparent text-gray-300 transition-colors duration-150 hover:text-white hover:bg-[#272a2f] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:ring-[#4752e2]"
-              title="Send custom request"
-              aria-label="Send custom request"
-            >
-              <Package size={16} />
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isImageLoading) return;
+              fileInputRef.current?.click();
+            }}
+            className="flex h-8 w-8 aspect-square items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+            title="Attach image"
+            aria-label="Attach image"
+            disabled={isImageLoading}
+          >
+            <Plus size={18} />
+          </button>
 
           <SecureTextarea
             value={replyMessage}
             onChange={setReplyMessage}
-            onKeyPress={handleKeyPress}
-            placeholder="Type a message..."
+            onKeyDown={handleKeyDown}
+            placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
             rows={1}
-            className="flex-1 !bg-transparent !text-white !border-0 !shadow-none !px-0 !py-0 text-[15px] placeholder:text-gray-500 resize-none focus:!outline-none focus:!ring-0 min-h-[30px] max-h-[120px]"
-            style={{ height: 'auto', overflowY: replyMessage.split('\n').length > 3 ? 'auto' : 'hidden' }}
+            className="flex-1 bg-transparent py-1.5 text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-tight"
             sanitizer={messageSanitizer}
-            maxLength={1000}
+            maxLength={250}
             characterCount={false}
             aria-label="Message"
           />
 
-          <button
-            onClick={handleReply}
-            disabled={!replyMessage.trim() && !selectedImage}
-            className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
-              !replyMessage.trim() && !selectedImage
-                ? 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
-                : 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
-            }`}
-            aria-label="Send message"
-          >
-            <Send size={16} />
-          </button>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowEmojiPicker(!showEmojiPicker);
+              }}
+              className={`flex items-center justify-center h-8 w-8 rounded-full ${
+                showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#333]'
+              } transition-colors duration-150`}
+              title="Emoji"
+              aria-label="Toggle emoji picker"
+              aria-pressed={showEmojiPicker}
+            >
+              <Smile size={20} className="flex-shrink-0" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCustomRequest();
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-600 bg-[#2b2b2b] text-gray-300 transition-colors duration-150 hover:bg-[#333] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] focus:ring-[#ff950e]"
+              title="Send custom request"
+              aria-label="Send custom request"
+            >
+              <img src="/Custom_Request_Icon.png" alt="Custom request" className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!canSend) return;
+                setShowEmojiPicker(false);
+                handleReply();
+              }}
+              disabled={!canSend}
+              className={`flex items-center justify-center px-3 py-1.5 rounded-2xl transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#222] ${
+                canSend
+                  ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
+                  : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
+              }`}
+              aria-label="Send message"
+            >
+              <ArrowUp size={16} strokeWidth={2.5} />
+            </button>
+          </div>
         </div>
       </div>
 
       {showEmojiPicker && (
-        <div ref={emojiPickerRef} className="absolute bottom-full mb-2 right-4">
+        <div
+          ref={emojiPickerRef}
+          className="absolute left-0 right-0 mx-4 bottom-full mb-2 bg-black border border-gray-800 shadow-lg z-50 rounded-lg"
+        >
           <EmojiPicker onEmojiClick={handleEmojiClick} recentEmojis={recentEmojis} onClose={() => setShowEmojiPicker(false)} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- restyle the buyer conversation composer to mirror the compact seller input, including inline actions for attachments, emojis, tips, and custom requests
- refresh the standalone buyer MessageInput component to match the new layout and behaviors

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5ab661d988328904f53a4c46ed2c8