### PR TITLE
Fix messaging layouts to keep threads within viewport

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -83,13 +83,13 @@ export default function AdminMessagesPage() {
 
   return (
     <RequireAuth role="admin">
-      <div className="min-h-screen bg-black flex flex-col">
+      <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
         <div className="py-3 bg-black flex-shrink-0"></div>
 
-        <div className="flex-1 overflow-hidden">
-          <div className="mx-auto flex h-full w-full max-w-6xl flex-col rounded-lg bg-[#121212] shadow-lg md:flex-row min-h-0 overflow-hidden">
+        <div className="flex-1 overflow-hidden md:h-[calc(100vh-2.25rem)] md:max-h-[calc(100vh-2.25rem)]">
+          <div className="mx-auto flex h-full w-full max-w-6xl flex-col rounded-lg bg-[#121212] shadow-lg md:flex-row min-h-0 max-h-full overflow-hidden">
             {/* Left column - Message threads and User Directory */}
-            <div className="flex w-full flex-1 flex-col border-r border-gray-800 bg-[#121212] min-h-0 md:w-1/3 md:flex-none">
+            <div className="flex w-full flex-1 flex-col border-r border-gray-800 bg-[#121212] min-h-0 md:w-1/3 md:flex-none md:max-h-full">
               <MessagesHeader
                 filterBy={filterBy}
                 setFilterBy={setFilterBy}
@@ -131,7 +131,7 @@ export default function AdminMessagesPage() {
               </div>
             </div>
             {/* Right column - Active conversation */}
-            <div className="flex w-full flex-1 flex-col bg-[#121212] min-h-0 md:w-2/3">
+            <div className="flex w-full flex-1 flex-col bg-[#121212] min-h-0 md:w-2/3 md:max-h-full">
               <ChatContent
                 activeThread={activeThread}
                 activeMessages={safeActiveMessages}

--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -209,25 +209,26 @@ export default function BuyerMessagesPage() {
   return (
     <BanCheck>
       <RequireAuth role="buyer">
-        {/* Desktop padding - hide on mobile */}
-        <div className="hidden md:block py-3 bg-black"></div>
-        
-        {/* Main container */}
-        {/* On mobile without activeThread: relative positioning to flow with header */}
-        {/* On mobile with activeThread: fixed positioning full screen */}
-        {/* On desktop: always full height */}
-        <div className={`${
-          isMobile
-            ? activeThread
-              ? 'fixed inset-0'
-              : 'flex flex-col h-full min-h-screen'
-            : 'bg-black flex flex-col h-full min-h-screen'
-        }`}>
+        <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
+          {/* Desktop padding - hide on mobile */}
+          <div className="hidden md:block py-3 bg-black"></div>
+
+          {/* Main container */}
+          {/* On mobile without activeThread: relative positioning to flow with header */}
+          {/* On mobile with activeThread: fixed positioning full screen */}
+          {/* On desktop: always full height */}
           <div className={`${
             isMobile
-              ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
-              : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0'
-          } bg-[#121212]`}>
+              ? activeThread
+                ? 'fixed inset-0'
+                : 'flex flex-col h-full min-h-screen'
+              : 'flex flex-1 flex-col min-h-0 md:h-[calc(100vh-1.5rem)] md:max-h-[calc(100vh-1.5rem)]'
+          }`}>
+            <div className={`${
+              isMobile
+                ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
+                : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0 md:max-h-full'
+            } bg-[#121212]`}>
             
             {/* Mobile: Only show ThreadsSidebar when no active thread */}
             <div className={`${
@@ -235,7 +236,7 @@ export default function BuyerMessagesPage() {
                 ? 'hidden'
                 : isMobile
                   ? 'flex flex-col h-full overflow-hidden min-h-0'
-                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0'
+                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0 md:max-h-full'
             }`}>
               <ThreadsSidebar
                 threads={threads}
@@ -265,8 +266,8 @@ export default function BuyerMessagesPage() {
             } ${
               isMobile
                 ? 'flex-col h-full overflow-hidden min-h-0'
-                : 'w-full md:w-2/3'
-            } flex-col bg-[#121212] overflow-hidden min-h-0`}>
+                : 'w-full md:w-2/3 md:max-h-full'
+            } flex-col bg-[#121212] overflow-hidden min-h-0 md:max-h-full`}>
               {activeThread ? (
                 <ConversationView
                   activeThread={activeThread}
@@ -329,66 +330,67 @@ export default function BuyerMessagesPage() {
           {/* Desktop bottom padding */}
           <div className="hidden md:block py-3 bg-black"></div>
         </div>
+      </div>
 
-        {/* Modals */}
-        {previewImage && (
-          <ImagePreviewModal
-            imageUrl={previewImage}
-            isOpen={true}
-            onClose={() => setPreviewImage(null)}
-          />
-        )}
-        
-        {showCustomRequestModal && activeThread && (
-          <CustomRequestModal
-            show={showCustomRequestModal}
-            onClose={closeCustomRequestModal}
-            activeThread={activeThread}
-            onSubmit={handleCustomRequestSubmit}
-            customRequestForm={{
-              title: customRequestForm.title ?? '',
-              price: customRequestForm.price ?? '',
-              description: customRequestForm.description ?? ''
-            }}
-            setCustomRequestForm={handleCustomRequestFormChange}
-            customRequestErrors={customRequestErrors}
-            isSubmittingRequest={isSubmittingRequest}
-            wallet={walletData}
-            user={user}
-          />
-        )}
-        
-        {showPayModal && payingRequest && activeThread && (
-          <PaymentModal
-            show={showPayModal}
-            onClose={() => {
-              setShowPayModal(false);
-              setPayingRequest(null);
-            }}
-            payingRequest={payingRequest}
-            wallet={walletData}
-            user={user}
-            onConfirmPay={handleConfirmPay}
-          />
-        )}
-        
-        {showTipModal && activeThread && (
-          <TipModal
-            show={showTipModal}
-            onClose={() => {
-              setShowTipModal(false);
-              setTipAmount('');
-              setTipResult(null);
-            }}
-            activeThread={activeThread}
-            tipAmount={tipAmount}
-            setTipAmount={setTipAmount}
-            tipResult={tipResult}
-            wallet={walletData}
-            user={user}
-            onSendTip={handleSendTip}
-          />
-        )}
+      {/* Modals */}
+      {previewImage && (
+        <ImagePreviewModal
+          imageUrl={previewImage}
+          isOpen={true}
+          onClose={() => setPreviewImage(null)}
+        />
+      )}
+
+      {showCustomRequestModal && activeThread && (
+        <CustomRequestModal
+          show={showCustomRequestModal}
+          onClose={closeCustomRequestModal}
+          activeThread={activeThread}
+          onSubmit={handleCustomRequestSubmit}
+          customRequestForm={{
+            title: customRequestForm.title ?? '',
+            price: customRequestForm.price ?? '',
+            description: customRequestForm.description ?? ''
+          }}
+          setCustomRequestForm={handleCustomRequestFormChange}
+          customRequestErrors={customRequestErrors}
+          isSubmittingRequest={isSubmittingRequest}
+          wallet={walletData}
+          user={user}
+        />
+      )}
+
+      {showPayModal && payingRequest && activeThread && (
+        <PaymentModal
+          show={showPayModal}
+          onClose={() => {
+            setShowPayModal(false);
+            setPayingRequest(null);
+          }}
+          payingRequest={payingRequest}
+          wallet={walletData}
+          user={user}
+          onConfirmPay={handleConfirmPay}
+        />
+      )}
+
+      {showTipModal && activeThread && (
+        <TipModal
+          show={showTipModal}
+          onClose={() => {
+            setShowTipModal(false);
+            setTipAmount('');
+            setTipResult(null);
+          }}
+          activeThread={activeThread}
+          tipAmount={tipAmount}
+          setTipAmount={setTipAmount}
+          tipResult={tipResult}
+          wallet={walletData}
+          user={user}
+          onSendTip={handleSendTip}
+        />
+      )}
       </RequireAuth>
     </BanCheck>
   );

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -118,37 +118,37 @@ export default function SellerMessagesPage() {
   // ----- className helpers (purely to keep JSX simple & error-proof) -----
   const outerWrap = isMobile && activeThread
     ? 'fixed inset-0 flex flex-col bg-black'
-    : 'flex h-full min-h-0 flex-1 flex-col bg-black';
+    : 'flex h-full min-h-0 max-h-full flex-1 flex-col bg-black';
 
   const innerWrap = `${
     isMobile
-      ? 'flex h-full min-h-0 flex-1 flex-col'
-      : 'mx-auto flex h-full min-h-0 flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
+      ? 'flex h-full min-h-0 max-h-full flex-1 flex-col'
+      : 'mx-auto flex h-full min-h-0 max-h-full flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
   } bg-[#121212]`;
 
   const sidebarWrap = `${
     activeThread && isMobile
       ? 'hidden'
       : isMobile
-        ? 'flex min-h-0 flex-1 flex-col overflow-hidden'
-        : 'w-full md:max-w-xs md:flex md:flex-col md:overflow-hidden md:min-h-0'
+        ? 'flex min-h-0 max-h-full flex-1 flex-col overflow-hidden'
+        : 'w-full md:max-w-xs md:flex md:flex-col md:overflow-hidden md:min-h-0 md:max-h-full'
   }`;
 
   const conversationWrap = `${
     !activeThread && isMobile ? 'hidden' : 'flex'
   } ${
-    isMobile ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'w-full md:flex-1'
-  } flex-col bg-[#121212] overflow-hidden min-h-0`;
+    isMobile ? 'flex min-h-0 max-h-full flex-1 flex-col overflow-hidden' : 'w-full md:flex-1'
+  } flex-col bg-[#121212] overflow-hidden min-h-0 max-h-full`;
 
   return (
     <BanCheck>
       <RequireAuth role="seller">
-        <div className="min-h-screen bg-black flex flex-col">
+        <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
           {/* Desktop padding - hide on mobile */}
           <div className="hidden md:block py-3 bg-black flex-shrink-0" />
 
           {/* Main container - matching buyer's responsive layout */}
-          <div className="flex-1 overflow-hidden relative">
+          <div className="flex-1 overflow-hidden relative min-h-0 md:h-[calc(100vh-1.5rem)] md:max-h-[calc(100vh-1.5rem)]">
             <div className={outerWrap}>
               <div className={innerWrap}>
                 {/* Mobile: Only show ThreadsSidebar when no active thread */}


### PR DESCRIPTION
## Summary
- clamp the seller and buyer messaging layouts to the viewport so their message panes scroll inside a fixed-height container
- update the admin messaging layout to share the same viewport-bound behavior and prevent infinite vertical growth

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc27b6e18c8328a963390e36d2fbae