### PR TITLE
Fix homepage structured data and Sentry config handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,15 @@
 // src/app/page.tsx
 'use client';
 
-import { Suspense, useCallback, lazy } from 'react';
+import { Suspense, useCallback } from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import BanCheck from '@/components/BanCheck';
 import HeroSection from '@/components/homepage/HeroSection';
 import TrustSignalsSection from '@/components/homepage/TrustSignalsSection';
 import CTASection from '@/components/homepage/CTASection';
 import Footer from '@/components/homepage/Footer';
-import Head from 'next/head';
 import dynamic from 'next/dynamic';
+import Script from 'next/script';
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://pantypost.com';
 
@@ -149,98 +149,95 @@ const SectionWrapper = ({
 };
 
 export default function Home() {
+  const homepageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Panty Post - Buy & Sell Used Panties Marketplace',
+    description:
+      'Discreet marketplace to buy and sell used panties with verified sellers and secure payments',
+    url: BASE_URL,
+    mainEntity: {
+      '@type': 'OnlineMarketplace',
+      name: 'PantyPost',
+      description: 'Anonymous marketplace for buying and selling used panties',
+      url: BASE_URL,
+      aggregateRating: {
+        '@type': 'AggregateRating',
+        ratingValue: '4.8',
+        reviewCount: '10000',
+        bestRating: '5',
+        worstRating: '1',
+      },
+      potentialAction: [
+        {
+          '@type': 'BuyAction',
+          target: {
+            '@type': 'EntryPoint',
+            urlTemplate: `${BASE_URL}/browse`,
+            actionPlatform: [
+              'http://schema.org/DesktopWebPlatform',
+              'http://schema.org/MobileWebPlatform',
+            ],
+          },
+        },
+        {
+          '@type': 'SellAction',
+          target: {
+            '@type': 'EntryPoint',
+            urlTemplate: `${BASE_URL}/login`,
+            actionPlatform: [
+              'http://schema.org/DesktopWebPlatform',
+              'http://schema.org/MobileWebPlatform',
+            ],
+          },
+        },
+      ],
+    },
+  } as const;
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is PantyPost and how does it work?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'PantyPost (also known as Panty Post) is a discreet marketplace that connects verified sellers with qualified buyers of used panties. Users can create an account, browse curated listings, and checkout securely with anonymous transactions.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Is PantyPost the same as Panty Post?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'Yes. PantyPost and Panty Post refer to the same privacy-first brand and marketplace for adult panty trading experiences.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How does PantyPost keep buyers and sellers safe?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text:
+            'PantyPost protects its community with ID verification, automated moderation, and secure escrow-style payments that keep every transaction anonymous and compliant.',
+        },
+      },
+    ],
+  } as const;
+
   return (
     <>
       {/* SEO: Structured Data for Homepage */}
-      <Head>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'WebPage',
-              name: 'Panty Post - Buy & Sell Used Panties Marketplace',
-              description: 'Discreet marketplace to buy and sell used panties with verified sellers and secure payments',
-              url: BASE_URL,
-              mainEntity: {
-                '@type': 'OnlineMarketplace',
-                name: 'PantyPost',
-                description: 'Anonymous marketplace for buying and selling used panties',
-                url: BASE_URL,
-                aggregateRating: {
-                  '@type': 'AggregateRating',
-                  ratingValue: '4.8',
-                  reviewCount: '10000',
-                  bestRating: '5',
-                  worstRating: '1'
-                },
-                potentialAction: [
-                  {
-                    '@type': 'BuyAction',
-                    target: {
-                      '@type': 'EntryPoint',
-                      urlTemplate: `${BASE_URL}/browse`,
-                      actionPlatform: [
-                        'http://schema.org/DesktopWebPlatform',
-                        'http://schema.org/MobileWebPlatform'
-                      ]
-                    }
-                  },
-                  {
-                    '@type': 'SellAction',
-                    target: {
-                      '@type': 'EntryPoint',
-                      urlTemplate: `${BASE_URL}/login`,
-                      actionPlatform: [
-                        'http://schema.org/DesktopWebPlatform',
-                        'http://schema.org/MobileWebPlatform'
-                      ]
-                    }
-                  }
-                ]
-              }
-            })
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'FAQPage',
-              mainEntity: [
-                {
-                  '@type': 'Question',
-                  name: 'What is PantyPost and how does it work?',
-                  acceptedAnswer: {
-                    '@type': 'Answer',
-                    text:
-                      'PantyPost (also known as Panty Post) is a discreet marketplace that connects verified sellers with qualified buyers of used panties. Users can create an account, browse curated listings, and checkout securely with anonymous transactions.'
-                  }
-                },
-                {
-                  '@type': 'Question',
-                  name: 'Is PantyPost the same as Panty Post?',
-                  acceptedAnswer: {
-                    '@type': 'Answer',
-                    text:
-                      'Yes. PantyPost and Panty Post refer to the same privacy-first brand and marketplace for adult panty trading experiences.'
-                  }
-                },
-                {
-                  '@type': 'Question',
-                  name: 'How does PantyPost keep buyers and sellers safe?',
-                  acceptedAnswer: {
-                    '@type': 'Answer',
-                    text:
-                      'PantyPost protects its community with ID verification, automated moderation, and secure escrow-style payments that keep every transaction anonymous and compliant.'
-                  }
-                }
-              ]
-            })
-          }}
-        />
-      </Head>
+      <Script id="homepage-schema" type="application/ld+json" strategy="beforeInteractive">
+        {JSON.stringify(homepageSchema)}
+      </Script>
+      <Script id="homepage-faq-schema" type="application/ld+json" strategy="beforeInteractive">
+        {JSON.stringify(faqSchema)}
+      </Script>
 
       <BanCheck>
         {/* FIXED GRADIENT BACKGROUND - Static on screen, doesn't scroll */}

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -160,9 +160,12 @@ export const analyticsConfig = {
 } as const;
 
 // Error reporting configuration
+const rawErrorReportingEnabled = getEnvBool('NEXT_PUBLIC_ENABLE_ERROR_REPORTING', !isDevelopment());
+const sentryDsn = getEnvVar('NEXT_PUBLIC_SENTRY_DSN', '');
 export const errorReportingConfig = {
-  enabled: getEnvBool('NEXT_PUBLIC_ENABLE_ERROR_REPORTING', !isDevelopment()),
-  sentryDsn: getEnvVar('NEXT_PUBLIC_SENTRY_DSN', ''),
+  enabled: rawErrorReportingEnabled && Boolean(sentryDsn),
+  sentryDsn,
+  requested: rawErrorReportingEnabled,
 } as const;
 
 // Feature toggles - Combined old and new features
@@ -479,7 +482,7 @@ export function validateConfiguration(): { valid: boolean; errors: string[] } {
   }
 
   // Validate monitoring in production
-  if (isProduction() && errorReportingConfig.enabled && !errorReportingConfig.sentryDsn) {
+  if (isProduction() && errorReportingConfig.requested && !errorReportingConfig.sentryDsn) {
     errors.push('Sentry DSN is required when error reporting is enabled');
   }
 


### PR DESCRIPTION
## Summary
- replace the homepage Head usage with Next.js Script tags and memoized schema data to avoid rendering undefined components and keep JSON-LD structured data
- make error reporting configuration automatically disable itself when a Sentry DSN is missing while still tracking when error reporting was requested so validation only warns when appropriate

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ff0381fbe483289d75b65e96b6b92d