### PR TITLE
Fix messaging layouts to use flex overflow containers

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -132,7 +132,7 @@ export default function ClientLayout({
           <div className={`flex flex-col fullscreen md:min-h-screen bg-black text-white ${showContent ? 'app-fade-in' : 'opacity-0'}`}>
             <BanCheck>
               {!shouldHideHeader && <Header />}
-              <main className="flex-1">
+              <main className="flex flex-1 overflow-hidden">
                 {children}
               </main>
               <AgeVerificationModal />

--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -209,125 +209,125 @@ export default function BuyerMessagesPage() {
   return (
     <BanCheck>
       <RequireAuth role="buyer">
-        {/* Desktop padding - hide on mobile */}
-        <div className="hidden md:block py-3 bg-black"></div>
-        
-        {/* Main container */}
-        {/* On mobile without activeThread: relative positioning to flow with header */}
-        {/* On mobile with activeThread: fixed positioning full screen */}
-        {/* On desktop: always full height */}
-        <div className={`${
-          isMobile
-            ? activeThread
-              ? 'fixed inset-0'
-              : 'flex flex-col h-full min-h-screen'
-            : 'bg-black flex flex-col h-full min-h-screen'
-        }`}>
-          <div className={`${
-            isMobile
-              ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
-              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0'
-          } bg-[#121212]`}>
-            
-            {/* Mobile: Only show ThreadsSidebar when no active thread */}
-            <div className={`${
-              activeThread && isMobile
-                ? 'hidden'
-                : isMobile
-                  ? 'flex flex-col h-full overflow-hidden min-h-0'
-                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0'
-            }`}>
-              <ThreadsSidebar
-                threads={threads}
-                lastMessages={lastMessages}
-                sellerProfiles={sellerProfiles}
-                uiUnreadCounts={uiUnreadCounts}
-                activeThread={activeThread}
-                setActiveThread={setActiveThread}
-                searchQuery={searchQuery}
-                setSearchQuery={setSearchQuery}
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-                filterBy={filterBy}
-                setFilterBy={setFilterBy}
-                totalUnreadCount={totalUnreadCount}
-                buyerRequests={buyerRequests}
-                setObserverReadMessages={setObserverReadMessages}
-              />
-            </div>
-            
-            {/* Mobile: Only show conversation when thread is active */}
-            {/* Desktop: Always show conversation area */}
-            <div className={`${
-              !activeThread && isMobile
-                ? 'hidden'
-                : 'flex'
-            } ${
-              isMobile
-                ? 'flex-col h-full overflow-hidden min-h-0'
-                : 'w-full md:w-2/3'
-            } flex-col bg-[#121212] overflow-hidden min-h-0`}>
-              {activeThread ? (
-                <ConversationView
-                  activeThread={activeThread}
-                  threads={threads}
-                  user={user}
-                  sellerProfiles={sellerProfiles}
-                  buyerRequests={buyerRequests}
-                  wallet={walletData}
-                  previewImage={previewImage}
-                  setPreviewImage={setPreviewImage}
-                  showEmojiPicker={showEmojiPicker}
-                  setShowEmojiPicker={setShowEmojiPicker}
-                  recentEmojis={recentEmojis}
-                  replyMessage={replyMessage}
-                  setReplyMessage={setReplyMessage}
-                  selectedImage={selectedImage}
-                  setSelectedImage={setSelectedImage}
-                  isImageLoading={isImageLoading}
-                  imageError={imageError}
-                  editRequestId={editRequestId}
-                  setEditRequestId={setEditRequestId}
-                  editPrice={numericEditPrice}
-                  setEditPrice={handleEditPriceChange}
-                  editTitle={editTitle}
-                  setEditTitle={setEditTitle}
-                  editTags={editTags}
-                  setEditTags={setEditTags}
-                  editMessage={editMessage}
-                  setEditMessage={setEditMessage}
-                  handleReply={handleReply}
-                  handleBlockToggle={handleBlockToggle}
-                  handleReport={handleReport}
-                  handleAccept={handleAccept}
-                  handleDecline={handleDecline}
-                  handleEditRequest={handleEditRequest}
-                  handleEditSubmit={handleEditSubmit}
-                  handlePayNow={handlePayNow}
-                  handleImageSelect={handleImageSelect}
-                  handleMessageVisible={handleMessageVisible}
-                  handleEmojiClick={handleEmojiClick}
-                  isUserBlocked={isUserBlocked(activeThread)}
-                  isUserReported={isUserReported(activeThread)}
-                  messagesEndRef={messagesEndRef}
-                  messagesContainerRef={messagesContainerRef}
-                  fileInputRef={fileInputRef}
-                  emojiPickerRef={emojiPickerRef}
-                  inputRef={inputRef}
-                  lastManualScrollTime={lastManualScrollTime}
-                  setShowCustomRequestModal={setShowCustomRequestModal}
-                  setShowTipModal={setShowTipModal}
-                  isMobile={isMobile}
-                  onBack={handleMobileBack}
-                />
-              ) : (
-                <EmptyState />
-              )}
-            </div>
-          </div>
-          
-          {/* Desktop bottom padding */}
+        <div className="flex min-h-0 flex-1 flex-col bg-black">
+          {/* Desktop padding - hide on mobile */}
           <div className="hidden md:block py-3 bg-black"></div>
+
+          {/* Main container */}
+          {/* On mobile without activeThread: relative positioning to flow with header */}
+          {/* On mobile with activeThread: fixed positioning full screen */}
+          {/* On desktop: always full height */}
+          <div className={`${
+            isMobile && activeThread
+              ? 'fixed inset-0 flex flex-col bg-black'
+              : 'flex min-h-0 flex-1 flex-col bg-black'
+          }`}>
+            <div className={`${
+              isMobile
+                ? 'flex min-h-0 flex-1 flex-col'
+                : 'mx-auto flex min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
+            } bg-[#121212]`}>
+
+              {/* Mobile: Only show ThreadsSidebar when no active thread */}
+              <div className={`${
+                activeThread && isMobile
+                  ? 'hidden'
+                  : isMobile
+                    ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
+                    : 'w-full md:max-w-xs md:flex md:flex-col md:overflow-hidden md:min-h-0'
+              }`}>
+                <ThreadsSidebar
+                  threads={threads}
+                  lastMessages={lastMessages}
+                  sellerProfiles={sellerProfiles}
+                  uiUnreadCounts={uiUnreadCounts}
+                  activeThread={activeThread}
+                  setActiveThread={setActiveThread}
+                  searchQuery={searchQuery}
+                  setSearchQuery={setSearchQuery}
+                  activeTab={activeTab}
+                  setActiveTab={setActiveTab}
+                  filterBy={filterBy}
+                  setFilterBy={setFilterBy}
+                  totalUnreadCount={totalUnreadCount}
+                  buyerRequests={buyerRequests}
+                  setObserverReadMessages={setObserverReadMessages}
+                />
+              </div>
+
+              {/* Mobile: Only show conversation when thread is active */}
+              {/* Desktop: Always show conversation area */}
+              <div className={`${
+                !activeThread && isMobile
+                  ? 'hidden'
+                  : 'flex'
+              } ${
+                isMobile
+                  ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
+                  : 'w-full md:flex-1'
+              } flex-col bg-[#121212] overflow-hidden min-h-0`}>
+                {activeThread ? (
+                  <ConversationView
+                    activeThread={activeThread}
+                    threads={threads}
+                    user={user}
+                    sellerProfiles={sellerProfiles}
+                    buyerRequests={buyerRequests}
+                    wallet={walletData}
+                    previewImage={previewImage}
+                    setPreviewImage={setPreviewImage}
+                    showEmojiPicker={showEmojiPicker}
+                    setShowEmojiPicker={setShowEmojiPicker}
+                    recentEmojis={recentEmojis}
+                    replyMessage={replyMessage}
+                    setReplyMessage={setReplyMessage}
+                    selectedImage={selectedImage}
+                    setSelectedImage={setSelectedImage}
+                    isImageLoading={isImageLoading}
+                    imageError={imageError}
+                    editRequestId={editRequestId}
+                    setEditRequestId={setEditRequestId}
+                    editPrice={numericEditPrice}
+                    setEditPrice={handleEditPriceChange}
+                    editTitle={editTitle}
+                    setEditTitle={setEditTitle}
+                    editTags={editTags}
+                    setEditTags={setEditTags}
+                    editMessage={editMessage}
+                    setEditMessage={setEditMessage}
+                    handleReply={handleReply}
+                    handleBlockToggle={handleBlockToggle}
+                    handleReport={handleReport}
+                    handleAccept={handleAccept}
+                    handleDecline={handleDecline}
+                    handleEditRequest={handleEditRequest}
+                    handleEditSubmit={handleEditSubmit}
+                    handlePayNow={handlePayNow}
+                    handleImageSelect={handleImageSelect}
+                    handleMessageVisible={handleMessageVisible}
+                    handleEmojiClick={handleEmojiClick}
+                    isUserBlocked={isUserBlocked(activeThread)}
+                    isUserReported={isUserReported(activeThread)}
+                    messagesEndRef={messagesEndRef}
+                    messagesContainerRef={messagesContainerRef}
+                    fileInputRef={fileInputRef}
+                    emojiPickerRef={emojiPickerRef}
+                    inputRef={inputRef}
+                    lastManualScrollTime={lastManualScrollTime}
+                    setShowCustomRequestModal={setShowCustomRequestModal}
+                    setShowTipModal={setShowTipModal}
+                    isMobile={isMobile}
+                    onBack={handleMobileBack}
+                  />
+                ) : (
+                  <EmptyState />
+                )}
+              </div>
+            </div>
+
+            {/* Desktop bottom padding */}
+            <div className="hidden md:block py-3 bg-black"></div>
+          </div>
         </div>
 
         {/* Modals */}

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -122,122 +122,122 @@ export default function SellerMessagesPage() {
   return (
     <BanCheck>
       <RequireAuth role="seller">
-        {/* Desktop padding - hide on mobile */}
-        <div className="hidden md:block py-3 bg-black"></div>
-        
-        {/* Main container - matching buyer's responsive layout */}
-        <div className={`${
-          isMobile
-            ? activeThread
-              ? 'fixed inset-0'
-              : 'flex flex-col h-full min-h-screen'
-            : 'bg-black flex flex-col h-full min-h-screen'
-        }`}>
-          <div className={`${
-            isMobile
-              ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
-              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0'
-          } bg-[#121212]`}>
-            
-            {/* Mobile: Only show ThreadsSidebar when no active thread */}
-            <div className={`${
-              activeThread && isMobile
-                ? 'hidden'
-                : isMobile
-                  ? 'flex flex-col h-full overflow-hidden min-h-0'
-                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0'
-            }`}>
-              <ThreadsSidebar
-                isAdmin={isAdmin}
-                threads={threads}
-                lastMessages={lastMessages}
-                buyerProfiles={buyerProfiles}
-                totalUnreadCount={totalUnreadCount}
-                uiUnreadCounts={uiUnreadCounts}
-                activeThread={activeThread}
-                setActiveThread={setActiveThread}
-                searchQuery={searchQuery}
-                setSearchQuery={setSearchQuery}
-                filterBy={filterBy}
-                setFilterBy={setFilterBy}
-                setObserverReadMessages={setObserverReadMessages}
-              />
-            </div>
-            
-            {/* Mobile: Only show conversation when thread is active */}
-            {/* Desktop: Always show conversation area */}
-            <div className={`${
-              !activeThread && isMobile
-                ? 'hidden'
-                : 'flex'
-            } ${
-              isMobile
-                ? 'flex-col h-full overflow-hidden min-h-0'
-                : 'w-full md:w-2/3'
-            } flex-col bg-[#121212] overflow-hidden min-h-0`}>
-              {activeThread ? (
-                <ConversationView
-                  activeThread={activeThread}
-                  threads={threads}
-                  buyerProfiles={buyerProfiles}
-                  sellerRequests={sellerRequests}
-                  isUserBlocked={isUserBlocked}
-                  isUserReported={isUserReported}
-                  handleReport={handleReport}
-                  handleBlockToggle={handleBlockToggle}
-                  user={user}
-                  messageInputControls={{
-                    replyMessage,
-                    setReplyMessage,
-                    selectedImage,
-                    setSelectedImage,
-                    isImageLoading,
-                    setIsImageLoading,
-                    imageError,
-                    setImageError,
-                    showEmojiPicker,
-                    setShowEmojiPicker,
-                    recentEmojis,
-                    handleReply,
-                    handleEmojiClick,
-                    handleImageSelect,
-                  }}
-                  editRequestControls={{
-                    editRequestId,
-                    setEditRequestId,
-                    editPrice,
-                    setEditPrice,
-                    editTitle,
-                    setEditTitle,
-                    editMessage,
-                    setEditMessage,
-                    handleEditSubmit,
-                  }}
-                  handleAccept={handleAccept}
-                  handleDecline={handleDecline}
-                  handleEditRequest={handleEditRequest}
-                  handleMessageVisible={handleMessageVisible}
-                  setPreviewImage={setPreviewImage}
-                  isMobile={isMobile}
-                  onBack={handleMobileBack}
-                />
-              ) : (
-                <EmptyState />
-              )}
-            </div>
-          </div>
-
-          {/* Desktop bottom padding */}
+        <div className="flex min-h-0 flex-1 flex-col bg-black">
+          {/* Desktop padding - hide on mobile */}
           <div className="hidden md:block py-3 bg-black"></div>
 
-          {/* Image Preview Modal */}
-          {previewImage && (
-            <ImagePreviewModal
-              imageUrl={previewImage}
-              isOpen={true}
-              onClose={() => setPreviewImage(null)}
-            />
-          )}
+          {/* Main container - matching buyer's responsive layout */}
+          <div className={`${
+            isMobile && activeThread
+              ? 'fixed inset-0 flex flex-col bg-black'
+              : 'flex min-h-0 flex-1 flex-col bg-black'
+          }`}>
+            <div className={`${
+              isMobile
+                ? 'flex min-h-0 flex-1 flex-col'
+                : 'mx-auto flex min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
+            } bg-[#121212]`}>
+
+              {/* Mobile: Only show ThreadsSidebar when no active thread */}
+              <div className={`${
+                activeThread && isMobile
+                  ? 'hidden'
+                  : isMobile
+                    ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
+                    : 'w-full md:max-w-xs md:flex md:flex-col md:overflow-hidden md:min-h-0'
+              }`}>
+                <ThreadsSidebar
+                  isAdmin={isAdmin}
+                  threads={threads}
+                  lastMessages={lastMessages}
+                  buyerProfiles={buyerProfiles}
+                  totalUnreadCount={totalUnreadCount}
+                  uiUnreadCounts={uiUnreadCounts}
+                  activeThread={activeThread}
+                  setActiveThread={setActiveThread}
+                  searchQuery={searchQuery}
+                  setSearchQuery={setSearchQuery}
+                  filterBy={filterBy}
+                  setFilterBy={setFilterBy}
+                  setObserverReadMessages={setObserverReadMessages}
+                />
+              </div>
+
+              {/* Mobile: Only show conversation when thread is active */}
+              {/* Desktop: Always show conversation area */}
+              <div className={`${
+                !activeThread && isMobile
+                  ? 'hidden'
+                  : 'flex'
+              } ${
+                isMobile
+                  ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
+                  : 'w-full md:flex-1'
+              } flex-col bg-[#121212] overflow-hidden min-h-0`}>
+                {activeThread ? (
+                  <ConversationView
+                    activeThread={activeThread}
+                    threads={threads}
+                    buyerProfiles={buyerProfiles}
+                    sellerRequests={sellerRequests}
+                    isUserBlocked={isUserBlocked}
+                    isUserReported={isUserReported}
+                    handleReport={handleReport}
+                    handleBlockToggle={handleBlockToggle}
+                    user={user}
+                    messageInputControls={{
+                      replyMessage,
+                      setReplyMessage,
+                      selectedImage,
+                      setSelectedImage,
+                      isImageLoading,
+                      setIsImageLoading,
+                      imageError,
+                      setImageError,
+                      showEmojiPicker,
+                      setShowEmojiPicker,
+                      recentEmojis,
+                      handleReply,
+                      handleEmojiClick,
+                      handleImageSelect,
+                    }}
+                    editRequestControls={{
+                      editRequestId,
+                      setEditRequestId,
+                      editPrice,
+                      setEditPrice,
+                      editTitle,
+                      setEditTitle,
+                      editMessage,
+                      setEditMessage,
+                      handleEditSubmit,
+                    }}
+                    handleAccept={handleAccept}
+                    handleDecline={handleDecline}
+                    handleEditRequest={handleEditRequest}
+                    handleMessageVisible={handleMessageVisible}
+                    setPreviewImage={setPreviewImage}
+                    isMobile={isMobile}
+                    onBack={handleMobileBack}
+                  />
+                ) : (
+                  <EmptyState />
+                )}
+              </div>
+            </div>
+
+            {/* Desktop bottom padding */}
+            <div className="hidden md:block py-3 bg-black"></div>
+
+            {/* Image Preview Modal */}
+            {previewImage && (
+              <ImagePreviewModal
+                imageUrl={previewImage}
+                isOpen={true}
+                onClose={() => setPreviewImage(null)}
+              />
+            )}
+          </div>
         </div>
       </RequireAuth>
     </BanCheck>


### PR DESCRIPTION
## Summary
- make the client layout main element a flex overflow-hidden container so feature pages control scroll areas
- clamp the buyer messaging page to the viewport with min-h-0 flex wrappers and dedicated scrollable panes
- mirror the viewport-bound flex scrolling structure for the seller messaging experience

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc03aa44c883288d8c942a2c8e44dc