### PR TITLE
Align inline message errors with chat inputs

### DIFF
--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -368,13 +368,6 @@ export default function ChatContent({
               Loading image...
             </div>
           )}
-          {imageError && (
-            <div className="px-4 pt-3 pb-0 text-sm text-red-400 flex items-center" role="alert" aria-live="assertive">
-              <AlertTriangle size={14} className="mr-1" />
-              {imageError}
-            </div>
-          )}
-
           {/* Input */}
           <div className="px-4 py-3">
             <div className="flex w-full items-center gap-3 rounded-2xl border border-[#2f3036] bg-[#1f1f24] px-3 py-2.5 focus-within:border-transparent focus-within:ring-2 focus-within:ring-[#4752e2] focus-within:ring-offset-2 focus-within:ring-offset-[#16161a]">
@@ -401,18 +394,34 @@ export default function ChatContent({
                 <Plus size={18} />
               </button>
 
-              <SecureTextarea
-                ref={inputRef}
-                value={content}
-                onChange={setContent}
-                onKeyDown={handleKeyDown}
-                placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-                className="flex-1 self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[44px] max-h-20 !resize-none overflow-auto leading-[1.6]"
-                rows={1}
-                maxLength={250}
-                characterCount={false}
-                sanitize
-              />
+              <div className="flex flex-1 items-center gap-2 min-w-0">
+                <div className="flex-1 min-w-0">
+                  <SecureTextarea
+                    ref={inputRef}
+                    value={content}
+                    onChange={setContent}
+                    onKeyDown={handleKeyDown}
+                    placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
+                    className="w-full self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[44px] max-h-20 !resize-none overflow-auto leading-[1.6]"
+                    rows={1}
+                    maxLength={250}
+                    characterCount={false}
+                    sanitize
+                  />
+                </div>
+                {imageError && (
+                  <div
+                    className="ml-1 flex items-center gap-1 text-xs text-red-400 whitespace-nowrap"
+                    role="alert"
+                    aria-live="polite"
+                  >
+                    <AlertTriangle size={14} className="flex-shrink-0" />
+                    <span className="truncate max-w-[140px] sm:max-w-[220px]">
+                      {sanitizeStrict(imageError)}
+                    </span>
+                  </div>
+                )}
+              </div>
 
               <div className="flex items-center gap-2">
                 <button

--- a/src/components/buyers/messages/MessageInput.tsx
+++ b/src/components/buyers/messages/MessageInput.tsx
@@ -92,13 +92,6 @@ export default function MessageInput({
 
       {isImageLoading && <div className="px-4 pt-3 pb-0 text-sm text-gray-400">Loading image...</div>}
 
-      {imageError && (
-        <div className="px-4 pt-3 pb-0 text-sm text-red-400 flex items-center">
-          <AlertTriangle size={14} className="mr-1" />
-          {sanitizeStrict(imageError)}
-        </div>
-      )}
-
       <div className="px-4 py-2">
         <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
           <input
@@ -124,18 +117,34 @@ export default function MessageInput({
             <Plus size={16} />
           </button>
 
-          <SecureTextarea
-            value={replyMessage}
-            onChange={setReplyMessage}
-            onKeyDown={handleKeyDown}
-            placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            rows={1}
-            className="flex-1 self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[32px] max-h-20 !resize-none overflow-auto leading-[1.6]"
-            sanitizer={messageSanitizer}
-            maxLength={250}
-            characterCount={false}
-            aria-label="Message"
-          />
+          <div className="flex flex-1 items-center gap-2 min-w-0">
+            <div className="flex-1 min-w-0">
+              <SecureTextarea
+                value={replyMessage}
+                onChange={setReplyMessage}
+                onKeyDown={handleKeyDown}
+                placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
+                rows={1}
+                className="w-full self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[32px] max-h-20 !resize-none overflow-auto leading-[1.6]"
+                sanitizer={messageSanitizer}
+                maxLength={250}
+                characterCount={false}
+                aria-label="Message"
+              />
+            </div>
+            {imageError && (
+              <div
+                className="ml-1 flex items-center gap-1 text-xs text-red-400 whitespace-nowrap"
+                role="alert"
+                aria-live="polite"
+              >
+                <AlertTriangle size={14} className="flex-shrink-0" />
+                <span className="truncate max-w-[140px] sm:max-w-[220px]">
+                  {sanitizeStrict(imageError)}
+                </span>
+              </div>
+            )}
+          </div>
 
           <div className="flex items-center gap-1.5">
             <button

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -129,13 +129,6 @@ const MessageInput: React.FC<MessageInputProps> = ({
         </div>
       )}
 
-      {validationError && (
-        <div className="mb-2 text-sm text-red-400 flex items-center">
-          <span className="mr-1">⚠️</span>
-          {sanitizeStrict(validationError)}
-        </div>
-      )}
-
       {selectedImage && (
         <div className="mb-2">
           <div className="relative inline-block">
@@ -191,21 +184,35 @@ const MessageInput: React.FC<MessageInputProps> = ({
               />
             </>
           )}
-          <div className="flex-1 flex items-center">
-            <SecureTextarea
-              ref={textareaRef}
-              value={content}
-              onChange={setContent}
-              onKeyDown={handleKeyDown}
-              placeholder={selectedImage ? 'Add a caption...' : placeholder}
-              className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[30px] resize-none"
-              rows={1}
-              maxLength={maxLength}
-              characterCount={false}
-              sanitize={true}
-              disabled={disabled}
-              aria-label="Message text"
-            />
+          <div className="flex flex-1 items-center gap-2 min-w-0">
+            <div className="flex-1 min-w-0">
+              <SecureTextarea
+                ref={textareaRef}
+                value={content}
+                onChange={setContent}
+                onKeyDown={handleKeyDown}
+                placeholder={selectedImage ? 'Add a caption...' : placeholder}
+                className="w-full !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 leading-[1.6] min-h-[30px] resize-none"
+                rows={1}
+                maxLength={maxLength}
+                characterCount={false}
+                sanitize={true}
+                disabled={disabled}
+                aria-label="Message text"
+              />
+            </div>
+            {validationError && (
+              <div
+                className="ml-1 flex items-center gap-1 text-xs text-red-400 whitespace-nowrap"
+                role="alert"
+                aria-live="polite"
+              >
+                <span aria-hidden="true">⚠️</span>
+                <span className="truncate max-w-[140px] sm:max-w-[200px]">
+                  {sanitizeStrict(validationError)}
+                </span>
+              </div>
+            )}
           </div>
 
           {showEmojiButton && (

--- a/src/components/seller/messages/MessageInput.tsx
+++ b/src/components/seller/messages/MessageInput.tsx
@@ -138,14 +138,6 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
           <div className="px-4 pt-3 pb-0 text-sm text-gray-400">Loading image...</div>
         )}
 
-        {/* Error display */}
-        {(imageError || validationError) && (
-          <div className="px-4 pt-3 pb-0 text-sm text-red-400 flex items-center">
-            <AlertTriangle size={14} className="mr-1" />
-            {sanitizeStrict(imageError || validationError || '')}
-          </div>
-        )}
-
         {/* Message input with security */}
         <div className="px-4 py-2.5">
           <div className="flex w-full items-center gap-2.5 rounded-lg border border-gray-700 bg-[#222] py-1 pl-2.5 pr-3 focus-within:border-transparent focus-within:ring-1 focus-within:ring-[#ff950e]">
@@ -172,18 +164,34 @@ const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
               <Plus size={18} />
             </button>
 
-            <SecureTextarea
-              ref={ref}
-              value={replyMessage}
-              onChange={setReplyMessage}
-              onKeyDown={onKeyDown}
-              placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-              className="flex-1 self-center bg-transparent py-[6px] text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-[1.6]"
-              rows={1}
-              maxLength={250}
-              characterCount={false}
-              sanitize={true}
-            />
+            <div className="flex flex-1 items-center gap-2 min-w-0">
+              <div className="flex-1 min-w-0">
+                <SecureTextarea
+                  ref={ref}
+                  value={replyMessage}
+                  onChange={setReplyMessage}
+                  onKeyDown={onKeyDown}
+                  placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
+                  className="w-full self-center bg-transparent py-[6px] text-white focus:outline-none focus:ring-0 min-h-[32px] max-h-20 resize-none overflow-auto leading-[1.6]"
+                  rows={1}
+                  maxLength={250}
+                  characterCount={false}
+                  sanitize={true}
+                />
+              </div>
+              {(imageError || validationError) && (
+                <div
+                  className="ml-1 flex items-center gap-1 text-xs text-red-400 whitespace-nowrap"
+                  role="alert"
+                  aria-live="polite"
+                >
+                  <AlertTriangle size={14} className="flex-shrink-0" />
+                  <span className="truncate max-w-[140px] sm:max-w-[200px]">
+                    {sanitizeStrict(imageError || validationError || '')}
+                  </span>
+                </div>
+              )}
+            </div>
 
             <div className="flex items-center gap-1.5">
               <button

--- a/src/components/seller/messages/MessageInputContainer.tsx
+++ b/src/components/seller/messages/MessageInputContainer.tsx
@@ -140,13 +140,6 @@ export default function MessageInputContainer({
         <div className="px-4 pt-3 pb-0 text-sm text-gray-400">Loading image...</div>
       )}
 
-      {imageError && (
-        <div className="px-4 pt-3 pb-0 text-sm text-red-400 flex items-center">
-          <AlertTriangle size={14} className="mr-1" />
-          {sanitizeStrict(imageError)}
-        </div>
-      )}
-
       {/* Input area */}
       <div className="px-4 py-2">
         <div className="flex w-full items-center gap-1.5 rounded-2xl border border-[#2a2d31] bg-[#1a1c20] px-3 py-1.5 focus-within:border-[#3d4352] focus-within:ring-1 focus-within:ring-[#4752e2]/40 focus-within:ring-offset-1 focus-within:ring-offset-[#16161a]">
@@ -173,22 +166,38 @@ export default function MessageInputContainer({
             <Plus size={16} />
           </button>
 
-          <SecureTextarea
-            ref={inputRef}
-            value={replyMessage}
-            onChange={setReplyMessage}
-            onKeyPress={handleKeyDown}
-            onFocus={(e) => {
-              e.preventDefault();
-            }}
-            placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
-            className="flex-1 self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[32px] max-h-20 !resize-none overflow-auto leading-[1.6]"
-            rows={1}
-            maxLength={250}
-            sanitizer={messageSanitizer}
-            characterCount={false}
-            aria-label="Message"
-          />
+          <div className="flex flex-1 items-center gap-2 min-w-0">
+            <div className="flex-1 min-w-0">
+              <SecureTextarea
+                ref={inputRef}
+                value={replyMessage}
+                onChange={setReplyMessage}
+                onKeyPress={handleKeyDown}
+                onFocus={(e) => {
+                  e.preventDefault();
+                }}
+                placeholder={selectedImage ? 'Add a caption...' : 'Type a message'}
+                className="w-full self-center !bg-transparent !border-0 !shadow-none !px-0 !py-[6px] text-[15px] text-gray-100 placeholder:text-gray-500 focus:!outline-none focus:!ring-0 min-h-[32px] max-h-20 !resize-none overflow-auto leading-[1.6]"
+                rows={1}
+                maxLength={250}
+                sanitizer={messageSanitizer}
+                characterCount={false}
+                aria-label="Message"
+              />
+            </div>
+            {imageError && (
+              <div
+                className="ml-1 flex items-center gap-1 text-xs text-red-400 whitespace-nowrap"
+                role="alert"
+                aria-live="polite"
+              >
+                <AlertTriangle size={14} className="flex-shrink-0" />
+                <span className="truncate max-w-[140px] sm:max-w-[220px]">
+                  {sanitizeStrict(imageError)}
+                </span>
+              </div>
+            )}
+          </div>
 
           <div className="flex items-center gap-1.5">
             <button


### PR DESCRIPTION
## Summary
- surface message validation feedback inline with the chat text areas so the "Type a message" hint stays aligned with the error text
- apply the same inline error layout across buyer, seller, admin, and shared messaging inputs for consistency
- constrain error labels to truncate within the chat control row while preserving existing sanitization

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f6d7dee8ec83289b10fce1745e63b2