### PR TITLE
Fix duplicate dollar sign in payments counter label

### DIFF
--- a/src/components/homepage/PaymentsProcessedCounter.tsx
+++ b/src/components/homepage/PaymentsProcessedCounter.tsx
@@ -191,7 +191,7 @@ export default function PaymentsProcessedCounter({
     >
       <ShieldCheck className="h-5 w-5 text-[#ff950e] animate-pulse-slow" aria-hidden="true" />
       <span className={textClasses}>
-        Total payments processed ($){' '}
+        Total payments processed{' '}
         <span className="relative inline-block">
           <motion.span
             className="font-bold"


### PR DESCRIPTION
## Summary
- update the payments processed label so it no longer renders a redundant dollar sign before the total

## Testing
- not run (UI text change)


------
https://chatgpt.com/codex/tasks/task_e_68ff0ceb444483288b016192ac3becf5