### PR TITLE
Align buyer message composer with seller UI

### DIFF
--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -761,8 +761,8 @@ export default function ConversationView(props: ConversationViewProps) {
       )}
 
       {/* Input */}
-      <div className="px-4 pt-2.5">
-        <div className="flex w-full items-center gap-2 rounded-full border border-[#2f2f2f] bg-[#1a1a1a] px-3 py-1.5 focus-within:ring-1 focus-within:ring-[#ff950e]">
+      <div className="px-4 py-2">
+        <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
           <input
             type="file"
             accept="image/jpeg,image/png,image/gif,image/webp"
@@ -777,13 +777,13 @@ export default function ConversationView(props: ConversationViewProps) {
               if (isImageLoading) return;
               triggerFileInput();
             }}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-[#3a3a3a] bg-[#232323] text-gray-300 transition-colors duration-150 hover:bg-[#2d2d2d] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
             title="Attach Image"
             type="button"
             aria-label="Attach image"
             disabled={isImageLoading}
           >
-            <Plus size={18} />
+            <Plus size={16} />
           </button>
 
           <SecureTextarea
@@ -795,7 +795,7 @@ export default function ConversationView(props: ConversationViewProps) {
               e.preventDefault();
             }}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="flex-1 bg-transparent py-1.5 text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-0.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[30px] max-h-20 !resize-none overflow-auto leading-tight"
             rows={1}
             maxLength={250}
             sanitizer={messageSanitizer}
@@ -809,17 +809,17 @@ export default function ConversationView(props: ConversationViewProps) {
                 e.stopPropagation();
                 setShowEmojiPicker(!showEmojiPicker);
               }}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 showEmojiPicker
-                  ? 'bg-[#ff950e] text-black'
-                  : 'text-[#ff950e] hover:bg-[#2d2d2d]'
+                  ? 'bg-[#ff950e] text-black focus:ring-[#ff950e]'
+                  : 'border border-transparent text-gray-300 hover:text-white hover:bg-[#272a2f] focus:ring-[#4752e2]'
               }`}
               title="Emoji"
               type="button"
               aria-label="Toggle emoji picker"
               aria-pressed={showEmojiPicker}
             >
-              <Smile size={20} className="flex-shrink-0" />
+              <Smile size={18} className="flex-shrink-0" />
             </button>
             <button
               type="button"
@@ -829,7 +829,7 @@ export default function ConversationView(props: ConversationViewProps) {
                 setShowEmojiPicker(false);
                 stableHandleReply();
               }}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 canSend
                   ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
@@ -837,22 +837,22 @@ export default function ConversationView(props: ConversationViewProps) {
               aria-label="Send message"
               disabled={!canSend}
             >
-              <ArrowUp size={16} strokeWidth={2.5} />
+              <ArrowUp size={14} strokeWidth={2.5} />
             </button>
           </div>
         </div>
-        <div className="mt-3 flex items-center gap-3 text-sm text-gray-300">
+        <div className="mt-2 flex items-center gap-2 text-xs text-gray-300">
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
               setShowTipModal(true);
             }}
-            className="flex items-center gap-2 rounded-full border border-[#2f2f2f] bg-[#1f1f1f] px-4 py-1.5 text-gray-200 transition-colors duration-150 hover:bg-[#2a2a2a] focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="flex items-center gap-1.5 rounded-full border border-[#363840] bg-[#202226] px-3 py-1 text-gray-200 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-1 focus:ring-[#4752e2]/60 focus:ring-offset-1 focus:ring-offset-[#16161a]"
             aria-label="Send tip"
           >
-            <img src="/Send_Tip_Icon.png" alt="Send tip" className="h-4 w-4" />
-            <span>Send Tip</span>
+            <img src="/Send_Tip_Icon.png" alt="Send tip" className="h-3.5 w-3.5" />
+            <span className="text-xs font-medium uppercase tracking-wide">Tip</span>
           </button>
           <button
             type="button"
@@ -860,11 +860,11 @@ export default function ConversationView(props: ConversationViewProps) {
               e.stopPropagation();
               setShowCustomRequestModal(true);
             }}
-            className="flex items-center gap-2 rounded-full border border-[#2f2f2f] bg-[#1f1f1f] px-4 py-1.5 text-gray-200 transition-colors duration-150 hover:bg-[#2a2a2a] focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="flex items-center gap-1.5 rounded-full border border-[#363840] bg-[#202226] px-3 py-1 text-gray-200 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-1 focus:ring-[#4752e2]/60 focus:ring-offset-1 focus:ring-offset-[#16161a]"
             aria-label="Send custom request"
           >
-            <img src="/Custom_Request_Icon.png" alt="Custom request" className="h-4 w-4" />
-            <span>Custom Request</span>
+            <img src="/Custom_Request_Icon.png" alt="Custom request" className="h-3.5 w-3.5" />
+            <span className="text-xs font-medium uppercase tracking-wide">Custom</span>
           </button>
         </div>
       </div>

--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -99,8 +99,8 @@ export default function MessageInput({
         </div>
       )}
 
-      <div className="px-4 pt-2.5">
-        <div className="flex w-full items-center gap-2 rounded-full border border-[#2f2f2f] bg-[#1a1a1a] px-3 py-1.5 focus-within:ring-1 focus-within:ring-[#ff950e]">
+      <div className="px-4 py-2">
+        <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
           <input
             ref={fileInputRef}
             type="file"
@@ -116,12 +116,12 @@ export default function MessageInput({
               if (isImageLoading) return;
               fileInputRef.current?.click();
             }}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-[#3a3a3a] bg-[#232323] text-gray-300 transition-colors duration-150 hover:bg-[#2d2d2d] hover:text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#363840] bg-[#202226] text-gray-300 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] focus:ring-[#4752e2] disabled:cursor-not-allowed disabled:opacity-50"
             title="Attach image"
             aria-label="Attach image"
             disabled={isImageLoading}
           >
-            <Plus size={18} />
+            <Plus size={16} />
           </button>
 
           <SecureTextarea
@@ -130,7 +130,7 @@ export default function MessageInput({
             onKeyDown={handleKeyDown}
             placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
             rows={1}
-            className="flex-1 bg-transparent py-1.5 text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-tight"
+            className="flex-1 !bg-transparent !border-0 !shadow-none !px-0 !py-0.5 text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[30px] max-h-20 !resize-none overflow-auto leading-tight"
             sanitizer={messageSanitizer}
             maxLength={250}
             characterCount={false}
@@ -144,14 +144,16 @@ export default function MessageInput({
                 e.stopPropagation();
                 setShowEmojiPicker(!showEmojiPicker);
               }}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 ${
-                showEmojiPicker ? 'bg-[#ff950e] text-black' : 'text-[#ff950e] hover:bg-[#2d2d2d]'
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
+                showEmojiPicker
+                  ? 'bg-[#ff950e] text-black focus:ring-[#ff950e]'
+                  : 'border border-transparent text-gray-300 hover:text-white hover:bg-[#272a2f] focus:ring-[#4752e2]'
               }`}
               title="Emoji"
               aria-label="Toggle emoji picker"
               aria-pressed={showEmojiPicker}
             >
