### PR TITLE
Fix conversation message overflow styling

### DIFF
--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -280,7 +280,7 @@ export default function ConversationView(props: ConversationViewProps) {
 
   // Scroll to bottom when messages change
   useEffect(() => {
-    scrollToBottom('auto');
+    scrollToBottom('smooth');
   }, [threadMessages.length, scrollToBottom]);
 
   // Thread focus/blur
@@ -928,8 +928,8 @@ export default function ConversationView(props: ConversationViewProps) {
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2 min-h-0"
-          style={{ 
+          className="flex-1 overflow-y-auto px-3 py-2 min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+          style={{
             WebkitOverflowScrolling: 'touch'
           }}
         >
@@ -939,7 +939,7 @@ export default function ConversationView(props: ConversationViewProps) {
         </div>
 
         {/* Composer with safe bottom */}
-        <div 
+        <div
           ref={composerRef}
           className="bg-[#111111] border-t border-gray-800 shadow-sm flex-shrink-0 safe-bottom"
         >
@@ -969,7 +969,7 @@ export default function ConversationView(props: ConversationViewProps) {
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212] min-h-0">
+    <div className="h-full flex flex-col bg-[#121212] min-h-0 overflow-hidden">
       {/* Desktop Header */}
       <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
         {renderDesktopHeader()}
@@ -977,10 +977,10 @@ export default function ConversationView(props: ConversationViewProps) {
 
       {/* Desktop Messages */}
       <div
-        className="flex-1 overflow-y-auto bg-[#121212] min-h-0"
+        className="flex-1 overflow-y-auto bg-[#121212] min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
         ref={messagesContainerRef}
       >
-        <div className="max-w-3xl mx-auto space-y-4 p-4">
+        <div className="max-w-3xl mx-auto space-y-3 p-4">
           {renderMessagesList()}
         </div>
       </div>

--- a/src/components/seller/messages/ConversationView.tsx
+++ b/src/components/seller/messages/ConversationView.tsx
@@ -193,7 +193,7 @@ export default function ConversationView({
 
   // Scroll to bottom when messages change
   useEffect(() => {
-    scrollToBottom('auto');
+    scrollToBottom('smooth');
   }, [threadMessages.length, scrollToBottom]);
 
   // Thread focus/blur
@@ -615,8 +615,8 @@ export default function ConversationView({
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2 min-h-0"
-          style={{ 
+          className="flex-1 overflow-y-auto px-3 py-2 min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+          style={{
             WebkitOverflowScrolling: 'touch'
           }}
         >
@@ -654,7 +654,7 @@ export default function ConversationView({
         </div>
 
         {/* Composer with safe bottom */}
-        <div 
+        <div
           ref={composerRef}
           className="bg-[#111111] border-t border-gray-800 shadow-sm flex-shrink-0 safe-bottom"
         >
@@ -691,7 +691,7 @@ export default function ConversationView({
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212] min-h-0">
+    <div className="h-full flex flex-col bg-[#121212] min-h-0 overflow-hidden">
       {/* Desktop Header */}
       <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
         {renderDesktopHeader()}
@@ -699,10 +699,10 @@ export default function ConversationView({
 
       {/* Desktop Messages */}
       <div
-        className="flex-1 overflow-y-auto bg-[#121212] min-h-0"
+        className="flex-1 overflow-y-auto bg-[#121212] min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
         ref={messagesContainerRef}
       >
-        <div className="max-w-3xl mx-auto space-y-4 p-4">
+        <div className="max-w-3xl mx-auto space-y-3 p-4">
           <MessagesList
             threadMessages={threadMessages}
             sellerRequests={sellerRequests}


### PR DESCRIPTION
## Summary
- keep buyer and seller conversation layouts constrained with flexbox and scrollable message regions
- add themed thin scrollbars, smooth scrolling, and consistent spacing for message lists
- ensure auto-scroll uses smooth behavior to follow new messages without stretching the page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc1d0afbbc832888c2431de4c9ce57