### PR TITLE
Improve seller profile tier layout spacing

### DIFF
--- a/src/app/sellers/profile/page.tsx
+++ b/src/app/sellers/profile/page.tsx
@@ -130,8 +130,8 @@ export default function SellerProfileSettingsPage() {
 
             {/* Tier Progress & Display Section */}
             {sellerTierInfo && (
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
-                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur">
+              <div className="grid grid-cols-1 gap-10 xl:grid-cols-[1.6fr_1fr]">
+                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur h-full">
                   <TierProgressCard
                     sellerTierInfo={sellerTierInfo}
                     userStats={userStats}
@@ -140,14 +140,15 @@ export default function SellerProfileSettingsPage() {
                     onTierClick={setSelectedTierDetails}
                   />
                 </div>
-
-                <TierDisplaySection
-                  sellerTierInfo={sellerTierInfo}
-                  userStats={userStats}
-                  nextTier={nextTier}
-                  selectedTierDetails={selectedTierDetails}
-                  onTierSelect={setSelectedTierDetails}
-                />
+                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur h-full">
+                  <TierDisplaySection
+                    sellerTierInfo={sellerTierInfo}
+                    userStats={userStats}
+                    nextTier={nextTier}
+                    selectedTierDetails={selectedTierDetails}
+                    onTierSelect={setSelectedTierDetails}
+                  />
+                </div>
               </div>
             )}
           </div>

--- a/src/components/seller-settings/TierDisplaySection.tsx
+++ b/src/components/seller-settings/TierDisplaySection.tsx
@@ -87,23 +87,29 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
   const credit = typeof sellerTierInfo.credit === 'number' && Number.isFinite(sellerTierInfo.credit) ? sellerTierInfo.credit : 0;
 
   return (
-    <div className="bg-gradient-to-r from-[#1a1a1a] to-[#272727] rounded-xl border border-gray-800 p-6 shadow-xl h-full flex flex-col gap-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div className="relative flex h-full flex-col gap-8 overflow-hidden rounded-3xl bg-gradient-to-br from-[#191919] via-[#111] to-[#1f1f1f] p-8 shadow-[0_24px_80px_-40px_rgba(0,0,0,0.9)]">
+      <div className="pointer-events-none absolute -bottom-16 -left-10 h-48 w-48 rounded-full bg-[#ff950e]/10 blur-3xl" />
+      <section className="relative z-10 flex flex-col gap-6 rounded-2xl border border-white/5 bg-black/40 p-6 backdrop-blur-sm lg:flex-row lg:items-center lg:justify-between">
         <div className="flex items-start gap-4">
           <div className="flex-shrink-0">
             {currentTier && currentTier !== 'None' ? <TierBadge tier={currentTier} size="2xl" showTooltip={true} /> : null}
           </div>
           <div className="space-y-2">
-            <h2 className="text-xl font-bold text-white mb-1 flex items-center">
-              <Award className="w-5 h-5 mr-2 text-[#ff950e]" />
-              Your Seller Tier:{' '}
-              <span className="ml-2 text-[#ff950e]">{currentTier && currentTier !== 'None' ? currentTier : '—'}</span>
+            <h2 className="flex items-center text-2xl font-semibold text-white">
+              <Award className="mr-3 h-6 w-6 text-[#ff950e]" />
+              Your Seller Tier
             </h2>
-            <p className="text-gray-300">
+            <p className="text-base text-gray-300">
+              Current level:{' '}
+              <span className="font-semibold text-[#ff950e]">
+                {currentTier && currentTier !== 'None' ? currentTier : '—'}
+              </span>
+            </p>
+            <p className="text-sm text-gray-400">
               {credit > 0 ? (
                 <>
-                  You earn an additional <span className="font-bold text-green-400">{(credit * 100).toFixed(0)}%</span> on all
-                  your sales!
+                  You earn an additional <span className="font-semibold text-green-400">{(credit * 100).toFixed(0)}%</span> on
+                  all your sales!
                 </>
               ) : (
                 <>Make more sales to earn additional credits on your sales</>
@@ -113,30 +119,33 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
         </div>
 
         {currentTier !== 'Goddess' && nextTier && (
-          <div className="bg-[#111] border border-gray-800 rounded-lg p-3 shadow-inner self-stretch lg:max-w-xs">
-            <div className="text-sm text-gray-400">
-              Next tier: <span className="font-medium text-purple-400">{nextTier}</span>
+          <div className="flex w-full flex-col gap-3 rounded-2xl border border-white/5 bg-black/60 p-5 shadow-inner lg:w-auto lg:max-w-xs">
+            <div className="text-sm font-medium text-gray-300">
+              Next tier:{' '}
+              <span className="text-purple-400">{nextTier}</span>
             </div>
-            <div className="flex items-center gap-2">
-              <TrendingUp className="w-4 h-4 text-green-400" />
-              <span className="text-green-300 text-sm">
-                Need: {TIER_LEVELS[nextTier].minSales.toLocaleString()} sales or{' '}
-                {formatCurrency(TIER_LEVELS[nextTier].minAmount)}
+            <div className="flex items-center gap-2 text-sm text-green-300">
+              <TrendingUp className="h-4 w-4 text-green-400" />
+              <span>
+                Need {TIER_LEVELS[nextTier].minSales.toLocaleString()} sales or {formatCurrency(TIER_LEVELS[nextTier].minAmount)}
               </span>
             </div>
           </div>
         )}
-      </div>
+      </section>
 
       {/* Simple Interactive Tier Table */}
-      <div className="bg-[#111] rounded-lg p-4 border border-gray-700 flex-1">
-        <h3 className="text-lg font-medium text-gray-300 mb-4 flex items-center gap-2">
-          <Star className="w-5 h-5 text-[#ff950e]" />
-          All Seller Tiers <span className="text-sm text-gray-500 font-normal">(Click to view details)</span>
-        </h3>
+      <section className="relative z-10 flex-1 rounded-2xl border border-white/5 bg-black/40 p-6 backdrop-blur-sm">
+        <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h3 className="flex items-center gap-2 text-lg font-semibold text-gray-200">
+            <Star className="h-5 w-5 text-[#ff950e]" />
+            Seller Tier Overview
+          </h3>
+          <span className="text-xs uppercase tracking-wide text-gray-500">Click a tier to explore benefits</span>
+        </div>
 
         {/* Tier Badges Row */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2 gap-3 mb-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
           {(['Tease', 'Flirt', 'Obsession', 'Desire', 'Goddess'] as TierLevel[]).map((tier) => {
             const isCurrentTier = currentTier === tier;
             const isSelected = selectedTierDetails === tier;
@@ -145,12 +154,12 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
               <button
                 key={tier}
                 onClick={() => onTierSelect(isSelected ? null : tier)}
-                className={`relative p-3 rounded-lg border-2 transition-all duration-300 text-left ${
+                className={`group relative flex items-center justify-between gap-3 rounded-2xl border-2 px-4 py-3 text-left transition-all duration-300 ${
                   isCurrentTier
-                    ? 'border-[#ff950e] bg-[#ff950e]/10'
+                    ? 'border-[#ff950e] bg-[#ff950e]/10 shadow-[0_12px_30px_-20px_rgba(255,149,14,0.8)]'
                     : isSelected
-                    ? 'border-purple-400 bg-purple-400/10'
-                    : 'border-gray-600 bg-gray-800/50 hover:border-gray-500'
+                    ? 'border-purple-400 bg-purple-400/15 shadow-[0_12px_30px_-20px_rgba(168,85,247,0.7)]'
+                    : 'border-gray-700 bg-gray-900/60 hover:border-[#ff950e]/50 hover:bg-gray-900'
                 }`}
                 type="button"
                 aria-pressed={isSelected}
@@ -159,11 +168,11 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
                 <div className="flex items-center gap-3">
                   <TierBadge tier={tier} size="lg" showTooltip={false} />
                   <div className="space-y-1">
-                    <div className="font-medium text-white text-sm">{tier}</div>
-                    <div className="text-xs text-gray-400">+{(TIER_LEVELS[tier].credit * 100).toFixed(0)}%</div>
-                    {isCurrentTier && <div className="text-xs text-[#ff950e] font-medium">Current</div>}
+                    <div className="text-sm font-medium text-white">{tier}</div>
+                    <div className="text-xs text-gray-400">+{(TIER_LEVELS[tier].credit * 100).toFixed(0)}% bonus</div>
                   </div>
                 </div>
+                {isCurrentTier && <div className="text-xs font-semibold text-[#ff950e]">Current</div>}
               </button>
             );
           })}
@@ -171,115 +180,115 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
 
         {/* Expanded Details */}
         {selectedTierDetails && (
-          <div className="border-t border-gray-700 pt-4 animate-in slide-in-from-top duration-300">
-            <div className="bg-[#0a0a0a] rounded-lg p-4 border border-gray-800">
-              <div className="flex items-center gap-3 mb-4">
+          <div className="mt-6 rounded-2xl border border-white/5 bg-[#0a0a0a] p-6 shadow-inner animate-in slide-in-from-top duration-300">
+            <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-4">
                 <TierBadge tier={selectedTierDetails} size="lg" showTooltip={false} />
                 <div>
                   <h4 className="text-xl font-bold text-[#ff950e]">{selectedTierDetails} Tier</h4>
-                  <p className="text-gray-400 text-sm">
-                    Level {(['Tease', 'Flirt', 'Obsession', 'Desire', 'Goddess'] as TierLevel[]).indexOf(selectedTierDetails) + 1} of
-                    5
+                  <p className="text-sm text-gray-400">
+                    Level {(['Tease', 'Flirt', 'Obsession', 'Desire', 'Goddess'] as TierLevel[]).indexOf(selectedTierDetails) + 1} of 5
                   </p>
                 </div>
               </div>
+            </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Requirements */}
-                <div>
-                  <h5 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
-                    <Target className="w-4 h-4 text-green-400" />
-                    Requirements
-                  </h5>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                      <span className="text-gray-300">Total Sales</span>
-                      <span className="text-[#ff950e] font-medium">{TIER_LEVELS[selectedTierDetails].minSales}+</span>
-                    </div>
-                    <div className="text-center text-gray-500 text-xs">OR</div>
-                    <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                      <span className="text-gray-300">Total Revenue</span>
-                      <span className="text-[#ff950e] font-medium">{formatCurrency(TIER_LEVELS[selectedTierDetails].minAmount)}+</span>
-                    </div>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              {/* Requirements */}
+              <div>
+                <h5 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+                  <Target className="h-4 w-4 text-green-400" />
+                  Requirements
+                </h5>
+                <div className="space-y-3 text-sm">
+                  <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                    <span className="text-gray-300">Total Sales</span>
+                    <span className="font-medium text-[#ff950e]">{TIER_LEVELS[selectedTierDetails].minSales}+</span>
+                  </div>
+                  <div className="text-center text-xs uppercase tracking-wide text-gray-500">or</div>
+                  <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                    <span className="text-gray-300">Total Revenue</span>
+                    <span className="font-medium text-[#ff950e]">
+                      {formatCurrency(TIER_LEVELS[selectedTierDetails].minAmount)}+
+                    </span>
+                  </div>
 
-                    {/* User Progress */}
-                    <div className="mt-3 pt-3 border-t border-gray-800">
-                      <p className="text-xs text-gray-400 mb-2">Your Progress:</p>
-                      <div className="text-xs space-y-1">
-                        <div className="flex justify-between">
-                          <span className="text-gray-300">Sales: {userStats.totalSales}</span>
-                          <span className="text-gray-300">Revenue: {formatCurrency(userStats.totalRevenue)}</span>
-                        </div>
-                        {selectedTierDetails !== currentTier && (
-                          <p className="text-green-400 mt-2">
-                            Need: {Math.max(0, TIER_LEVELS[selectedTierDetails].minSales - userStats.totalSales)} more sales OR{' '}
-                            {formatCurrency(Math.max(0, TIER_LEVELS[selectedTierDetails].minAmount - userStats.totalRevenue))} more
-                            revenue
-                          </p>
-                        )}
+                  {/* User Progress */}
+                  <div className="mt-4 rounded-xl border border-white/5 bg-black/50 p-4">
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Your progress</p>
+                    <div className="space-y-2 text-xs text-gray-300">
+                      <div className="flex items-center justify-between">
+                        <span>Sales: {userStats.totalSales}</span>
+                        <span>Revenue: {formatCurrency(userStats.totalRevenue)}</span>
                       </div>
+                      {selectedTierDetails !== currentTier && (
+                        <p className="text-sm text-green-400">
+                          Need {Math.max(0, TIER_LEVELS[selectedTierDetails].minSales - userStats.totalSales)} more sales or{' '}
+                          {formatCurrency(Math.max(0, TIER_LEVELS[selectedTierDetails].minAmount - userStats.totalRevenue))} more revenue
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>
+              </div>
 
-                {/* Benefits */}
-                <div>
-                  <h5 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
-                    <Gift className="w-4 h-4 text-purple-400" />
-                    Benefits
-                  </h5>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                      <span className="text-gray-300">Bonus Credits</span>
-                      <span className="text-green-400 font-bold">
-                        {TIER_LEVELS[selectedTierDetails].credit > 0
-                          ? `+${(TIER_LEVELS[selectedTierDetails].credit * 100).toFixed(0)}%`
-                          : 'None'}
+              {/* Benefits */}
+              <div>
+                <h5 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+                  <Gift className="h-4 w-4 text-purple-400" />
+                  Benefits
+                </h5>
+                <div className="space-y-3 text-sm">
+                  <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                    <span className="text-gray-300">Bonus Credits</span>
+                    <span className="font-bold text-green-400">
+                      {TIER_LEVELS[selectedTierDetails].credit > 0
+                        ? `+${(TIER_LEVELS[selectedTierDetails].credit * 100).toFixed(0)}%`
+                        : 'None'}
+                    </span>
+                  </div>
+
+                  {selectedTierDetails !== 'Tease' && (
+                    <>
+                      <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                        <span className="text-gray-300">Priority Support</span>
+                        <span className="text-green-400">✓</span>
+                      </div>
+                      <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                        <span className="text-gray-300">Featured Profile</span>
+                        <span className="text-green-400">✓</span>
+                      </div>
+                    </>
+                  )}
+
+                  {(selectedTierDetails === 'Desire' || selectedTierDetails === 'Goddess') && (
+                    <>
+                      <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                        <span className="text-gray-300">Custom Badge</span>
+                        <span className="text-green-400">✓</span>
+                      </div>
+                      <div className="flex items-center justify-between rounded-xl border border-white/5 bg-black/60 p-3">
+                        <span className="text-gray-300">VIP Events</span>
+                        <span className="text-green-400">✓</span>
+                      </div>
+                    </>
+                  )}
+
+                  {selectedTierDetails === 'Goddess' && (
+                    <div className="flex items-center justify-between rounded-xl border border-purple-500/40 bg-gradient-to-r from-purple-900/30 to-pink-900/30 p-3">
+                      <span className="text-gray-300">Elite Status</span>
+                      <span className="flex items-center gap-1 text-purple-400">
+                        <Crown className="h-4 w-4" />
+                        VIP
                       </span>
                     </div>
-
-                    {selectedTierDetails !== 'Tease' && (
-                      <>
-                        <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                          <span className="text-gray-300">Priority Support</span>
-                          <span className="text-green-400">✓</span>
-                        </div>
-                        <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                          <span className="text-gray-300">Featured Profile</span>
-                          <span className="text-green-400">✓</span>
-                        </div>
-                      </>
-                    )}
-
-                    {(selectedTierDetails === 'Desire' || selectedTierDetails === 'Goddess') && (
-                      <>
-                        <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                          <span className="text-gray-300">Custom Badge</span>
-                          <span className="text-green-400">✓</span>
-                        </div>
-                        <div className="flex items-center justify-between p-2 bg-[#111] rounded">
-                          <span className="text-gray-300">VIP Events</span>
-                          <span className="text-green-400">✓</span>
-                        </div>
-                      </>
-                    )}
-
-                    {selectedTierDetails === 'Goddess' && (
-                      <div className="flex items-center justify-between p-2 bg-gradient-to-r from-purple-900/30 to-pink-900/30 rounded border border-purple-500/30">
-                        <span className="text-gray-300">Elite Status</span>
-                        <span className="text-purple-400 flex items-center gap-1">
-                          <Crown className="w-4 h-4" />
-                          VIP
-                        </span>
-                      </div>
-                    )}
-                  </div>
+                  )}
                 </div>
               </div>
             </div>
           </div>
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/components/seller-settings/TierProgressCard.tsx
+++ b/src/components/seller-settings/TierProgressCard.tsx
@@ -107,89 +107,102 @@ export default function TierProgressCard(rawProps: TierProgressCardProps) {
   const revenuePct = clampPercent(tierProgress.revenueProgress);
 
   return (
-    <div className="bg-[#1a1a1a] rounded-xl shadow-lg border border-gray-800 p-6 relative overflow-hidden">
-      <div className="absolute top-0 right-0 opacity-10">{getTierIcon(currentTier)}</div>
+    <div className="relative flex h-full flex-col justify-between gap-10 overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#161616] via-[#101010] to-[#161616] p-8 shadow-[0_24px_80px_-40px_rgba(0,0,0,0.9)]">
+      <div className="pointer-events-none absolute -top-10 -right-6 h-40 w-40 rounded-full bg-[#ff950e]/10 blur-3xl" />
+      <div className="absolute top-8 right-8 text-[#ff950e]/40">{getTierIcon(currentTier)}</div>
 
-      <h2 className="text-xl font-bold mb-6 text-white">Seller Tier Progress</h2>
-
-      {/* Current Tier Display */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <p className="text-sm text-gray-400 mb-1">Current Tier</p>
-          <div className="flex items-center gap-2">
-            {currentTier !== 'None' ? <TierBadge tier={currentTier} size="md" /> : null}
-            <span className="text-lg font-bold text-white">{currentTier}</span>
-          </div>
+      <header className="flex flex-col items-start gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-medium uppercase tracking-widest text-[#ff950e]/70">Seller insights</p>
+          <h2 className="text-2xl font-semibold text-white">Seller Tier Progress</h2>
         </div>
-        <button onClick={() => onTierClick(currentTier)} className="text-[#ff950e] text-sm hover:underline" type="button">
+        <button
+          onClick={() => onTierClick(currentTier)}
+          className="inline-flex items-center rounded-full border border-[#ff950e]/40 px-4 py-2 text-sm font-medium text-[#ff950e] transition hover:border-[#ff950e]/60 hover:bg-[#ff950e]/10"
+          type="button"
+        >
           View Details
         </button>
-      </div>
+      </header>
 
-      {/* Stats Display */}
-      <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="bg-black rounded-lg p-3">
-          <p className="text-xs text-gray-400">Total Sales</p>
-          <p className="text-xl font-bold text-[#ff950e]">{userStats.totalSales}</p>
+      {/* Current Tier Display */}
+      <section className="flex flex-col justify-between gap-6 rounded-2xl border border-white/5 bg-black/40 p-6 backdrop-blur-sm sm:flex-row sm:items-center">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-gray-400">Current Tier</p>
+          <div className="flex items-center gap-3">
+            {currentTier !== 'None' ? <TierBadge tier={currentTier} size="lg" /> : null}
+            <span className="text-2xl font-semibold text-white">{currentTier}</span>
+          </div>
         </div>
-        <div className="bg-black rounded-lg p-3">
-          <p className="text-xs text-gray-400">Total Revenue</p>
-          <p className="text-xl font-bold text-[#ff950e]">{formatCurrency(userStats.totalRevenue)}</p>
+        <div className="grid w-full grid-cols-1 gap-4 sm:w-auto sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/5 bg-black/60 p-4 text-center shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Total Sales</p>
+            <p className="text-2xl font-bold text-[#ff950e]">{userStats.totalSales}</p>
+          </div>
+          <div className="rounded-2xl border border-white/5 bg-black/60 p-4 text-center shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Total Revenue</p>
+            <p className="text-2xl font-bold text-[#ff950e]">{formatCurrency(userStats.totalRevenue)}</p>
+          </div>
         </div>
-      </div>
+      </section>
 
       {/* Progress to Next Tier */}
       {currentTier !== 'Goddess' && nextRequirements && (
-        <div className="space-y-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-gray-400">Progress to {nextTier}</p>
-            <TierBadge tier={nextTier} size="sm" />
+        <section className="flex flex-col gap-6 rounded-2xl border border-white/5 bg-black/40 p-6 backdrop-blur-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm font-medium text-gray-200">
+              Progress to <span className="text-[#ff950e]">{nextTier}</span>
+            </p>
+            <div className="flex items-center gap-3">
+              <TierBadge tier={nextTier} size="sm" />
+              <span className="text-xs uppercase tracking-wide text-gray-400">Next milestone</span>
+            </div>
           </div>
 
           {/* Sales Progress */}
-          <div>
-            <div className="flex justify-between text-xs text-gray-400 mb-1">
-              <span>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center justify-between text-xs text-gray-400">
+              <span className="font-medium text-gray-300">
                 Sales: {userStats.totalSales}/{nextRequirements.minSales}
               </span>
-              <span>{salesPct.toFixed(0)}%</span>
+              <span className="text-[#ff950e]">{salesPct.toFixed(0)}%</span>
             </div>
-            <div className="w-full bg-gray-800 rounded-full h-2">
+            <div className="h-3 w-full overflow-hidden rounded-full bg-gray-800">
               <div
-                className="bg-gradient-to-r from-[#ff950e] to-[#ff6b00] h-2 rounded-full transition-all duration-500"
+                className="h-full rounded-full bg-gradient-to-r from-[#ff950e] via-[#ff7a0a] to-[#ff6b00] transition-all duration-500"
                 style={{ width: `${salesPct}%` }}
               />
             </div>
           </div>
 
           {/* Revenue Progress */}
-          <div>
-            <div className="flex justify-between text-xs text-gray-400 mb-1">
-              <span>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center justify-between text-xs text-gray-400">
+              <span className="font-medium text-gray-300">
                 Revenue: {formatCurrency(userStats.totalRevenue)}/{formatCurrency(nextRequirements.minAmount)}
               </span>
-              <span>{revenuePct.toFixed(0)}%</span>
+              <span className="text-[#ff950e]">{revenuePct.toFixed(0)}%</span>
             </div>
-            <div className="w-full bg-gray-800 rounded-full h-2">
+            <div className="h-3 w-full overflow-hidden rounded-full bg-gray-800">
               <div
-                className="bg-gradient-to-r from-[#ff950e] to-[#ff6b00] h-2 rounded-full transition-all duration-500"
+                className="h-full rounded-full bg-gradient-to-r from-[#ff950e] via-[#ff7a0a] to-[#ff6b00] transition-all duration-500"
                 style={{ width: `${revenuePct}%` }}
               />
             </div>
           </div>
 
-          <p className="text-xs text-gray-500 text-center mt-3">Reach both milestones to unlock {nextTier} tier</p>
-        </div>
+          <p className="text-center text-xs text-gray-400">
+            Reach both milestones to unlock <span className="text-[#ff950e] font-medium">{nextTier}</span> tier
+          </p>
+        </section>
       )}
 
       {/* Max Tier Reached */}
       {currentTier === 'Goddess' && (
-        <div className="text-center">
-          <div className="bg-gradient-to-r from-[#ff950e] to-[#ff6b00] text-black p-3 rounded-lg">
-            <p className="font-bold">🎉 Maximum Tier Achieved!</p>
-            <p className="text-sm">You've reached the highest seller tier</p>
-          </div>
-        </div>
+        <section className="rounded-2xl border border-[#ff950e]/40 bg-gradient-to-r from-[#ff950e] to-[#ff6b00] p-6 text-center text-black shadow-lg">
+          <p className="text-lg font-bold">🎉 Maximum Tier Achieved!</p>
+          <p className="text-sm font-medium">You've reached the highest seller tier</p>
+        </section>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- expand the seller tier grid to use a wider two-column layout with balanced spacing wrappers
- refresh the Seller Tier Progress card with larger spacing, centered stats, and emphasized progress visualization
- restyle the Seller Tier Overview section with card-like groupings, tier badges, and clearer requirement/benefit panels

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6902cfd230f483288c3870670afa6d73