### PR TITLE
Adjust message layouts to respect header height

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -58,7 +58,7 @@ export default function AdminMessagesPage() {
   if (!isAdmin) {
     return (
       <RequireAuth role="admin">
-        <div className="h-screen flex items-center justify-center bg-black">
+        <div className="h-full flex items-center justify-center bg-black">
           <div className="bg-[#121212] rounded-lg shadow-lg p-8 max-w-md">
             <div className="flex items-center mb-4">
               <AlertTriangle size={32} className="text-[#ff950e] mr-3" />
@@ -85,7 +85,7 @@ export default function AdminMessagesPage() {
     <RequireAuth role="admin">
       <div className="py-3 bg-black"></div>
 
-      <div className="h-screen bg-black flex flex-col overflow-hidden">
+      <div className="h-full bg-black flex flex-col overflow-hidden">
         <div className="flex-1 flex flex-col md:flex-row max-w-6xl mx-auto w-full bg-[#121212] rounded-lg shadow-lg overflow-hidden">
           {/* Left column - Message threads and User Directory */}
           <div className="w-full md:w-1/3 border-r border-gray-800 flex flex-col bg-[#121212]">

--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -198,7 +198,7 @@ export default function BuyerMessagesPage() {
       <BanCheck>
         <RequireAuth role="buyer">
           <div className="py-3 bg-black"></div>
-          <div className="h-screen bg-black flex items-center justify-center">
+          <div className="h-full bg-black flex items-center justify-center">
             <div className="text-white">Loading...</div>
           </div>
         </RequireAuth>
@@ -217,11 +217,11 @@ export default function BuyerMessagesPage() {
         {/* On mobile with activeThread: fixed positioning full screen */}
         {/* On desktop: always full height */}
         <div className={`${
-          isMobile 
-            ? activeThread 
-              ? 'fixed inset-0' 
-              : 'h-screen flex flex-col'
-            : 'h-screen bg-black flex flex-col'
+          isMobile
+            ? activeThread
+              ? 'fixed inset-0'
+              : 'flex flex-col h-full'
+            : 'bg-black flex flex-col h-full'
         }`}>
           <div className={`${
             isMobile 

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -111,7 +111,7 @@ export default function SellerMessagesPage() {
       <BanCheck>
         <RequireAuth role="seller">
           <div className="py-3 bg-black"></div>
-          <div className="h-screen bg-black flex items-center justify-center">
+          <div className="h-full bg-black flex items-center justify-center">
             <div className="text-white">Loading...</div>
           </div>
         </RequireAuth>
@@ -127,11 +127,11 @@ export default function SellerMessagesPage() {
         
         {/* Main container - matching buyer's responsive layout */}
         <div className={`${
-          isMobile 
-            ? activeThread 
-              ? 'fixed inset-0' 
-              : 'h-screen flex flex-col'
-            : 'h-screen bg-black flex flex-col'
+          isMobile
+            ? activeThread
+              ? 'fixed inset-0'
+              : 'flex flex-col h-full'
+            : 'bg-black flex flex-col h-full'
         }`}>
           <div className={`${
             isMobile 


### PR DESCRIPTION
## Summary
- update buyer, seller, and admin message layouts to size to the available space instead of forcing a full viewport height
- ensure the loading states also use the available height so the header and composer remain visible together

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb5886fe348328bafe5c97ac7e23aa