### PR TITLE
Remove gradients from login flow buttons

### DIFF
--- a/src/components/login/PasswordStep.tsx
+++ b/src/components/login/PasswordStep.tsx
@@ -308,8 +308,7 @@ export default function PasswordStep({
         <button
           type="submit"
           disabled={!role || !password || isLoading || hasUser || isRateLimited || isPasswordResetPending}
-          className="w-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] hover:from-[#ff6b00] hover:to-[#ff950e] disabled:from-gray-700 disabled:to-gray-600 text-black disabled:text-gray-400 font-semibold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 disabled:cursor-not-allowed hover:scale-[1.02] active:scale-[0.98]"
-          style={{ color: (!role || !password || isLoading || hasUser || isRateLimited || isPasswordResetPending) ? undefined : '#000' }}
+          className="w-full bg-[#ff950e] hover:bg-[#ff6b00] disabled:bg-gray-700 text-black disabled:text-gray-400 font-semibold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 disabled:cursor-not-allowed hover:scale-[1.02] active:scale-[0.98]"
         >
           {isPasswordResetPending ? (
             <>

--- a/src/components/login/UsernameStep.tsx
+++ b/src/components/login/UsernameStep.tsx
@@ -52,8 +52,7 @@ export default function UsernameStep({
         <button
           type="submit"
           disabled={isDisabled || !username}
-          className="w-full bg-gradient-to-r from-[#ff950e] to-[#ff6b00] hover:from-[#ff6b00] hover:to-[#ff950e] disabled:from-gray-700 disabled:to-gray-600 text-black disabled:text-gray-400 font-semibold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 disabled:cursor-not-allowed hover:scale-[1.02] active:scale-[0.98]"
-          style={{ color: isDisabled || !username ? undefined : '#000' }}
+          className="w-full bg-[#ff950e] hover:bg-[#ff6b00] disabled:bg-gray-700 text-black disabled:text-gray-400 font-semibold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 disabled:cursor-not-allowed hover:scale-[1.02] active:scale-[0.98]"
         >
           Continue
           <ArrowRight className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- replace gradient backgrounds on the username step and password step buttons with a solid brand color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb575528708328b30595e94978bd20