### PR TITLE
Fix message image uploads to use persistent storage

### DIFF
--- a/src/hooks/useBuyerMessages.ts
+++ b/src/hooks/useBuyerMessages.ts
@@ -1172,7 +1172,7 @@ export const useBuyerMessages = () => {
       
       // Upload to Cloudinary instead of just reading as base64
       console.log('Uploading image to Cloudinary...');
-      const uploadResult = await uploadToCloudinary(file);
+      const uploadResult = await uploadToCloudinary(file, 'message');
       
       // Set the Cloudinary URL, not base64 data
       setSelectedImage(uploadResult.url);

--- a/src/hooks/useSellerMessages.ts
+++ b/src/hooks/useSellerMessages.ts
@@ -970,7 +970,7 @@ export function useSellerMessages() {
       
       // Upload to Cloudinary
       console.log('Uploading image to Cloudinary...');
-      const uploadResult = await uploadToCloudinary(file);
+      const uploadResult = await uploadToCloudinary(file, 'message');
       
       // Validate returned URL
       const urlValidation = z.string().url().safeParse(uploadResult.url);


### PR DESCRIPTION
## Summary
- extend the upload helper to support a dedicated `message` upload type that targets the generic upload endpoint
- update buyer and seller messaging flows to use the new message upload type so chat images persist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6e43c0cb88328bad55a6c387362d2