### PR TITLE
Improve message layout scrolling behavior

### DIFF
--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -220,22 +220,22 @@ export default function BuyerMessagesPage() {
           isMobile
             ? activeThread
               ? 'fixed inset-0'
-              : 'flex flex-col h-full'
-            : 'bg-black flex flex-col h-full'
+              : 'flex flex-col h-full min-h-screen'
+            : 'bg-black flex flex-col h-full min-h-screen'
         }`}>
           <div className={`${
-            isMobile 
-              ? 'w-full h-full flex flex-col overflow-hidden' 
-              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden'
+            isMobile
+              ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
+              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0'
           } bg-[#121212]`}>
             
             {/* Mobile: Only show ThreadsSidebar when no active thread */}
             <div className={`${
-              activeThread && isMobile 
-                ? 'hidden' 
-                : isMobile 
-                  ? 'flex flex-col h-full overflow-hidden' 
-                  : 'w-full md:w-1/3 overflow-hidden'
+              activeThread && isMobile
+                ? 'hidden'
+                : isMobile
+                  ? 'flex flex-col h-full overflow-hidden min-h-0'
+                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0'
             }`}>
               <ThreadsSidebar
                 threads={threads}
@@ -259,14 +259,14 @@ export default function BuyerMessagesPage() {
             {/* Mobile: Only show conversation when thread is active */}
             {/* Desktop: Always show conversation area */}
             <div className={`${
-              !activeThread && isMobile 
-                ? 'hidden' 
+              !activeThread && isMobile
+                ? 'hidden'
                 : 'flex'
             } ${
-              isMobile 
-                ? 'flex-col h-full overflow-hidden' 
+              isMobile
+                ? 'flex-col h-full overflow-hidden min-h-0'
                 : 'w-full md:w-2/3'
-            } flex-col bg-[#121212] overflow-hidden`}>
+            } flex-col bg-[#121212] overflow-hidden min-h-0`}>
               {activeThread ? (
                 <ConversationView
                   activeThread={activeThread}

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -130,22 +130,22 @@ export default function SellerMessagesPage() {
           isMobile
             ? activeThread
               ? 'fixed inset-0'
-              : 'flex flex-col h-full'
-            : 'bg-black flex flex-col h-full'
+              : 'flex flex-col h-full min-h-screen'
+            : 'bg-black flex flex-col h-full min-h-screen'
         }`}>
           <div className={`${
-            isMobile 
-              ? 'w-full h-full flex flex-col overflow-hidden' 
-              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden'
+            isMobile
+              ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
+              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0'
           } bg-[#121212]`}>
             
             {/* Mobile: Only show ThreadsSidebar when no active thread */}
             <div className={`${
-              activeThread && isMobile 
-                ? 'hidden' 
-                : isMobile 
-                  ? 'flex flex-col h-full overflow-hidden' 
-                  : 'w-full md:w-1/3 overflow-hidden'
+              activeThread && isMobile
+                ? 'hidden'
+                : isMobile
+                  ? 'flex flex-col h-full overflow-hidden min-h-0'
+                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0'
             }`}>
               <ThreadsSidebar
                 isAdmin={isAdmin}
@@ -167,14 +167,14 @@ export default function SellerMessagesPage() {
             {/* Mobile: Only show conversation when thread is active */}
             {/* Desktop: Always show conversation area */}
             <div className={`${
-              !activeThread && isMobile 
-                ? 'hidden' 
+              !activeThread && isMobile
+                ? 'hidden'
                 : 'flex'
             } ${
-              isMobile 
-                ? 'flex-col h-full overflow-hidden' 
+              isMobile
+                ? 'flex-col h-full overflow-hidden min-h-0'
                 : 'w-full md:w-2/3'
-            } flex-col bg-[#121212] overflow-hidden`}>
+            } flex-col bg-[#121212] overflow-hidden min-h-0`}>
               {activeThread ? (
                 <ConversationView
                   activeThread={activeThread}

--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -258,24 +258,29 @@ export default function ConversationView(props: ConversationViewProps) {
   }, [isMobile, messagesContainerRef]);
 
   // Auto-scroll to bottom on new messages
-  const scrollToBottom = useCallback((behavior: 'instant' | 'smooth' = 'instant') => {
-    if (!messagesContainerRef.current) return;
-    
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const scroller = messagesContainerRef.current;
+    if (!scroller) return;
+
     const isNearBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 100;
-    
-    // Only auto-scroll if user is near bottom or it's a new conversation
+
     if (isNearBottom || !userHasScrolledRef.current) {
-      scroller.scrollTo({
-        top: scroller.scrollHeight,
-        behavior: behavior
+      requestAnimationFrame(() => {
+        scroller.scrollTo({
+          top: scroller.scrollHeight,
+          behavior
+        });
+
+        if (messagesEndRef.current) {
+          messagesEndRef.current.scrollIntoView({ behavior, block: 'end' });
+        }
       });
     }
-  }, [messagesContainerRef]);
+  }, [messagesContainerRef, messagesEndRef]);
 
   // Scroll to bottom when messages change
   useEffect(() => {
-    scrollToBottom('instant');
+    scrollToBottom('auto');
   }, [threadMessages.length, scrollToBottom]);
 
   // Thread focus/blur
@@ -392,7 +397,7 @@ export default function ConversationView(props: ConversationViewProps) {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         handleReply();
-        scrollToBottom('instant');
+        scrollToBottom('auto');
       }
     },
     [handleReply, scrollToBottom]
@@ -408,7 +413,7 @@ export default function ConversationView(props: ConversationViewProps) {
     
     // Scroll to bottom after sending
     setTimeout(() => {
-      scrollToBottom('instant');
+      scrollToBottom('auto');
       // Refocus input without scrolling
       if (inputRef.current) {
         (inputRef.current as any).focus({ preventScroll: true });
@@ -916,14 +921,14 @@ export default function ConversationView(props: ConversationViewProps) {
   // Mobile Layout
   if (isMobile) {
     return (
-      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden">
+      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden min-h-0">
         {/* Mobile Header */}
         {renderMobileHeader()}
 
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2"
+          className="flex-1 overflow-y-auto px-3 py-2 min-h-0"
           style={{ 
             WebkitOverflowScrolling: 'touch'
           }}
@@ -964,15 +969,15 @@ export default function ConversationView(props: ConversationViewProps) {
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212]">
+    <div className="h-full flex flex-col bg-[#121212] min-h-0">
       {/* Desktop Header */}
       <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
         {renderDesktopHeader()}
       </div>
 
       {/* Desktop Messages */}
-      <div 
-        className="flex-1 overflow-y-auto bg-[#121212]" 
+      <div
+        className="flex-1 overflow-y-auto bg-[#121212] min-h-0"
         ref={messagesContainerRef}
       >
         <div className="max-w-3xl mx-auto space-y-4 p-4">

--- a/src/components/buyers/messages/ThreadsSidebar.tsx
+++ b/src/components/buyers/messages/ThreadsSidebar.tsx
@@ -394,7 +394,7 @@ export default function ThreadsSidebar({
       </div>
       
       {/* Thread List */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto min-h-0">
         {activeTab === 'messages' && (
           <>
             {filteredThreads.length === 0 ? (

--- a/src/components/seller/messages/ConversationView.tsx
+++ b/src/components/seller/messages/ConversationView.tsx
@@ -171,23 +171,29 @@ export default function ConversationView({
   }, [isMobile]);
 
   // Auto-scroll to bottom
-  const scrollToBottom = useCallback((behavior: 'instant' | 'smooth' = 'instant') => {
-    if (!messagesContainerRef.current) return;
-    
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const scroller = messagesContainerRef.current;
+    if (!scroller) return;
+
     const isNearBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 100;
-    
+
     if (isNearBottom || !userHasScrolledRef.current) {
-      scroller.scrollTo({
-        top: scroller.scrollHeight,
-        behavior: behavior
+      requestAnimationFrame(() => {
+        scroller.scrollTo({
+          top: scroller.scrollHeight,
+          behavior,
+        });
+
+        if (messagesEndRef.current) {
+          messagesEndRef.current.scrollIntoView({ behavior, block: 'end' });
+        }
       });
     }
-  }, []);
+  }, [messagesEndRef]);
 
   // Scroll to bottom when messages change
   useEffect(() => {
-    scrollToBottom('instant');
+    scrollToBottom('auto');
   }, [threadMessages.length, scrollToBottom]);
 
   // Thread focus/blur
@@ -336,7 +342,7 @@ export default function ConversationView({
       messageInputControls.handleReply();
       
       setTimeout(() => {
-        scrollToBottom('instant');
+        scrollToBottom('auto');
         if (inputRef.current) {
           (inputRef.current as any).focus({ preventScroll: true });
         }
@@ -602,14 +608,14 @@ export default function ConversationView({
   // Mobile Layout
   if (isMobile) {
     return (
-      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden">
+      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden min-h-0">
         {/* Mobile Header */}
         {renderMobileHeader()}
 
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2"
+          className="flex-1 overflow-y-auto px-3 py-2 min-h-0"
           style={{ 
             WebkitOverflowScrolling: 'touch'
           }}
@@ -685,15 +691,15 @@ export default function ConversationView({
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212]">
+    <div className="h-full flex flex-col bg-[#121212] min-h-0">
       {/* Desktop Header */}
       <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
         {renderDesktopHeader()}
       </div>
 
       {/* Desktop Messages */}
-      <div 
-        className="flex-1 overflow-y-auto bg-[#121212]" 
+      <div
+        className="flex-1 overflow-y-auto bg-[#121212] min-h-0"
         ref={messagesContainerRef}
       >
         <div className="max-w-3xl mx-auto space-y-4 p-4">

--- a/src/components/seller/messages/ThreadsSidebar.tsx
+++ b/src/components/seller/messages/ThreadsSidebar.tsx
@@ -122,7 +122,7 @@ export default function ThreadsSidebar({
       </div>
       
       {/* Thread List */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto min-h-0">
         {filteredThreads.length === 0 ? (
           <div className="p-4 text-center text-gray-400">
             <MessageSquare className="mx-auto mb-2 opacity-50" size={24} />


### PR DESCRIPTION
## Summary
- prevent the buyer and seller message layouts from expanding the entire page by enforcing viewport-height flex containers and min-h-0 overflow handling
- adjust conversation views so chat panes maintain their own scroll areas on mobile and desktop, including thread sidebars
- ensure conversations automatically follow new messages by scrolling to the end element when updates arrive or messages are sent

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf855db8c8328abcbc4f162d51786