### PR TITLE
Fix homepage stats counter icon import

### DIFF
--- a/src/components/homepage/PaymentsProcessedCounter.tsx
+++ b/src/components/homepage/PaymentsProcessedCounter.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, useSpring, AnimatePresence } from 'framer-motion';
-import { ShieldDollar } from 'lucide-react';
+import { ShieldCheck } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import { useWebSocket } from '@/context/WebSocketContext';
 import { usePublicWebSocket } from '@/hooks/usePublicWebSocket';
@@ -189,7 +189,7 @@ export default function PaymentsProcessedCounter({
       transition={{ duration: 0.5 }}
       aria-label="Total payments processed"
     >
-      <ShieldDollar className="h-5 w-5 text-[#ff950e] animate-pulse-slow" aria-hidden="true" />
+      <ShieldCheck className="h-5 w-5 text-[#ff950e] animate-pulse-slow" aria-hidden="true" />
       <span className={textClasses}>
         Total payments processed ($){' '}
         <span className="relative inline-block">


### PR DESCRIPTION
## Summary
- replace the nonexistent `ShieldDollar` import in the homepage payments counter with the supported `ShieldCheck` icon from `lucide-react`
- ensure the counter renders without throwing, allowing the homepage sections to load

## Testing
- curl -s -o /tmp/home.html http://localhost:3000

------
https://chatgpt.com/codex/tasks/task_e_68ff068d82bc8328b323bb80528c0575