### PR TITLE
Allow image-only messages to be delivered

### DIFF
--- a/pantypost-backend/models/Message.js
+++ b/pantypost-backend/models/Message.js
@@ -19,8 +19,11 @@ const messageSchema = new mongoose.Schema({
   },
   content: {
     type: String,
-    required: true,
-    maxlength: 1000
+    maxlength: 1000,
+    default: '',
+    required: function() {
+      return !(this.type === 'image' && this.meta && this.meta.imageUrl);
+    }
   },
   type: {
     type: String,

--- a/pantypost-backend/routes/message.routes.js
+++ b/pantypost-backend/routes/message.routes.js
@@ -275,7 +275,9 @@ router.post('/send', authMiddleware, async (req, res) => {
     const sender = req.user.username;
     
     // Validate input
-    if (!receiver || !content) {
+    const hasImage = type === 'image' || (meta && meta.imageUrl);
+
+    if (!receiver || (!content && !hasImage)) {
       return res.status(400).json({
         success: false,
         error: 'Receiver and content are required'

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -389,6 +389,8 @@ export const MessageProvider: React.FC<{ children: ReactNode }> = ({ children })
         return;
       }
 
+      const isImageMessage = options?.type === 'image' || !!options?.meta?.imageUrl;
+
       let sanitizedContent = content;
       if (sanitizedContent.trim()) {
         const contentValidation = messageSchemas.messageContent.safeParse(sanitizedContent);
@@ -397,6 +399,11 @@ export const MessageProvider: React.FC<{ children: ReactNode }> = ({ children })
           return;
         }
         sanitizedContent = contentValidation.data;
+      } else if (!isImageMessage) {
+        console.error('Message content cannot be empty');
+        return;
+      } else {
+        sanitizedContent = '';
       }
 
       let sanitizedMeta = options?.meta;


### PR DESCRIPTION
## Summary
- allow the messaging context to send API requests when an image message has no text body
- relax client-side validation so image messages keep their metadata while still guarding normal messages
- permit the backend API and schema to save image-only messages by adjusting validation rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6e117cf788328979a17871e7e7f5b