-              <Smile size={20} className="flex-shrink-0" />
+              <Smile size={18} className="flex-shrink-0" />
             </button>
             <button
               type="button"
@@ -162,30 +164,30 @@ export default function MessageInput({
                 handleReply();
               }}
               disabled={!canSend}
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] ${
+              className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[#1f1f24] ${
                 canSend
                   ? 'bg-[#ff950e] text-black hover:bg-[#e88800] focus:ring-[#ff950e]'
                   : 'bg-[#2b2b2b] text-gray-500 cursor-not-allowed focus:ring-[#2b2b2b]'
               }`}
               aria-label="Send message"
             >
-              <ArrowUp size={16} strokeWidth={2.5} />
+              <ArrowUp size={14} strokeWidth={2.5} />
             </button>
           </div>
         </div>
-        <div className="mt-3 flex items-center gap-3 text-sm text-gray-300">
+        <div className="mt-2 flex items-center gap-2 text-xs text-gray-300">
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
               onCustomRequest();
             }}
-            className="flex items-center gap-2 rounded-full border border-[#2f2f2f] bg-[#1f1f1f] px-4 py-1.5 text-gray-200 transition-colors duration-150 hover:bg-[#2a2a2a] focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="flex items-center gap-1.5 rounded-full border border-[#363840] bg-[#202226] px-3 py-1 text-gray-200 transition-colors duration-150 hover:border-[#4a4c56] hover:bg-[#272a2f] hover:text-white focus:outline-none focus:ring-1 focus:ring-[#4752e2]/60 focus:ring-offset-1 focus:ring-offset-[#16161a]"
             title="Send custom request"
             aria-label="Send custom request"
           >
-            <img src="/Custom_Request_Icon.png" alt="Custom request" className="h-4 w-4" />
-            <span>Custom Request</span>
+            <img src="/Custom_Request_Icon.png" alt="Custom request" className="h-3.5 w-3.5" />
+            <span className="text-xs font-medium uppercase tracking-wide">Custom</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle the buyer message composer to match the seller chat bar layout and controls
- shrink the buyer-only action buttons into compact badges positioned below the composer

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f5ec09cd6c8328a8d8bd8b377d3385