### PR TITLE
Revamp buyer order cards layout

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -67,8 +67,6 @@ export default function OrderCard({
 
   const typeLabel =
     type === 'auction' ? 'Auction win' : type === 'custom' ? 'Custom request' : 'Direct purchase';
-  const typeChip = typeLabel;
-
   const shortId = useMemo(() => {
     if (displayOrderId) {
       return String(displayOrderId).slice(0, 10);
@@ -118,15 +116,14 @@ export default function OrderCard({
 
   const metaItems = useMemo(() => {
     return [
-      <span key="order-id" className="inline-flex items-center gap-1">
-        <span className="opacity-70">Order ID:</span>
-        <code className="text-neutral-300">{shortId}</code>
+      <span key="order-id" className="font-medium text-neutral-200">
+        #{shortId}
       </span>,
       <span key="placed">Placed {placedDate}</span>,
       <span key="type">{typeLabel}</span>,
       <span
         key="status"
-        className={`inline-flex items-center rounded-md border px-2 py-0.5 ${statusTone}`}
+        className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${statusTone}`}
       >
         {statusLabel}
       </span>,
@@ -148,35 +145,61 @@ export default function OrderCard({
     [metaItems]
   );
 
+  const addressPreview = useMemo(() => {
+    const previewFromOrder = (order as unknown as { deliveryAddressPreview?: string })?.deliveryAddressPreview;
+    if (typeof previewFromOrder === 'string' && previewFromOrder.trim().length > 0) {
+      return previewFromOrder.trim();
+    }
+
+    const pendingAddress = (order as unknown as { pendingDeliveryAddress?: Partial<Order['deliveryAddress']> })
+      ?.pendingDeliveryAddress;
+
+    const addressSource = pendingAddress || order.deliveryAddress;
+    if (!addressSource) {
+      return null;
+    }
+
+    const { fullName, addressLine1, city, state, postalCode, country } = addressSource;
+    const parts = [fullName, addressLine1, [city, state].filter(Boolean).join(', '), postalCode, country]
+      .map((part) => (part ?? '').toString().trim())
+      .filter((part) => part.length > 0);
+
+    if (parts.length === 0) {
+      return null;
+    }
+
+    return parts.slice(0, 3).join(' • ');
+  }, [order]);
+
   return (
     <article
-      className={`rounded-xl bg-[var(--color-card)] border border-neutral-800/80 shadow-lg p-4 hover:border-neutral-700 transition-colors ${styles.borderStyle}`}
+      className={`group rounded-2xl border border-neutral-800/80 bg-[var(--color-card)] p-4 shadow-[0_12px_30px_-16px_rgba(0,0,0,0.8)] transition-colors hover:border-neutral-700 ${styles.borderStyle}`}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-3">
         <div className="flex items-start justify-between gap-3">
-          <h3 className="text-base font-semibold text-white leading-tight truncate">
+          <h3 className="truncate text-sm font-semibold leading-tight text-white sm:text-base">
             <SecureMessageDisplay content={order.title || 'Untitled order'} allowBasicFormatting={false} as="span" />
           </h3>
-          <span className="shrink-0 text-sm font-bold text-[var(--color-primary)]">${totalPaid}</span>
+          <span className="shrink-0 text-sm font-semibold text-[var(--color-primary)] sm:text-base">${totalPaid}</span>
         </div>
 
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-400">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-neutral-400">
           {interleavedMeta}
         </div>
 
-        <span className="mt-2 inline-flex items-center rounded-md border border-neutral-700 px-2 py-0.5 text-[11px] uppercase tracking-wide text-neutral-300">
-          {typeChip}
-        </span>
-
         {thumbnailUrl && (
-          <div className="mt-3 flex items-center gap-3">
-            <img src={thumbnailUrl} alt="" className="h-14 w-14 rounded-lg object-cover border border-neutral-800" />
+          <div className="flex items-start gap-3">
+            <img
+              src={thumbnailUrl}
+              alt=""
+              className="h-16 w-16 shrink-0 rounded-lg border border-neutral-800 object-cover"
+            />
             {subtitle && (
               <SecureMessageDisplay
                 content={subtitle}
                 allowBasicFormatting={false}
                 as="p"
-                className="text-sm text-neutral-300 line-clamp-2"
+                className="text-xs leading-relaxed text-neutral-300 line-clamp-2"
               />
             )}
           </div>
@@ -187,21 +210,39 @@ export default function OrderCard({
             content={subtitle}
             allowBasicFormatting={false}
             as="p"
-            className="mt-3 text-sm text-neutral-300 line-clamp-2"
+            className="text-xs leading-relaxed text-neutral-300 line-clamp-2"
           />
         )}
 
-        <div className="mt-3 flex items-center justify-end gap-2">
-          {showConfirmAddress && (
-            <button
-              className="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)]/90 hover:bg-[var(--color-primary)] px-3 py-1.5 text-sm font-medium text-black"
-              onClick={handleConfirmAddress}
-            >
-              Confirm address
-            </button>
-          )}
+        {showConfirmAddress && (
+          <div className="rounded-xl border border-neutral-800/80 bg-neutral-900/70 p-3">
+            <div className="flex flex-col gap-2 text-xs text-neutral-300">
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-white">Confirm delivery address</p>
+                  <p className="text-xs text-neutral-400">
+                    We&apos;ll share your preferred delivery details with the seller once you confirm.
+                  </p>
+                  {addressPreview && (
+                    <p className="text-xs text-neutral-400">
+                      <span className="text-neutral-200">{addressPreview}</span>
+                    </p>
+                  )}
+                </div>
+                <button
+                  className="shrink-0 rounded-md bg-[var(--color-primary)] px-3 py-1 text-xs font-semibold text-black transition-colors hover:bg-[var(--color-primary)]/90"
+                  onClick={handleConfirmAddress}
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end">
           <button
-            className="inline-flex items-center gap-1 rounded-lg border border-neutral-700 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-900"
+            className="inline-flex items-center gap-1 rounded-md border border-neutral-700 px-3 py-1 text-xs font-medium text-neutral-200 transition-colors hover:border-neutral-600 hover:bg-neutral-900"
             onClick={handleViewDetails}
           >
             View details
@@ -209,7 +250,7 @@ export default function OrderCard({
         </div>
 
         {isExpanded && (
-          <div className="mt-3 rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
+          <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
             <ExpandedOrderContent
               order={order}
               type={type}


### PR DESCRIPTION
## Summary
- condense buyer order cards with a compact header, tighter spacing, and a single meta line
- adjust optional media and description layout for modern minimalist presentation
- embed the confirm delivery address prompt within cards with a small confirm button and maintain view details action

## Testing
- npm run lint *(fails: existing lint issues throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_690473c9ee788328aa37793239144837