### PR TITLE
Fix admin wallet balance resetting on invalid updates

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -582,16 +582,31 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        let balanceValue: number;
-        if (typeof data.balance === "number") {
-          balanceValue = data.balance;
-        } else if (typeof data.newBalance === "number") {
-          balanceValue = data.newBalance;
-        } else if (data.data && typeof data.data.balance === "number") {
-          balanceValue = data.data.balance;
-        } else {
-          console.warn("[WalletContext] No valid balance in update data:", data);
-          balanceValue = 0;
+        const rawBalanceCandidates = [
+          data.balance,
+          data.newBalance,
+          data.data?.balance,
+          data.payload?.balance,
+        ];
+
+        let balanceValue: number | null = null;
+        for (const candidate of rawBalanceCandidates) {
+          if (typeof candidate === "number" && Number.isFinite(candidate)) {
+            balanceValue = candidate;
+            break;
+          }
+          if (typeof candidate === "string") {
+            const parsed = Number.parseFloat(candidate);
+            if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+              balanceValue = parsed;
+              break;
+            }
+          }
+        }
+
+        if (balanceValue === null) {
+          console.warn("[WalletContext] Skipping balance update with no valid amount:", data);
+          return;
         }
 
         const balanceValidation = walletOperationSchemas.balanceAmount.safeParse(balanceValue);
@@ -657,17 +672,31 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      let balanceValue: number;
+      const rawBalanceCandidates = [
+        data.balance,
+        data.newBalance,
+        data.data?.balance,
+        data.payload?.balance,
+      ];
 
-      if (typeof data.balance === "number") {
-        balanceValue = data.balance;
-      } else if (typeof data.newBalance === "number") {
-        balanceValue = data.newBalance;
-      } else if (data.data && typeof data.data.balance === "number") {
-        balanceValue = data.data.balance;
-      } else {
-        console.warn("[WalletContext] No valid balance in platform update:", data);
-        balanceValue = 0;
+      let balanceValue: number | null = null;
+      for (const candidate of rawBalanceCandidates) {
+        if (typeof candidate === "number" && Number.isFinite(candidate)) {
+          balanceValue = candidate;
+          break;
+        }
+        if (typeof candidate === "string") {
+          const parsed = Number.parseFloat(candidate);
+          if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+            balanceValue = parsed;
+            break;
+          }
+        }
+      }
+
+      if (balanceValue === null) {
+        console.warn("[WalletContext] Skipping platform balance update with no valid amount:", data);
+        return;
       }
 
       const balanceValidation = walletOperationSchemas.balanceAmount.safeParse(balanceValue);


### PR DESCRIPTION
## Summary
- ignore wallet balance websocket updates that omit a numeric amount so we do not overwrite the cached admin balance with 0
- apply the same validation to platform balance websocket events to keep the header display stable for admins

## Testing
- npm run lint (fails: existing lint errors throughout the project)


------
https://chatgpt.com/codex/tasks/task_e_68fa3dad57f083288c01581079e978cf