### PR TITLE
Extend chat scroll layout to buyer and seller messages

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -83,76 +83,77 @@ export default function AdminMessagesPage() {
 
   return (
     <RequireAuth role="admin">
-      <div className="py-3 bg-black"></div>
+      <div className="min-h-screen bg-black flex flex-col">
+        <div className="py-3 bg-black flex-shrink-0"></div>
 
-      <div className="h-full bg-black flex flex-col overflow-hidden">
-        <div className="flex-1 flex flex-col md:flex-row max-w-6xl mx-auto w-full bg-[#121212] rounded-lg shadow-lg overflow-hidden">
-          {/* Left column - Message threads and User Directory */}
-          <div className="w-full md:w-1/3 border-r border-gray-800 flex flex-col bg-[#121212]">
-            <MessagesHeader
-              filterBy={filterBy}
-              setFilterBy={setFilterBy}
-              totalUnreadCount={totalUnreadCount ?? 0}
-              showUserDirectory={showUserDirectory}
-              setShowUserDirectory={setShowUserDirectory}
-              searchQuery={searchQuery ?? ''}
-              setSearchQuery={setSearchQuery}
-              directorySearchQuery={directorySearchQuery ?? ''}
-              setDirectorySearchQuery={setDirectorySearchQuery}
-            />
+        <div className="flex-1 overflow-hidden">
+          <div className="mx-auto flex h-full w-full max-w-6xl flex-col rounded-lg bg-[#121212] shadow-lg md:flex-row min-h-0 overflow-hidden">
+            {/* Left column - Message threads and User Directory */}
+            <div className="flex w-full flex-1 flex-col border-r border-gray-800 bg-[#121212] min-h-0 md:w-1/3 md:flex-none">
+              <MessagesHeader
+                filterBy={filterBy}
+                setFilterBy={setFilterBy}
+                totalUnreadCount={totalUnreadCount ?? 0}
+                showUserDirectory={showUserDirectory}
+                setShowUserDirectory={setShowUserDirectory}
+                searchQuery={searchQuery ?? ''}
+                setSearchQuery={setSearchQuery}
+                directorySearchQuery={directorySearchQuery ?? ''}
+                setDirectorySearchQuery={setDirectorySearchQuery}
+              />
 
-            {/* Content Area - Either Conversations or User Directory */}
-            <div className="flex-1 overflow-y-auto bg-[#121212]">
-              {showUserDirectory ? (
-                <UserDirectoryContent
-                  allUsers={safeAllUsers}
-                  directorySearchQuery={directorySearchQuery ?? ''}
-                  filterBy={filterBy}
-                  onStartConversation={handleStartConversation}
-                  onClearFilters={() => {
-                    setDirectorySearchQuery('');
-                    setFilterBy('all');
-                  }}
-                />
-              ) : (
-                <ConversationsContent
-                  threads={safeThreads}
-                  lastMessages={safeLastMessages}
-                  unreadCounts={safeUnreadCounts}
-                  userProfiles={safeUserProfiles}
-                  activeThread={activeThread}
-                  searchQuery={searchQuery ?? ''}
-                  filterBy={filterBy}
-                  onThreadSelect={handleThreadSelect}
-                  onStartNewConversation={() => setShowUserDirectory(true)}
-                />
-              )}
+              {/* Content Area - Either Conversations or User Directory */}
+              <div className="flex-1 overflow-y-auto bg-[#121212]">
+                {showUserDirectory ? (
+                  <UserDirectoryContent
+                    allUsers={safeAllUsers}
+                    directorySearchQuery={directorySearchQuery ?? ''}
+                    filterBy={filterBy}
+                    onStartConversation={handleStartConversation}
+                    onClearFilters={() => {
+                      setDirectorySearchQuery('');
+                      setFilterBy('all');
+                    }}
+                  />
+                ) : (
+                  <ConversationsContent
+                    threads={safeThreads}
+                    lastMessages={safeLastMessages}
+                    unreadCounts={safeUnreadCounts}
+                    userProfiles={safeUserProfiles}
+                    activeThread={activeThread}
+                    searchQuery={searchQuery ?? ''}
+                    filterBy={filterBy}
+                    onThreadSelect={handleThreadSelect}
+                    onStartNewConversation={() => setShowUserDirectory(true)}
+                  />
+                )}
+              </div>
             </div>
-          </div>
-
-          {/* Right column - Active conversation */}
-          <div className="w-full md:w-2/3 flex flex-col bg-[#121212]">
-            <ChatContent
-              activeThread={activeThread}
-              activeMessages={safeActiveMessages}
-              userProfiles={safeUserProfiles}
-              content={content}
-              setContent={setContent}
-              selectedImage={selectedImage}
-              setSelectedImage={setSelectedImage}
-              isUserBlocked={isUserBlocked}
-              isUserReported={isUserReported}
-              onSend={handleSend}
-              onBlockToggle={handleBlockToggle}
-              onReport={handleReport}
-              onStartNewConversation={() => setShowUserDirectory(true)}
-              username={safeUsername}
-            />
+            {/* Right column - Active conversation */}
+            <div className="flex w-full flex-1 flex-col bg-[#121212] min-h-0 md:w-2/3">
+              <ChatContent
+                activeThread={activeThread}
+                activeMessages={safeActiveMessages}
+                userProfiles={safeUserProfiles}
+                content={content}
+                setContent={setContent}
+                selectedImage={selectedImage}
+                setSelectedImage={setSelectedImage}
+                isUserBlocked={isUserBlocked}
+                isUserReported={isUserReported}
+                onSend={handleSend}
+                onBlockToggle={handleBlockToggle}
+                onReport={handleReport}
+                onStartNewConversation={() => setShowUserDirectory(true)}
+                username={safeUsername}
+              />
+            </div>
           </div>
         </div>
 
         {/* Bottom Padding */}
-        <div className="py-6 bg-black"></div>
+        <div className="py-6 bg-black flex-shrink-0"></div>
       </div>
     </RequireAuth>
   );

--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -209,24 +209,25 @@ export default function BuyerMessagesPage() {
   return (
     <BanCheck>
       <RequireAuth role="buyer">
-        <div className="flex min-h-0 flex-1 flex-col bg-black">
+        <div className="min-h-screen bg-black flex flex-col">
           {/* Desktop padding - hide on mobile */}
-          <div className="hidden md:block py-3 bg-black"></div>
+          <div className="hidden md:block py-3 bg-black flex-shrink-0"></div>
 
           {/* Main container */}
           {/* On mobile without activeThread: relative positioning to flow with header */}
           {/* On mobile with activeThread: fixed positioning full screen */}
           {/* On desktop: always full height */}
-          <div className={`${
-            isMobile && activeThread
-              ? 'fixed inset-0 flex flex-col bg-black'
-              : 'flex min-h-0 flex-1 flex-col bg-black'
-          }`}>
+          <div className="flex-1 overflow-hidden relative">
             <div className={`${
-              isMobile
-                ? 'flex min-h-0 flex-1 flex-col'
-                : 'mx-auto flex min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
-            } bg-[#121212]`}>
+              isMobile && activeThread
+                ? 'fixed inset-0 flex flex-col bg-black'
+                : 'flex h-full min-h-0 flex-1 flex-col bg-black'
+            }`}>
+              <div className={`${
+                isMobile
+                  ? 'flex h-full min-h-0 flex-1 flex-col'
+                  : 'mx-auto flex h-full min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
+              } bg-[#121212]`}>
 
               {/* Mobile: Only show ThreadsSidebar when no active thread */}
               <div className={`${
@@ -326,7 +327,7 @@ export default function BuyerMessagesPage() {
             </div>
 
             {/* Desktop bottom padding */}
-            <div className="hidden md:block py-3 bg-black"></div>
+            <div className="hidden md:block py-3 bg-black flex-shrink-0"></div>
           </div>
         </div>
 

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -122,21 +122,22 @@ export default function SellerMessagesPage() {
   return (
     <BanCheck>
       <RequireAuth role="seller">
-        <div className="flex min-h-0 flex-1 flex-col bg-black">
+        <div className="min-h-screen bg-black flex flex-col">
           {/* Desktop padding - hide on mobile */}
-          <div className="hidden md:block py-3 bg-black"></div>
+          <div className="hidden md:block py-3 bg-black flex-shrink-0"></div>
 
           {/* Main container - matching buyer's responsive layout */}
-          <div className={`${
-            isMobile && activeThread
-              ? 'fixed inset-0 flex flex-col bg-black'
-              : 'flex min-h-0 flex-1 flex-col bg-black'
-          }`}>
+          <div className="flex-1 overflow-hidden relative">
             <div className={`${
-              isMobile
-                ? 'flex min-h-0 flex-1 flex-col'
-                : 'mx-auto flex min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
-            } bg-[#121212]`}>
+              isMobile && activeThread
+                ? 'fixed inset-0 flex flex-col bg-black'
+                : 'flex h-full min-h-0 flex-1 flex-col bg-black'
+            }`}>
+              <div className={`${
+                isMobile
+                  ? 'flex h-full min-h-0 flex-1 flex-col'
+                  : 'mx-auto flex h-full min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
+              } bg-[#121212]`}>
 
               {/* Mobile: Only show ThreadsSidebar when no active thread */}
               <div className={`${
@@ -227,18 +228,18 @@ export default function SellerMessagesPage() {
             </div>
 
             {/* Desktop bottom padding */}
-            <div className="hidden md:block py-3 bg-black"></div>
-
-            {/* Image Preview Modal */}
-            {previewImage && (
-              <ImagePreviewModal
-                imageUrl={previewImage}
-                isOpen={true}
-                onClose={() => setPreviewImage(null)}
-              />
-            )}
+            <div className="hidden md:block py-3 bg-black flex-shrink-0"></div>
           </div>
         </div>
+
+        {/* Image Preview Modal */}
+        {previewImage && (
+          <ImagePreviewModal
+            imageUrl={previewImage}
+            isOpen={true}
+            onClose={() => setPreviewImage(null)}
+          />
+        )}
       </RequireAuth>
     </BanCheck>
   );

--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -151,20 +151,22 @@ export default function ChatContent({
 
   if (!activeThread) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-400">
-        <div className="text-center p-4">
-          <div className="flex justify-center mb-4">
-            <MessageCircle size={64} className="text-gray-600" />
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex flex-1 items-center justify-center text-gray-400">
+          <div className="text-center p-4">
+            <div className="mb-4 flex justify-center">
+              <MessageCircle size={64} className="text-gray-600" />
+            </div>
+            <p className="mb-2 text-xl">Select a conversation to view messages</p>
+            <p className="mb-4 text-sm">Your messages will appear here</p>
+            <button
+              onClick={onStartNewConversation}
+              className="mx-auto flex items-center justify-center rounded-lg bg-[#ff950e] px-4 py-2 font-medium text-black transition-colors hover:bg-[#e88800]"
+            >
+              <MessageSquarePlus size={16} className="mr-2" />
+              Start New Conversation
+            </button>
           </div>
-          <p className="text-xl mb-2">Select a conversation to view messages</p>
-          <p className="text-sm mb-4">Your messages will appear here</p>
-          <button
-            onClick={onStartNewConversation}
-            className="px-4 py-2 bg-[#ff950e] text-black font-medium rounded-lg hover:bg-[#e88800] transition-colors flex items-center justify-center mx-auto"
-          >
-            <MessageSquarePlus size={16} className="mr-2" />
-            Start New Conversation
-          </button>
         </div>
       </div>
     );
@@ -173,7 +175,7 @@ export default function ChatContent({
   const canSend = (!!content.trim() || !!selectedImage) && !isImageLoading;
 
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-col">
       {/* Header */}
       <div className="px-4 py-3 flex items-center justify-between border-b border-gray-800 bg-[#1a1a1a]">
         <div className="flex items-center">
@@ -243,7 +245,7 @@ export default function ChatContent({
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 bg-[#121212]">
+      <div className="flex-1 overflow-y-auto p-4 bg-[#121212] min-h-0">
         <div className="max-w-3xl mx-auto space-y-4">
           {activeMessages.map((msg, index) => {
             const isFromMe = msg.sender === username;
@@ -475,6 +477,6 @@ export default function ChatContent({
       )}
 
       <ImagePreviewModal imageUrl={previewImage || ''} isOpen={!!previewImage} onClose={() => setPreviewImage(null)} />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the buyer messages page in a full-height layout with an internal scroll container for the conversation panel
- apply the same full-height scrollable structure to the seller messages page and move the image preview modal outside the scroll region

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc1472a73c8328bfc3cd676e02ecfb