### PR TITLE
Remove default text for image-only messages

### DIFF
--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -390,10 +390,6 @@ export const MessageProvider: React.FC<{ children: ReactNode }> = ({ children })
       }
 
       let sanitizedContent = content;
-      if (options?.type === 'image' && !sanitizedContent.trim() && options?.meta?.imageUrl) {
-        sanitizedContent = 'Image shared';
-      }
-
       if (sanitizedContent.trim()) {
         const contentValidation = messageSchemas.messageContent.safeParse(sanitizedContent);
         if (!contentValidation.success) {

--- a/src/hooks/useBuyerMessages.ts
+++ b/src/hooks/useBuyerMessages.ts
@@ -679,7 +679,7 @@ export const useBuyerMessages = () => {
     // Create optimistic message
     const tempId = uuidv4();
     const threadId = getConversationKey(user.username, activeThread);
-    const messageContent = replyMessage.trim() || (selectedImage ? 'Image shared' : '');
+    const messageContent = replyMessage.trim();
     
     const optimisticMsg: OptimisticMessage = {
       id: tempId,

--- a/src/hooks/useSellerMessages.ts
+++ b/src/hooks/useSellerMessages.ts
@@ -629,7 +629,7 @@ export function useSellerMessages() {
       });
 
       // For image messages, allow empty text
-      const messageContent = sanitizedContent || (selectedImage ? 'Image shared' : '');
+      const messageContent = sanitizedContent;
 
       // Create optimistic message
       const tempId = uuidv4();


### PR DESCRIPTION
## Summary
- stop injecting the "Image shared" placeholder when sending image-only messages
- allow image messages to be sent with empty text content in the shared messaging context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6ddcf1e448328b855cc4800114498