### PR TITLE
Adjust seller messages layout to contain scrolling

### DIFF
--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -116,43 +116,29 @@ export default function SellerMessagesPage() {
   }
 
   // ----- className helpers (purely to keep JSX simple & error-proof) -----
-  const outerWrap = isMobile && activeThread
-    ? 'fixed inset-0 flex flex-col bg-black'
-    : 'flex h-full min-h-0 max-h-full flex-1 flex-col bg-black';
+  const showSidebar = !isMobile || !activeThread;
+  const showConversation = !isMobile || !!activeThread;
 
-  const innerWrap = `${
+  const innerWrap = isMobile
+    ? 'flex h-full w-full min-h-0 overflow-hidden bg-[#121212]'
+    : 'mx-auto flex h-full w-full min-h-0 max-w-6xl overflow-hidden rounded-lg shadow-lg bg-[#121212]';
+
+  const sidebarWrap = `${showSidebar ? 'flex' : 'hidden'} ${
     isMobile
-      ? 'flex h-full min-h-0 max-h-full flex-1 flex-col'
-      : 'mx-auto flex h-full min-h-0 max-h-full flex-1 w-full max-w-6xl flex-col overflow-hidden rounded-lg shadow-lg md:flex-row'
-  } bg-[#121212]`;
+      ? 'w-full'
+      : 'w-[320px] border-r border-gray-800'
+  } flex-shrink-0 flex-col bg-[#1a1a1a] min-h-0 overflow-hidden`;
 
-  const sidebarWrap = `${
-    activeThread && isMobile
-      ? 'hidden'
-      : isMobile
-        ? 'flex min-h-0 max-h-full flex-1 flex-col overflow-hidden'
-        : 'w-full md:max-w-xs md:flex md:flex-col md:overflow-hidden md:min-h-0 md:max-h-full'
-  }`;
-
-  const conversationWrap = `${
-    !activeThread && isMobile ? 'hidden' : 'flex'
-  } ${
-    isMobile ? 'flex min-h-0 max-h-full flex-1 flex-col overflow-hidden' : 'w-full md:flex-1'
-  } flex-col bg-[#121212] overflow-hidden min-h-0 max-h-full`;
+  const conversationWrap = `${showConversation ? 'flex' : 'hidden'} flex-1 flex flex-col bg-[#121212] min-h-0 overflow-hidden`;
 
   return (
     <BanCheck>
       <RequireAuth role="seller">
-        <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
-          {/* Desktop padding - hide on mobile */}
-          <div className="hidden md:block py-3 bg-black flex-shrink-0" />
-
-          {/* Main container - matching buyer's responsive layout */}
-          <div className="flex-1 overflow-hidden relative min-h-0 md:h-[calc(100vh-1.5rem)] md:max-h-[calc(100vh-1.5rem)]">
-            <div className={outerWrap}>
+        <div className="min-h-[100dvh] overflow-hidden bg-black">
+          <main className="h-[calc(100dvh-64px)] overscroll-contain overflow-hidden">
+            <div className="flex h-full">
               <div className={innerWrap}>
-                {/* Mobile: Only show ThreadsSidebar when no active thread */}
-                <div className={sidebarWrap}>
+                <aside className={sidebarWrap}>
                   <ThreadsSidebar
                     isAdmin={isAdmin}
                     threads={threads}
@@ -168,11 +154,9 @@ export default function SellerMessagesPage() {
                     setFilterBy={setFilterBy}
                     setObserverReadMessages={setObserverReadMessages}
                   />
-                </div>
+                </aside>
 
-                {/* Mobile: Only show conversation when thread is active */}
-                {/* Desktop: Always show conversation area */}
-                <div className={conversationWrap}>
+                <section className={conversationWrap}>
                   {activeThread ? (
                     <ConversationView
                       activeThread={activeThread}
@@ -222,13 +206,10 @@ export default function SellerMessagesPage() {
                   ) : (
                     <EmptyState />
                   )}
-                </div>
+                </section>
               </div>
-
-              {/* Desktop bottom padding */}
-              <div className="hidden md:block py-3 bg-black flex-shrink-0" />
             </div>
-          </div>
+          </main>
 
           {/* Image Preview Modal */}
           {previewImage && (

--- a/src/components/seller/messages/ConversationView.tsx
+++ b/src/components/seller/messages/ConversationView.tsx
@@ -608,14 +608,14 @@ export default function ConversationView({
   // Mobile Layout
   if (isMobile) {
     return (
-      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden min-h-0">
+      <div className="flex h-full flex-1 flex-col overflow-hidden bg-[#121212]">
         {/* Mobile Header */}
         {renderMobileHeader()}
 
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2 min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+          className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 py-2 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
           style={{
             WebkitOverflowScrolling: 'touch'
           }}
@@ -656,7 +656,7 @@ export default function ConversationView({
         {/* Composer with safe bottom */}
         <div
           ref={composerRef}
-          className="bg-[#111111] border-t border-gray-800 shadow-sm flex-shrink-0 safe-bottom"
+          className="safe-bottom flex-none border-t border-gray-800 bg-[#111111] shadow-sm"
         >
           {!isUserBlocked ? (
             <MessageInputContainer
@@ -691,15 +691,15 @@ export default function ConversationView({
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212] min-h-0 overflow-hidden">
+    <div className="flex h-full w-full flex-1 flex-col overflow-hidden bg-[#121212] min-h-0">
       {/* Desktop Header */}
-      <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
+      <div className="flex-none border-b border-gray-800 bg-[#1a1a1a] shadow-sm">
         {renderDesktopHeader()}
       </div>
 
       {/* Desktop Messages */}
       <div
-        className="flex-1 overflow-y-auto bg-[#121212] min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+        className="flex-1 min-h-0 overflow-y-auto overscroll-contain bg-[#121212] scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
         ref={messagesContainerRef}
       >
         <div className="max-w-3xl mx-auto space-y-3 p-4">
@@ -737,7 +737,7 @@ export default function ConversationView({
 
       {/* Desktop Composer */}
       {!isUserBlocked ? (
-        <div className="relative border-t border-gray-800 bg-[#1a1a1a]">
+        <div className="relative flex-none border-t border-gray-800 bg-[#1a1a1a]">
           <MessageInputContainer
             isUserBlocked={isUserBlocked}
             onBlockToggle={handleBlockToggle}
@@ -750,7 +750,7 @@ export default function ConversationView({
           />
         </div>
       ) : (
-        <div className="p-4 border-t border-gray-800 text-center text-sm text-red-400 bg-[#1a1a1a] flex items-center justify-center">
+        <div className="flex flex-none items-center justify-center border-t border-gray-800 bg-[#1a1a1a] p-4 text-center text-sm text-red-400">
           <ShieldAlert size={16} className="mr-2" />
           You have blocked this buyer
           <button

--- a/src/components/seller/messages/MessageItem.tsx
+++ b/src/components/seller/messages/MessageItem.tsx
@@ -157,19 +157,21 @@ export default function MessageItem({
         {/* Image message with secure display */}
         {msg.type === 'image' && msg.meta?.imageUrl && (
           <div className="mt-1 mb-2">
-            <SecureImage
-              src={msg.meta.imageUrl}
-              alt="Shared image"
-              className="max-w-full rounded cursor-pointer hover:opacity-90 transition-opacity shadow-sm"
-              onError={() => console.error('Failed to load image')}
-              onClick={(e: React.MouseEvent<HTMLImageElement>) => {
-                e.stopPropagation();
-                setPreviewImage(msg.meta?.imageUrl || null);
-              }}
-            />
+            <div className="flex max-h-[60vh] items-center justify-center overflow-hidden rounded-md bg-black/30">
+              <SecureImage
+                src={msg.meta.imageUrl}
+                alt="Shared image"
+                className="h-auto w-full max-h-[60vh] cursor-pointer object-contain transition-opacity hover:opacity-90"
+                onError={() => console.error('Failed to load image')}
+                onClick={(e: React.MouseEvent<HTMLImageElement>) => {
+                  e.stopPropagation();
+                  setPreviewImage(msg.meta?.imageUrl || null);
+                }}
+              />
+            </div>
             {msg.content && (
               <div className={`mt-2 ${isSingleEmojiMsg ? 'text-3xl' : ''}`}>
-                <SecureMessageDisplay 
+                <SecureMessageDisplay
                   content={msg.content}
                   allowBasicFormatting={false}
                   className={isFromMe ? 'text-black' : 'text-[#fefefe]'}

--- a/src/components/seller/messages/ThreadsSidebar.tsx
+++ b/src/components/seller/messages/ThreadsSidebar.tsx
@@ -72,9 +72,9 @@ export default function ThreadsSidebar({
   };
 
   return (
-    <div className="h-full bg-[#1a1a1a] border-r border-gray-800 flex flex-col">
+    <div className="flex h-full flex-col bg-[#1a1a1a] border-r border-gray-800">
       {/* Header */}
-      <div className="p-4 border-b border-gray-800">
+      <div className="flex-none p-4 border-b border-gray-800">
         <h2 className="text-xl font-bold text-white mb-3 flex items-center">
           <MessageSquare className="mr-2 text-[#ff950e]" size={20} />
           {isAdmin ? 'Admin Messages' : 'Messages'}
@@ -120,9 +120,9 @@ export default function ThreadsSidebar({
           </button>
         </div>
       </div>
-      
+
       {/* Thread List */}
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
         {filteredThreads.length === 0 ? (
           <div className="p-4 text-center text-gray-400">
             <MessageSquare className="mx-auto mb-2 opacity-50" size={24} />


### PR DESCRIPTION
## Summary
- refactor the seller messages page shell to fill the viewport with flex layout and hide global scrolling
- update the threads sidebar and conversation view so only their internal lists scroll while the composer stays pinned
- constrain shared image bubbles to a safe viewport height to avoid stretching the layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd8bb5598483288cb22ef777f4a7ca