### PR TITLE
Ensure messaging pages use viewport-bound chat layout

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -83,13 +83,11 @@ export default function AdminMessagesPage() {
 
   return (
     <RequireAuth role="admin">
-      <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
-        <div className="py-3 bg-black flex-shrink-0"></div>
-
-        <div className="flex-1 overflow-hidden md:h-[calc(100vh-2.25rem)] md:max-h-[calc(100vh-2.25rem)]">
-          <div className="mx-auto flex h-full w-full max-w-6xl flex-col rounded-lg bg-[#121212] shadow-lg md:flex-row min-h-0 max-h-full overflow-hidden">
+      <div className="min-h-[100dvh] overflow-hidden overscroll-contain bg-black">
+        <main className="flex h-[calc(100dvh-64px)] w-full overscroll-contain">
+          <div className="mx-auto flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-lg bg-[#121212] shadow-lg md:flex-row">
             {/* Left column - Message threads and User Directory */}
-            <div className="flex w-full flex-1 flex-col border-r border-gray-800 bg-[#121212] min-h-0 md:w-1/3 md:flex-none md:max-h-full">
+            <div className="flex w-full flex-1 flex-col border-r border-gray-800 bg-[#121212] min-h-0 md:w-1/3 md:flex-none">
               <MessagesHeader
                 filterBy={filterBy}
                 setFilterBy={setFilterBy}
@@ -103,7 +101,7 @@ export default function AdminMessagesPage() {
               />
 
               {/* Content Area - Either Conversations or User Directory */}
-              <div className="flex-1 overflow-y-auto bg-[#121212]">
+              <div className="flex-1 overflow-y-auto overscroll-contain bg-[#121212] min-h-0">
                 {showUserDirectory ? (
                   <UserDirectoryContent
                     allUsers={safeAllUsers}
@@ -131,7 +129,7 @@ export default function AdminMessagesPage() {
               </div>
             </div>
             {/* Right column - Active conversation */}
-            <div className="flex w-full flex-1 flex-col bg-[#121212] min-h-0 md:w-2/3 md:max-h-full">
+            <div className="flex w-full flex-1 flex-col bg-[#121212] min-h-0 md:w-2/3">
               <ChatContent
                 activeThread={activeThread}
                 activeMessages={safeActiveMessages}
@@ -150,10 +148,7 @@ export default function AdminMessagesPage() {
               />
             </div>
           </div>
-        </div>
-
-        {/* Bottom Padding */}
-        <div className="py-6 bg-black flex-shrink-0"></div>
+        </main>
       </div>
     </RequireAuth>
   );

--- a/src/app/buyers/messages/page.tsx
+++ b/src/app/buyers/messages/page.tsx
@@ -206,131 +206,106 @@ export default function BuyerMessagesPage() {
     );
   }
 
+  const showSidebar = !isMobile || !activeThread;
+  const showConversation = !isMobile || !!activeThread;
+
+  const innerWrap = isMobile
+    ? 'flex h-full w-full min-h-0 overflow-hidden bg-[#121212]'
+    : 'mx-auto flex h-full w-full min-h-0 max-w-6xl overflow-hidden rounded-lg shadow-lg bg-[#121212]';
+
+  const sidebarWrap = `${showSidebar ? 'flex' : 'hidden'} ${
+    isMobile ? 'w-full' : 'w-[320px] border-r border-gray-800'
+  } flex-shrink-0 flex-col bg-[#1a1a1a] min-h-0 h-full overflow-hidden`;
+
+  const conversationWrap = `${showConversation ? 'flex' : 'hidden'} flex-1 flex h-full flex-col bg-[#121212] min-h-0 overflow-hidden`;
+
   return (
     <BanCheck>
       <RequireAuth role="buyer">
-        <div className="bg-black flex min-h-screen flex-col md:h-screen md:min-h-0">
-          {/* Desktop padding - hide on mobile */}
-          <div className="hidden md:block py-3 bg-black"></div>
-
-          {/* Main container */}
-          {/* On mobile without activeThread: relative positioning to flow with header */}
-          {/* On mobile with activeThread: fixed positioning full screen */}
-          {/* On desktop: always full height */}
-          <div className={`${
-            isMobile
-              ? activeThread
-                ? 'fixed inset-0'
-                : 'flex flex-col h-full min-h-screen'
-              : 'flex flex-1 flex-col min-h-0 md:h-[calc(100vh-1.5rem)] md:max-h-[calc(100vh-1.5rem)]'
-          }`}>
-            <div className={`${
-              isMobile
-                ? 'w-full h-full flex flex-col overflow-hidden min-h-0'
-                : 'flex-1 max-w-6xl mx-auto w-full rounded-lg shadow-lg flex flex-col md:flex-row overflow-hidden min-h-0 md:max-h-full'
-            } bg-[#121212]`}>
-            
-            {/* Mobile: Only show ThreadsSidebar when no active thread */}
-            <div className={`${
-              activeThread && isMobile
-                ? 'hidden'
-                : isMobile
-                  ? 'flex flex-col h-full overflow-hidden min-h-0'
-                  : 'w-full md:w-1/3 overflow-hidden flex flex-col min-h-0 md:max-h-full'
-            }`}>
-              <ThreadsSidebar
-                threads={threads}
-                lastMessages={lastMessages}
-                sellerProfiles={sellerProfiles}
-                uiUnreadCounts={uiUnreadCounts}
-                activeThread={activeThread}
-                setActiveThread={setActiveThread}
-                searchQuery={searchQuery}
-                setSearchQuery={setSearchQuery}
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-                filterBy={filterBy}
-                setFilterBy={setFilterBy}
-                totalUnreadCount={totalUnreadCount}
-                buyerRequests={buyerRequests}
-                setObserverReadMessages={setObserverReadMessages}
-              />
-            </div>
-            
-            {/* Mobile: Only show conversation when thread is active */}
-            {/* Desktop: Always show conversation area */}
-            <div className={`${
-              !activeThread && isMobile
-                ? 'hidden'
-                : 'flex'
-            } ${
-              isMobile
-                ? 'flex-col h-full overflow-hidden min-h-0'
-                : 'w-full md:w-2/3 md:max-h-full'
-            } flex-col bg-[#121212] overflow-hidden min-h-0 md:max-h-full`}>
-              {activeThread ? (
-                <ConversationView
-                  activeThread={activeThread}
+        <div className="min-h-[100dvh] overflow-hidden overscroll-contain bg-black">
+          <main className="flex h-[calc(100dvh-64px)] w-full overscroll-contain">
+            <div className={innerWrap}>
+              <aside className={sidebarWrap}>
+                <ThreadsSidebar
                   threads={threads}
-                  user={user}
+                  lastMessages={lastMessages}
                   sellerProfiles={sellerProfiles}
+                  uiUnreadCounts={uiUnreadCounts}
+                  activeThread={activeThread}
+                  setActiveThread={setActiveThread}
+                  searchQuery={searchQuery}
+                  setSearchQuery={setSearchQuery}
+                  activeTab={activeTab}
+                  setActiveTab={setActiveTab}
+                  filterBy={filterBy}
+                  setFilterBy={setFilterBy}
+                  totalUnreadCount={totalUnreadCount}
                   buyerRequests={buyerRequests}
-                  wallet={walletData}
-                  previewImage={previewImage}
-                  setPreviewImage={setPreviewImage}
-                  showEmojiPicker={showEmojiPicker}
-                  setShowEmojiPicker={setShowEmojiPicker}
-                  recentEmojis={recentEmojis}
-                  replyMessage={replyMessage}
-                  setReplyMessage={setReplyMessage}
-                  selectedImage={selectedImage}
-                  setSelectedImage={setSelectedImage}
-                  isImageLoading={isImageLoading}
-                  imageError={imageError}
-                  editRequestId={editRequestId}
-                  setEditRequestId={setEditRequestId}
-                  editPrice={numericEditPrice}
-                  setEditPrice={handleEditPriceChange}
-                  editTitle={editTitle}
-                  setEditTitle={setEditTitle}
-                  editTags={editTags}
-                  setEditTags={setEditTags}
-                  editMessage={editMessage}
-                  setEditMessage={setEditMessage}
-                  handleReply={handleReply}
-                  handleBlockToggle={handleBlockToggle}
-                  handleReport={handleReport}
-                  handleAccept={handleAccept}
-                  handleDecline={handleDecline}
-                  handleEditRequest={handleEditRequest}
-                  handleEditSubmit={handleEditSubmit}
-                  handlePayNow={handlePayNow}
-                  handleImageSelect={handleImageSelect}
-                  handleMessageVisible={handleMessageVisible}
-                  handleEmojiClick={handleEmojiClick}
-                  isUserBlocked={isUserBlocked(activeThread)}
-                  isUserReported={isUserReported(activeThread)}
-                  messagesEndRef={messagesEndRef}
-                  messagesContainerRef={messagesContainerRef}
-                  fileInputRef={fileInputRef}
-                  emojiPickerRef={emojiPickerRef}
-                  inputRef={inputRef}
-                  lastManualScrollTime={lastManualScrollTime}
-                  setShowCustomRequestModal={setShowCustomRequestModal}
-                  setShowTipModal={setShowTipModal}
-                  isMobile={isMobile}
-                  onBack={handleMobileBack}
+                  setObserverReadMessages={setObserverReadMessages}
                 />
-              ) : (
-                <EmptyState />
-              )}
+              </aside>
+
+              <section className={conversationWrap}>
+                {activeThread ? (
+                  <ConversationView
+                    activeThread={activeThread}
+                    threads={threads}
+                    user={user}
+                    sellerProfiles={sellerProfiles}
+                    buyerRequests={buyerRequests}
+                    wallet={walletData}
+                    previewImage={previewImage}
+                    setPreviewImage={setPreviewImage}
+                    showEmojiPicker={showEmojiPicker}
+                    setShowEmojiPicker={setShowEmojiPicker}
+                    recentEmojis={recentEmojis}
+                    replyMessage={replyMessage}
+                    setReplyMessage={setReplyMessage}
+                    selectedImage={selectedImage}
+                    setSelectedImage={setSelectedImage}
+                    isImageLoading={isImageLoading}
+                    imageError={imageError}
+                    editRequestId={editRequestId}
+                    setEditRequestId={setEditRequestId}
+                    editPrice={numericEditPrice}
+                    setEditPrice={handleEditPriceChange}
+                    editTitle={editTitle}
+                    setEditTitle={setEditTitle}
+                    editTags={editTags}
+                    setEditTags={setEditTags}
+                    editMessage={editMessage}
+                    setEditMessage={setEditMessage}
+                    handleReply={handleReply}
+                    handleBlockToggle={handleBlockToggle}
+                    handleReport={handleReport}
+                    handleAccept={handleAccept}
+                    handleDecline={handleDecline}
+                    handleEditRequest={handleEditRequest}
+                    handleEditSubmit={handleEditSubmit}
+                    handlePayNow={handlePayNow}
+                    handleImageSelect={handleImageSelect}
+                    handleMessageVisible={handleMessageVisible}
+                    handleEmojiClick={handleEmojiClick}
+                    isUserBlocked={isUserBlocked(activeThread)}
+                    isUserReported={isUserReported(activeThread)}
+                    messagesEndRef={messagesEndRef}
+                    messagesContainerRef={messagesContainerRef}
+                    fileInputRef={fileInputRef}
+                    emojiPickerRef={emojiPickerRef}
+                    inputRef={inputRef}
+                    lastManualScrollTime={lastManualScrollTime}
+                    setShowCustomRequestModal={setShowCustomRequestModal}
+                    setShowTipModal={setShowTipModal}
+                    isMobile={isMobile}
+                    onBack={handleMobileBack}
+                  />
+                ) : (
+                  <EmptyState />
+                )}
+              </section>
             </div>
-          </div>
-          
-          {/* Desktop bottom padding */}
-          <div className="hidden md:block py-3 bg-black"></div>
+          </main>
         </div>
-      </div>
 
       {/* Modals */}
       {previewImage && (

--- a/src/app/sellers/messages/page.tsx
+++ b/src/app/sellers/messages/page.tsx
@@ -127,17 +127,16 @@ export default function SellerMessagesPage() {
     isMobile
       ? 'w-full'
       : 'w-[320px] border-r border-gray-800'
-  } flex-shrink-0 flex-col bg-[#1a1a1a] min-h-0 overflow-hidden`;
+  } flex-shrink-0 flex-col bg-[#1a1a1a] min-h-0 h-full overflow-hidden`;
 
-  const conversationWrap = `${showConversation ? 'flex' : 'hidden'} flex-1 flex flex-col bg-[#121212] min-h-0 overflow-hidden`;
+  const conversationWrap = `${showConversation ? 'flex' : 'hidden'} flex-1 flex h-full flex-col bg-[#121212] min-h-0 overflow-hidden`;
 
   return (
     <BanCheck>
       <RequireAuth role="seller">
-        <div className="min-h-[100dvh] overflow-hidden bg-black">
-          <main className="h-[calc(100dvh-64px)] overscroll-contain overflow-hidden">
-            <div className="flex h-full">
-              <div className={innerWrap}>
+        <div className="min-h-[100dvh] overflow-hidden overscroll-contain bg-black">
+          <main className="flex h-[calc(100dvh-64px)] w-full overscroll-contain">
+            <div className={innerWrap}>
                 <aside className={sidebarWrap}>
                   <ThreadsSidebar
                     isAdmin={isAdmin}

--- a/src/components/admin/messages/ChatContent.tsx
+++ b/src/components/admin/messages/ChatContent.tsx
@@ -151,7 +151,7 @@ export default function ChatContent({
 
   if (!activeThread) {
     return (
-      <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[#121212]">
         <div className="flex flex-1 items-center justify-center text-gray-400">
           <div className="text-center p-4">
             <div className="mb-4 flex justify-center">
@@ -175,7 +175,7 @@ export default function ChatContent({
   const canSend = (!!content.trim() || !!selectedImage) && !isImageLoading;
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[#121212]">
       {/* Header */}
       <div className="px-4 py-3 flex items-center justify-between border-b border-gray-800 bg-[#1a1a1a]">
         <div className="flex items-center">
@@ -245,7 +245,7 @@ export default function ChatContent({
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 bg-[#121212] min-h-0">
+      <div className="flex-1 overflow-y-auto overscroll-contain p-4 bg-[#121212] min-h-0">
         <div className="max-w-3xl mx-auto space-y-4">
           {activeMessages.map((msg, index) => {
             const isFromMe = msg.sender === username;
@@ -281,15 +281,17 @@ export default function ChatContent({
                   {/* Image message */}
                   {msg.type === 'image' && msg.meta?.imageUrl && (
                     <div className="mt-1 mb-2">
-                      <SecureImage
-                        src={msg.meta.imageUrl}
-                        alt="Shared image"
-                        className="max-w-full rounded cursor-pointer hover:opacity-90 transition-opacity shadow-sm"
-                        onClick={(e: React.MouseEvent<HTMLImageElement>) => {
-                          e.stopPropagation();
-                          setPreviewImage(msg.meta?.imageUrl || null);
-                        }}
-                      />
+                      <div className="max-h-[60vh] overflow-hidden rounded-md bg-black/30">
+                        <SecureImage
+                          src={msg.meta.imageUrl}
+                          alt="Shared image"
+                          className="h-auto w-full cursor-pointer object-contain transition-opacity hover:opacity-90"
+                          onClick={(e: React.MouseEvent<HTMLImageElement>) => {
+                            e.stopPropagation();
+                            setPreviewImage(msg.meta?.imageUrl || null);
+                          }}
+                        />
+                      </div>
                       {msg.content && (
                         <div className={`mt-2 ${isSingleEmojiMsg ? 'text-3xl' : ''}`}>
                           <SecureMessageDisplay content={msg.content} allowBasicFormatting={false} className="text-white" />
@@ -341,7 +343,7 @@ export default function ChatContent({
 
       {/* Composer */}
       {!isUserBlocked && (
-        <div className="relative border-t border-gray-800 bg-[#1a1a1a]">
+        <div className="relative flex-none border-t border-gray-800 bg-[#1a1a1a]">
           {showEmojiPicker && <EmojiPicker onEmojiSelect={handleEmojiSelect} onClose={() => setShowEmojiPicker(false)} />}
 
           {/* Selected image preview */}
@@ -461,7 +463,7 @@ export default function ChatContent({
       )}
 
       {isUserBlocked && (
-        <div className="p-4 border-t border-gray-800 text-center text-sm text-red-400 bg-[#1a1a1a] flex items-center justify-center">
+        <div className="flex flex-none items-center justify-center border-t border-gray-800 bg-[#1a1a1a] p-4 text-center text-sm text-red-400">
           <ShieldAlert size={16} className="mr-2" />
           You have blocked this user
           <button

--- a/src/components/admin/messages/MessagesHeader.tsx
+++ b/src/components/admin/messages/MessagesHeader.tsx
@@ -36,7 +36,7 @@ export default function MessagesHeader({
 
   return (
     <>
-      <div className="px-4 pt-4 pb-2">
+      <div className="flex-none px-4 pt-4 pb-2">
         <h2 className="text-2xl font-bold text-[#ff950e] mb-2 flex items-center">
           <MessageCircle size={24} className="mr-2 text-[#ff950e]" />
           Admin Messages
@@ -108,7 +108,7 @@ export default function MessagesHeader({
         </div>
       </div>
 
-      <div className="px-4 pb-3">
+      <div className="flex-none px-4 pb-3">
         <div className="relative">
           <SecureInput
             type="text"

--- a/src/components/buyers/messages/ConversationView.tsx
+++ b/src/components/buyers/messages/ConversationView.tsx
@@ -921,14 +921,14 @@ export default function ConversationView(props: ConversationViewProps) {
   // Mobile Layout
   if (isMobile) {
     return (
-      <div className="fixed inset-0 bg-[#121212] flex flex-col overflow-hidden min-h-0">
+      <div className="flex h-full flex-col overflow-hidden bg-[#121212] min-h-0">
         {/* Mobile Header */}
         {renderMobileHeader()}
 
         {/* Messages container */}
         <div
           ref={messagesContainerRef}
-          className="flex-1 overflow-y-auto px-3 py-2 min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+          className="flex-1 overflow-y-auto overscroll-contain px-3 py-2 min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
           style={{
             WebkitOverflowScrolling: 'touch'
           }}
@@ -941,7 +941,7 @@ export default function ConversationView(props: ConversationViewProps) {
         {/* Composer with safe bottom */}
         <div
           ref={composerRef}
-          className="bg-[#111111] border-t border-gray-800 shadow-sm flex-shrink-0 safe-bottom"
+          className="bg-[#111111] border-t border-gray-800 shadow-sm flex-none safe-bottom"
         >
           {!isUserBlocked ? (
             <div className="relative">
@@ -969,7 +969,7 @@ export default function ConversationView(props: ConversationViewProps) {
 
   // Desktop Layout
   return (
-    <div className="h-full flex flex-col bg-[#121212] min-h-0 overflow-hidden">
+    <div className="flex h-full flex-col bg-[#121212] min-h-0 overflow-hidden">
       {/* Desktop Header */}
       <div className="flex-shrink-0 bg-[#1a1a1a] border-b border-gray-800 shadow-sm">
         {renderDesktopHeader()}
@@ -977,7 +977,7 @@ export default function ConversationView(props: ConversationViewProps) {
 
       {/* Desktop Messages */}
       <div
-        className="flex-1 overflow-y-auto bg-[#121212] min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
+        className="flex-1 overflow-y-auto overscroll-contain bg-[#121212] min-h-0 scroll-smooth scrollbar-thin scrollbar-thumb-[#ff950e]/40 scrollbar-track-[#1a1a1a]"
         ref={messagesContainerRef}
       >
         <div className="max-w-3xl mx-auto space-y-3 p-4">
@@ -987,11 +987,11 @@ export default function ConversationView(props: ConversationViewProps) {
 
       {/* Desktop Composer */}
       {!isUserBlocked ? (
-        <div className="relative border-t border-gray-800 bg-[#1a1a1a]">
+        <div className="relative flex-none border-t border-gray-800 bg-[#1a1a1a]">
           {renderComposer()}
         </div>
       ) : (
-        <div className="p-4 border-t border-gray-800 text-center text-sm text-red-400 bg-[#1a1a1a] flex items-center justify-center">
+        <div className="flex flex-none items-center justify-center border-t border-gray-800 bg-[#1a1a1a] p-4 text-center text-sm text-red-400">
           <ShieldAlert size={16} className="mr-2" />
           You have blocked this seller
           <button

--- a/src/components/buyers/messages/MessageItem.tsx
+++ b/src/components/buyers/messages/MessageItem.tsx
@@ -176,19 +176,21 @@ export default function MessageItem({
         {/* Image message */}
         {msg.type === 'image' && msg.meta?.imageUrl && (
           <div className="mt-1 mb-2">
-            <SecureImage
-              src={msg.meta.imageUrl}
-              alt="Shared image"
-              className="max-w-full rounded cursor-pointer hover:opacity-90 transition-opacity shadow-sm"
-              onError={() => console.error('Failed to load image')}
-              onClick={(e: React.MouseEvent<HTMLImageElement>) => {
-                e.stopPropagation();
-                setPreviewImage(msg.meta?.imageUrl || null);
-              }}
-            />
+            <div className="max-h-[60vh] overflow-hidden rounded-md bg-black/30">
+              <SecureImage
+                src={msg.meta.imageUrl}
+                alt="Shared image"
+                className="h-auto w-full cursor-pointer object-contain transition-opacity hover:opacity-90"
+                onError={() => console.error('Failed to load image')}
+                onClick={(e: React.MouseEvent<HTMLImageElement>) => {
+                  e.stopPropagation();
+                  setPreviewImage(msg.meta?.imageUrl || null);
+                }}
+              />
+            </div>
             {msg.content && (
               <div className={`mt-2 ${isSingleEmojiMsg ? 'text-3xl' : ''}`}>
-                <SecureMessageDisplay 
+                <SecureMessageDisplay
                   content={msg.content}
                   allowBasicFormatting={false}
                   className={isFromMe ? 'text-black' : 'text-[#fefefe]'}

--- a/src/components/buyers/messages/ThreadsSidebar.tsx
+++ b/src/components/buyers/messages/ThreadsSidebar.tsx
@@ -311,9 +311,9 @@ export default function ThreadsSidebar({
   }, [buyerRequests]);
   
   return (
-    <div className="h-full flex flex-col bg-[#1a1a1a]">
+    <div className="flex h-full flex-col bg-[#1a1a1a] border-r border-gray-800">
       {/* Header */}
-      <div className="p-4 border-b border-gray-800">
+      <div className="flex-none p-4 border-b border-gray-800">
         <h2 className="text-xl font-bold text-white mb-4">Messages</h2>
         
         {/* Search */}
@@ -394,7 +394,7 @@ export default function ThreadsSidebar({
       </div>
       
       {/* Thread List */}
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div className="flex-1 overflow-y-auto overscroll-contain min-h-0">
         {activeTab === 'messages' && (
           <>
             {filteredThreads.length === 0 ? (


### PR DESCRIPTION
## Summary
- update seller, buyer, and admin messaging pages to use flex layouts that lock page height to the viewport while keeping the site header visible
- adjust messaging sidebars and conversation containers so only thread lists and message history scroll across all roles
- wrap shared message imagery in bounded containers and fix composer sections to remain visible at the bottom of the chat panes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd94c793e083289bcb84e5ba611aa1