### PR TITLE
Improve type safety across shared modules

### DIFF
--- a/src/types/ban.ts
+++ b/src/types/ban.ts
@@ -33,7 +33,7 @@ export interface BanHistoryEntry {
   details: string;
   timestamp: string;
   adminUsername: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface AppealReview {

--- a/src/types/browse.ts
+++ b/src/types/browse.ts
@@ -1,6 +1,7 @@
 // src/types/browse.ts
 
-import { Listing, AuctionSettings } from '@/context/ListingContext';
+import { Listing } from '@/context/ListingContext';
+import type { User } from '@/context/AuthContext';
 
 export interface SellerProfile {
   bio: string | null;
@@ -42,7 +43,7 @@ export interface DisplayPrice {
 
 // Component Props
 export interface BrowseHeaderProps {
-  user: any;
+  user: User | null;
   filteredListingsCount: number;
   filter: FilterOptions['filter'];
   categoryCounts: CategoryCounts;
@@ -72,7 +73,7 @@ export interface ListingCardProps {
   onMouseLeave: () => void;
   onClick: () => void;
   onQuickView: (e: React.MouseEvent) => void;
-  user: any;
+  user: User | null;
   isSubscribed: boolean;
   displayPrice: DisplayPrice;
   forceUpdateTimer: number;
@@ -86,7 +87,7 @@ export interface ListingGridProps {
   onListingLeave: () => void;
   onListingClick: (listingId: string, isLocked: boolean) => void;
   onQuickView: (e: React.MouseEvent, listingId: string) => void;
-  user: any;
+  user: User | null;
   isSubscribed: (username: string, seller: string) => boolean;
   getDisplayPrice: (listing: Listing) => DisplayPrice;
   forceUpdateTimer: number;

--- a/src/types/browseDetail.ts
+++ b/src/types/browseDetail.ts
@@ -1,7 +1,6 @@
 // src/types/browseDetail.ts
 
 import { Listing } from '@/context/ListingContext';
-import { DeliveryAddress } from '@/components/AddressConfirmationModal';
 
 export interface SellerProfile {
   bio?: string | null;
@@ -135,13 +134,13 @@ export interface PurchaseSectionProps {
 export interface SellerProfileProps {
   seller: string;
   sellerProfile: SellerProfile;
-  sellerTierInfo: any;
+  sellerTierInfo: ListingWithDetails['sellerTierInfo'];
   sellerAverageRating: number | null | undefined;
   sellerReviewCount: number;
   isVerified: boolean;
 }
 
-export interface TrustBadgesProps {}
+export type TrustBadgesProps = Record<string, never>;
 
 export interface BidHistoryModalProps {
   show: boolean;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,6 +1,7 @@
 // src/types/dashboard.ts
 
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import type { Listing } from '@/context/ListingContext';
 
 export interface SubscriptionInfo {
   seller: string;
@@ -49,7 +50,7 @@ export interface StatsGridProps {
   stats: DashboardStats;
 }
 
-export interface QuickActionsProps {}
+export type QuickActionsProps = Record<string, never>;
 
 export interface RecentActivityProps {
   activities: RecentActivity[];
@@ -60,5 +61,5 @@ export interface SubscribedSellersProps {
 }
 
 export interface FeaturedListingsProps {
-  listings: any[]; // You can replace with proper Listing type
+  listings: Listing[];
 }

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -14,7 +14,7 @@ export interface FieldState<T = string> {
 }
 
 // Form state
-export interface FormState<T extends Record<string, any>> {
+export interface FormState<T extends Record<string, unknown>> {
   values: T;
   errors: Partial<Record<keyof T, string>>;
   touched: Partial<Record<keyof T, boolean>>;
@@ -26,22 +26,22 @@ export interface FormState<T extends Record<string, any>> {
 }
 
 // Validation rule
-export type ValidationRule<T = any> = {
-  validate: (value: T, formValues?: any) => boolean | Promise<boolean>;
+export type ValidationRule<T = unknown> = {
+  validate: (value: T, formValues?: Record<string, unknown>) => boolean | Promise<boolean>;
   message: string | ((value: T) => string);
 };
 
 // Field config
-export interface FieldConfig<T = any> {
+export interface FieldConfig<T = unknown> {
   name: string;
   defaultValue?: T;
   rules?: ValidationRule<T>[];
-  transform?: (value: any) => T;
+  transform?: (value: unknown) => T;
   format?: (value: T) => string;
 }
 
 // Form config
-export interface FormConfig<T extends Record<string, any>> {
+export interface FormConfig<T extends Record<string, unknown>> {
   fields: {
     [K in keyof T]: FieldConfig<T[K]>;
   };
@@ -52,7 +52,7 @@ export interface FormConfig<T extends Record<string, any>> {
 }
 
 // Form handlers
-export interface FormHandlers<T extends Record<string, any>> {
+export interface FormHandlers<T extends Record<string, unknown>> {
   handleChange: <K extends keyof T>(field: K, value: T[K]) => void;
   handleBlur: (field: keyof T) => void;
   handleSubmit: (e?: React.FormEvent) => Promise<void>;
@@ -66,7 +66,7 @@ export interface FormHandlers<T extends Record<string, any>> {
 
 // Common validation rules
 export const ValidationRules = {
-  required: (message = 'This field is required'): ValidationRule => ({
+  required: (message = 'This field is required'): ValidationRule<unknown> => ({
     validate: (value) => {
       if (typeof value === 'string') return value.trim().length > 0;
       if (Array.isArray(value)) return value.length > 0;
@@ -106,7 +106,7 @@ export const ValidationRules = {
   }),
 
   custom: <T>(
-    validate: (value: T, formValues?: any) => boolean | Promise<boolean>,
+    validate: (value: T, formValues?: Record<string, unknown>) => boolean | Promise<boolean>,
     message: string
   ): ValidationRule<T> => ({
     validate,
@@ -131,7 +131,7 @@ export interface FormFieldProps<T = string> {
 }
 
 // Form submission result
-export interface FormSubmitResult<T = any> {
+export interface FormSubmitResult<T = unknown> {
   success: boolean;
   data?: T;
   errors?: Record<string, string>;

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -17,7 +17,6 @@ import {
 import { User } from '@/context/AuthContext';
 import { Listing } from '@/context/ListingContext';
 import { Order } from '@/context/WalletContext';
-import { Result } from './type-utils';
 
 // Basic type guards
 export const isString = (value: unknown): value is string => {
@@ -123,7 +122,7 @@ export const isCommonVerificationStatus = (value: unknown): value is CommonVerif
 // Entity guards
 export const isUser = (value: unknown): value is User => {
   if (!isObject(value)) return false;
-  const user = value as any;
+  const user = value as Record<string, unknown>;
   return (
     isString(user.id) &&
     isString(user.username) &&
@@ -137,7 +136,7 @@ export const isUser = (value: unknown): value is User => {
 
 export const isListing = (value: unknown): value is Listing => {
   if (!isObject(value)) return false;
-  const listing = value as any;
+  const listing = value as Record<string, unknown>;
   return (
     isString(listing.id) &&
     isString(listing.title) &&
@@ -152,7 +151,7 @@ export const isListing = (value: unknown): value is Listing => {
 
 export const isOrder = (value: unknown): value is Order => {
   if (!isObject(value)) return false;
-  const order = value as any;
+  const order = value as Record<string, unknown>;
   return (
     isString(order.id) &&
     isString(order.title) &&
@@ -205,16 +204,20 @@ export const hasRequiredFields = <T extends Record<string, unknown>>(
 
 // API Response guards
 export const isApiError = (error: unknown): error is { message: string; code?: string } => {
-  return isObject(error) && isString((error as any).message);
+  return (
+    isObject(error) &&
+    'message' in error &&
+    isString((error as { message?: unknown }).message)
+  );
 };
 
 export const isApiResponse = <T>(
   response: unknown,
   dataGuard?: (data: unknown) => data is T
-): response is { success: boolean; data?: T; error?: any } => {
+): response is { success: boolean; data?: T; error?: unknown } => {
   if (!isObject(response)) return false;
-  const res = response as any;
-  if (!isBoolean(res.success)) return false;
+  const res = response as Record<string, unknown>;
+  if (!('success' in res) || !isBoolean(res.success)) return false;
   if (res.success && dataGuard && !dataGuard(res.data)) return false;
   return true;
 };

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,5 +1,7 @@
 // src/types/login.ts
 
+import type { ComponentType, SVGProps } from 'react';
+
 export interface LoginState {
   username: string;
   password: string;  // ADDED PASSWORD
@@ -14,7 +16,7 @@ export interface LoginState {
 export interface RoleOption {
   key: string;
   label: string;
-  icon: any;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   description: string;
 }
 
@@ -84,4 +86,4 @@ export interface LoginFooterProps {
   step: number;
 }
 
-export interface TrustIndicatorsProps {}
+export type TrustIndicatorsProps = Record<string, never>;

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -42,7 +42,7 @@ export interface MessageThread {
   updatedAt: string;
   blockedBy?: string[];
   metadata?: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/src/types/myListings.ts
+++ b/src/types/myListings.ts
@@ -1,6 +1,8 @@
 // src/types/myListings.ts
 
 import { Listing } from '@/context/ListingContext';
+import type { ComponentType, SVGProps } from 'react';
+import type { Order } from './order';
 
 export interface ListingFormState {
   title: string;
@@ -37,7 +39,7 @@ export interface ListingDraft {
 export interface StatsCardProps {
   title: string;
   count: number;
-  icon: React.ComponentType<any>;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   iconColor: string;
   borderColor: string;
 }
@@ -81,7 +83,7 @@ export interface VerificationBannerProps {
 
 export interface TipsCardProps {
   title: string;
-  icon: React.ComponentType<any>;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   iconColor: string;
   borderColor: string;
   tips: string[];
@@ -90,7 +92,7 @@ export interface TipsCardProps {
 }
 
 export interface RecentSalesProps {
-  orders: any[];
+  orders: Order[];
 }
 
 export interface DraftListProps {

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -7,7 +7,7 @@ export interface Notification {
   type: 'sale' | 'bid' | 'subscription' | 'tip' | 'order' | 'auction_end' | 'message' | 'system';
   title: string;
   message: string;
-  data?: any;
+  data?: Record<string, unknown>;
   read: boolean;
   cleared: boolean;
   deleted?: boolean;
@@ -20,8 +20,8 @@ export interface Notification {
 
 export interface NotificationResponse {
   success: boolean;
-  data?: Notification | Notification[] | any;
-  error?: any;
+  data?: Notification | Notification[] | Record<string, unknown>;
+  error?: unknown;
 }
 
 export interface NotificationPaginationResponse {
@@ -35,5 +35,5 @@ export interface NotificationPaginationResponse {
       totalPages: number;
     };
   };
-  error?: any;
+  error?: unknown;
 }

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -81,7 +81,7 @@ export interface Listing {
   featured?: boolean;
   verified?: boolean;
   nsfw?: boolean;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface CustomRequestPurchase {
@@ -90,7 +90,7 @@ export interface CustomRequestPurchase {
   seller: string;
   amount: number;
   description: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 
 export interface DepositLog {

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,5 +1,7 @@
 // src/types/type-utils.ts
 
+import type React from 'react';
+
 /**
  * Utility types for common patterns
  */
@@ -25,7 +27,9 @@ export type OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>
 
 // Function types
 export type AsyncFunction<T = void> = () => Promise<T>;
-export type AsyncFunctionWithArgs<TArgs extends any[], TReturn = void> = (...args: TArgs) => Promise<TReturn>;
+export type AsyncFunctionWithArgs<TArgs extends unknown[], TReturn = void> = (
+  ...args: TArgs
+) => Promise<TReturn>;
 
 // Event handler types
 export type ChangeHandler<T = string> = (value: T) => void;
@@ -35,15 +39,15 @@ export type ClickHandler = React.MouseEventHandler<HTMLElement>;
 export type KeyHandler = React.KeyboardEventHandler<HTMLElement>;
 
 // Component prop types
-export type PropsWithClassName<P = {}> = P & {
+export type PropsWithClassName<P = Record<string, unknown>> = P & {
   className?: string;
 };
 
-export type PropsWithChildren<P = {}> = P & {
+export type PropsWithChildren<P = Record<string, unknown>> = P & {
   children?: React.ReactNode;
 };
 
-export type PropsWithRef<P = {}, T = HTMLElement> = P & {
+export type PropsWithRef<P = Record<string, unknown>, T = HTMLElement> = P & {
   ref?: React.Ref<T>;
 };
 
@@ -85,7 +89,7 @@ export interface SortState<T = string> {
 }
 
 // Filter state
-export interface FilterState<T = Record<string, any>> {
+export interface FilterState<T = Record<string, unknown>> {
   filters: T;
   isActive: boolean;
 }

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -73,7 +73,7 @@ export interface UserActivity {
   userId: string;
   type: 'login' | 'profile_update' | 'listing_created' | 'order_placed' | 'message_sent';
   timestamp: string;
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
   ipAddress?: string;
   userAgent?: string;
 }
@@ -186,7 +186,7 @@ export interface UserError {
   code: UserErrorCode;
   message: string;
   field?: string;
-  details?: any;
+  details?: unknown;
 }
 
 // Validation schemas

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -251,7 +251,7 @@ export interface RiskFactor {
   description: string;
   severity: 'low' | 'medium' | 'high';
   score: number;
-  details?: any;
+  details?: Record<string, unknown>;
 }
 
 export interface ComplianceCheck {
@@ -260,7 +260,7 @@ export interface ComplianceCheck {
   status: 'pending' | 'passed' | 'failed' | 'review';
   checkedAt: ISOTimestamp;
   expiresAt?: ISOTimestamp;
-  details?: any;
+  details?: Record<string, unknown>;
 }
 
 // Reconciliation
@@ -399,7 +399,7 @@ export enum WalletErrorCode {
 export interface WalletError {
   code: WalletErrorCode;
   message: string;
-  details?: any;
+  details?: Record<string, unknown>;
   transactionId?: string;
   timestamp: ISOTimestamp;
 }
@@ -425,7 +425,7 @@ export interface CustomRequestPurchase {
   seller: string;
   amount: number;
   description: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 
 // Helper type guards

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -71,12 +71,12 @@ export enum WebSocketEvent {
 }
 
 // Type for WebSocket event handlers
-export type WebSocketHandler<T = any> = (data: T) => void;
+export type WebSocketHandler<T = unknown> = (data: T) => void;
 
 // WebSocket options
 export interface WebSocketOptions {
   url: string;
-  auth?: Record<string, any>;
+  auth?: Record<string, unknown>;
   autoConnect?: boolean;
   reconnect?: boolean;
   reconnectAttempts?: number;
@@ -91,7 +91,7 @@ export interface WebSocketError {
 }
 
 // WebSocket message structure
-export interface WebSocketMessage<T = any> {
+export interface WebSocketMessage<T = unknown> {
   event: WebSocketEvent;
   data: T;
   timestamp?: number;
@@ -124,7 +124,7 @@ export interface RealtimeNotification {
   type: 'message' | 'order' | 'wallet' | 'system';
   title: string;
   body: string;
-  data?: any;
+  data?: Record<string, unknown>;
   read: boolean;
   createdAt: string;
 }
@@ -133,7 +133,7 @@ export interface RealtimeNotification {
 export interface OrderUpdateData {
   orderId: string;
   status?: string;
-  updates?: Record<string, any>;
+  updates?: Record<string, unknown>;
   timestamp?: number;
 }
 
@@ -158,7 +158,7 @@ export interface AuctionBidData {
 export interface ListingUpdateData {
   listingId: string;
   title?: string;
-  updates?: Record<string, any>;
+  updates?: Record<string, unknown>;
   soldTo?: string;
   price?: number;
   timestamp?: number;

--- a/src/utils/banUtils.tsx
+++ b/src/utils/banUtils.tsx
@@ -1,12 +1,13 @@
 // src/utils/banUtils.tsx
-import { 
-  AlertTriangle, 
-  MessageSquare, 
-  AlertCircle, 
-  UserCheck, 
-  Info 
+import type { ComponentType, SVGProps } from 'react';
+import {
+  AlertTriangle,
+  MessageSquare,
+  AlertCircle,
+  UserCheck,
+  Info
 } from 'lucide-react';
-import { BanEntry, BanReason } from '@/types/ban';
+import { BanEntry } from '@/types/ban';
 import { sanitizeStrict } from '@/utils/security/sanitization';
 
 export const getBanReasonDisplay = (reason: string, customReason?: string) => {
@@ -14,7 +15,7 @@ export const getBanReasonDisplay = (reason: string, customReason?: string) => {
     return 'Unknown Reason';
   }
 
-  const reasonMap: Record<string, { label: string, icon: any, color: string }> = {
+  const reasonMap: Record<string, { label: string; icon: ComponentType<SVGProps<SVGSVGElement>>; color: string }> = {
     harassment: { label: 'Harassment', icon: AlertTriangle, color: 'text-red-400' },
     spam: { label: 'Spam', icon: MessageSquare, color: 'text-yellow-400' },
     inappropriate_content: { label: 'Inappropriate Content', icon: AlertCircle, color: 'text-orange-400' },
@@ -39,14 +40,19 @@ export const getBanReasonDisplay = (reason: string, customReason?: string) => {
   );
 };
 
-export const isValidBan = (ban: any): ban is BanEntry => {
-  return ban && 
-         typeof ban === 'object' && 
-         ban.id && 
-         ban.username && 
-         typeof ban.username === 'string' &&
-         ban.banType &&
-         ban.reason &&
-         ban.startTime &&
-         typeof ban.bannedBy === 'string'; // Changed to check type instead of truthiness
+export const isValidBan = (ban: unknown): ban is BanEntry => {
+  if (typeof ban !== 'object' || ban === null) {
+    return false;
+  }
+
+  const candidate = ban as Record<string, unknown>;
+
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.username === 'string' &&
+    typeof candidate.banType === 'string' &&
+    typeof candidate.reason === 'string' &&
+    typeof candidate.startTime === 'string' &&
+    typeof candidate.bannedBy === 'string'
+  );
 };

--- a/src/utils/lazyWithLoading.tsx
+++ b/src/utils/lazyWithLoading.tsx
@@ -1,6 +1,6 @@
 // src/utils/lazyWithLoading.tsx
 import dynamic from 'next/dynamic';
-import { ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 // Loading skeleton component
 export const LoadingSkeleton = () => (
@@ -13,8 +13,8 @@ export const LoadingSkeleton = () => (
 );
 
 // Generic lazy loading wrapper
-export function lazyWithLoading<T extends ComponentType<any>>(
-  importFunc: () => Promise<{ default: T }>,
+export function lazyWithLoading<TProps extends Record<string, unknown>>(
+  importFunc: () => Promise<{ default: ComponentType<TProps> }>,
   LoadingComponent?: ComponentType
 ) {
   return dynamic(importFunc, {

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -14,7 +14,7 @@ export interface Message {
   isTip?: boolean;
   tipAmount?: number;
   isCustomRequest?: boolean;
-  requestData?: any;
+  requestData?: Record<string, unknown>;
   messageKey?: string;
   meta?: {
     id?: string;
@@ -44,7 +44,7 @@ export interface CustomRequest {
 }
 
 // Process messages to handle custom requests correctly
-export function getLatestCustomRequestMessages(messages: Message[], requests: CustomRequest[]): Message[] {
+export function getLatestCustomRequestMessages(messages: Message[], _requests: CustomRequest[]): Message[] {
   const seen = new Set<string>();
   const result: Message[] = [];
 

--- a/src/utils/myListingsUtils.ts
+++ b/src/utils/myListingsUtils.ts
@@ -1,5 +1,6 @@
 // src/utils/myListingsUtils.ts
 
+import type { Listing } from '@/context/ListingContext';
 import { ListingFormState } from '@/types/myListings';
 
 export const INITIAL_FORM_STATE: ListingFormState = {
@@ -119,7 +120,7 @@ export const parseTags = (tagsString: string): string[] => {
  * @param listing - Listing object
  * @returns Type label string
  */
-export const getListingTypeLabel = (listing: any): string => {
+export const getListingTypeLabel = (listing: Pick<Listing, 'auction' | 'isPremium'>): string => {
   if (listing.auction) return 'Auction';
   if (listing.isPremium) return 'Premium';
   return 'Standard';
@@ -130,7 +131,7 @@ export const getListingTypeLabel = (listing: any): string => {
  * @param listing - Listing object
  * @returns Color class string
  */
-export const getListingTypeColor = (listing: any): string => {
+export const getListingTypeColor = (listing: Pick<Listing, 'auction' | 'isPremium'>): string => {
   if (listing.auction) return 'text-purple-500 border-purple-500';
   if (listing.isPremium) return 'text-yellow-500 border-yellow-500';
   return 'text-green-500 border-green-500';

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -3,17 +3,15 @@
 
 import { Listing } from '@/context/ListingContext';
 
+type PriceableListing = Pick<Listing, 'price' | 'markedUpPrice' | 'auction'>;
+
 /**
  * Get the total amount a buyer needs to pay for a listing
  * This is the SINGLE SOURCE OF TRUTH used by both:
  * - Pre-purchase balance checks
  * - Actual wallet debits in WalletContext
  */
-export function getBuyerDebitAmount(listing: { 
-  markedUpPrice?: number; 
-  price: number;
-  auction?: any;
-}): number {
+export function getBuyerDebitAmount(listing: PriceableListing): number {
   // For auctions, we don't use this function (handled separately)
   if (listing.auction) {
     return 0;
@@ -53,8 +51,8 @@ export function getAuctionPlatformFee(winningBid: number): number {
  * Check if buyer has sufficient balance for a purchase
  */
 export function hasSufficientBalance(
-  buyerBalance: number, 
-  listing: { markedUpPrice?: number; price: number; auction?: any }
+  buyerBalance: number,
+  listing: PriceableListing
 ): boolean {
   const required = getBuyerDebitAmount(listing);
   return buyerBalance >= required;
@@ -65,7 +63,7 @@ export function hasSufficientBalance(
  */
 export function getAmountNeeded(
   buyerBalance: number,
-  listing: { markedUpPrice?: number; price: number; auction?: any }
+  listing: PriceableListing
 ): number {
   const required = getBuyerDebitAmount(listing);
   const needed = required - buyerBalance;

--- a/src/utils/sanitizeInput.ts
+++ b/src/utils/sanitizeInput.ts
@@ -68,18 +68,18 @@ export function sanitizeUsername(username: string): string {
  * @param max - Maximum allowed value (default: 999999)
  * @returns The sanitized number or 0 if invalid
  */
-export function sanitizeNumber(input: any, min: number = 0, max: number = 999999): number {
-  const num = parseFloat(input);
-  
-  if (isNaN(num) || !isFinite(num)) {
+export function sanitizeNumber(input: unknown, min: number = 0, max: number = 999999): number {
+  const raw = typeof input === 'number' ? input : Number.parseFloat(String(input));
+
+  if (!Number.isFinite(raw)) {
     return min;
   }
-  
-  if (num < min) return min;
-  if (num > max) return max;
-  
+
+  if (raw < min) return min;
+  if (raw > max) return max;
+
   // Round to 2 decimal places for currency
-  return Math.round(num * 100) / 100;
+  return Math.round(raw * 100) / 100;
 }
 
 /**
@@ -128,32 +128,32 @@ export function sanitizeTags(tags: string[]): string[] {
  * @param obj - Object to sanitize
  * @returns Sanitized object
  */
-export function sanitizeObject(obj: any): any {
+export function sanitizeObject<T>(obj: T): T {
   if (obj === null || obj === undefined) {
     return obj;
   }
 
   if (typeof obj === 'string') {
-    return sanitizeString(obj);
+    return sanitizeString(obj) as unknown as T;
   }
 
   if (typeof obj === 'number') {
-    return sanitizeNumber(obj);
+    return sanitizeNumber(obj) as unknown as T;
   }
 
   if (Array.isArray(obj)) {
-    return obj.map(item => sanitizeObject(item));
+    return obj.map(item => sanitizeObject(item)) as unknown as T;
   }
 
   if (typeof obj === 'object') {
-    const sanitized: any = {};
+    const sanitized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
       const sanitizedKey = sanitizeString(key);
       if (sanitizedKey) {
         sanitized[sanitizedKey] = sanitizeObject(value);
       }
     }
-    return sanitized;
+    return sanitized as unknown as T;
   }
 
   return obj;

--- a/src/utils/security/rate-limiter.ts
+++ b/src/utils/security/rate-limiter.ts
@@ -275,10 +275,10 @@ export function getRateLimiter(): ActionRateLimiter {
  * Rate limit decorator for functions
  */
 export function rateLimit(action: string, config: RateLimitConfig) {
-  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+  return function (target: Record<string, unknown>, propertyKey: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
 
-    descriptor.value = async function (...args: any[]) {
+    descriptor.value = async function (...args: unknown[]) {
       const limiter = getRateLimiter();
       const result = limiter.check(action, config);
 

--- a/src/utils/security/sanitization.ts
+++ b/src/utils/security/sanitization.ts
@@ -309,23 +309,23 @@ export function sanitizeStringArray(
  * Sanitizes object keys and values recursively
  * Prevents prototype pollution attacks
  */
-export function sanitizeObject<T extends Record<string, any>>(
+export function sanitizeObject<T extends Record<string, unknown>>(
   obj: T,
   options: {
     maxDepth?: number;
     allowedKeys?: string[];
     keySanitizer?: (key: string) => string;
-    valueSanitizer?: (value: any) => any;
+    valueSanitizer?: (value: unknown) => unknown;
   } = {}
 ): Partial<T> {
   const {
     maxDepth = 5,
     allowedKeys,
     keySanitizer = sanitizeStrict,
-    valueSanitizer = (v) => (typeof v === 'string' ? sanitizeStrict(v) : v),
+    valueSanitizer = (v: unknown) => (typeof v === 'string' ? sanitizeStrict(v) : v),
   } = options;
   
-  function sanitizeRecursive(input: any, depth: number): any {
+  function sanitizeRecursive(input: unknown, depth: number): unknown {
     if (depth > maxDepth) {
       return null;
     }
@@ -347,11 +347,11 @@ export function sanitizeObject<T extends Record<string, any>>(
     }
     
     if (typeof input === 'object') {
-      const sanitized: any = {};
+      const sanitized: Record<string, unknown> = {};
       
       for (const [key, value] of Object.entries(input)) {
         // Skip prototype properties
-        if (!input.hasOwnProperty(key)) continue;
+        if (!Object.prototype.hasOwnProperty.call(input, key)) continue;
         
         // Skip dangerous keys
         if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
@@ -375,7 +375,7 @@ export function sanitizeObject<T extends Record<string, any>>(
     return null;
   }
   
-  return sanitizeRecursive(obj, 0);
+  return sanitizeRecursive(obj, 0) as Partial<T>;
 }
 
 /**

--- a/src/utils/security/validation.ts
+++ b/src/utils/security/validation.ts
@@ -411,7 +411,10 @@ export class CSRFTokenManager {
 /**
  * Input debouncing for validation
  */
-export function debounce<T extends (...args: any[]) => any>(func: T, wait: number): (...args: Parameters<T>) => void {
+export function debounce<T extends (...args: unknown[]) => unknown>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
   let timeout: NodeJS.Timeout | null = null;
 
   return function executedFunction(...args: Parameters<T>) {

--- a/src/utils/storageSyncFix.ts
+++ b/src/utils/storageSyncFix.ts
@@ -1,6 +1,7 @@
 // src/utils/storageSyncFix.ts
 import { storageService } from '@/services/storage.service';
 import { ordersService } from '@/services/orders.service';
+import type { Order } from '@/types/wallet';
 
 /**
  * Force synchronize all wallet-related localStorage data
@@ -14,7 +15,7 @@ export async function forceWalletStorageSync(): Promise<void> {
   
   // Force read current data
   const buyers = await storageService.getItem<Record<string, number>>('wallet_buyers', {});
-  const orders = await storageService.getItem<any[]>('wallet_orders', []);
+  const orders = await storageService.getItem<Order[]>('wallet_orders', []);
   
   // Re-write to trigger storage events
   await storageService.setItem('wallet_buyers', buyers);
@@ -55,7 +56,7 @@ export async function atomicRefundOperation(
       console.log('[AtomicRefund] Refund amount is 0, fetching from orders...');
       
       // Get all orders
-      const orders = await storageService.getItem<any[]>('wallet_orders', []);
+      const orders = await storageService.getItem<Order[]>('wallet_orders', []);
       
       // Find the pending auction order for this listing and bidder
       const pendingOrder = orders.find(order => 
@@ -85,7 +86,7 @@ export async function atomicRefundOperation(
     
     // 1. Get current data
     const buyers = await storageService.getItem<Record<string, number>>('wallet_buyers', {});
-    const orders = await storageService.getItem<any[]>('wallet_orders', []);
+    const orders = await storageService.getItem<Order[]>('wallet_orders', []);
     
     // 2. Update buyer balance - ONLY for the specific bidder
     const currentBalance = roundCurrency(buyers[bidder] || 0);

--- a/src/utils/validation/schemas.ts
+++ b/src/utils/validation/schemas.ts
@@ -498,9 +498,11 @@ export function validateField<T>(
   value: unknown
 ): string | undefined {
   try {
-    const fieldSchema = (schema as any).shape[fieldName];
-    if (fieldSchema) {
-      fieldSchema.parse(value);
+    if (schema instanceof z.ZodObject) {
+      const fieldSchema = schema.shape[fieldName as keyof typeof schema.shape];
+      if (fieldSchema) {
+        (fieldSchema as z.ZodTypeAny).parse(value);
+      }
     }
     return undefined;
   } catch (error) {


### PR DESCRIPTION
## Summary
- replace `any` usage across shared type definitions with explicit unions and typed records for downstream safety
- update admin, wallet, and sanitization utilities to rely on typed storage interactions and stricter helper generics
- clean up unused exports while aligning React helper props with specific icon/component typings

## Testing
- npm run lint *(fails: existing lint violations in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_69006143f78c8328a18069b1cf1337d9