### PR TITLE
Add address confirmation button to direct purchase orders

### DIFF
--- a/src/components/buyers/my-orders/OrderCard.tsx
+++ b/src/components/buyers/my-orders/OrderCard.tsx
@@ -63,7 +63,7 @@ export default function OrderCard({
   const fallbackOrder = order as { _id?: string };
   const orderId = order.id || fallbackOrder._id || `order-${Date.now()}`;
   const displayOrderId = order.id || fallbackOrder._id || '';
-  const needsAddress = order.wasAuction && !hasDeliveryAddress;
+  const needsAddress = !hasDeliveryAddress && (order.wasAuction || type === 'direct');
 
   const typeLabel =
     type === 'auction' ? 'Auction win' : type === 'custom' ? 'Custom request' : 'Direct purchase';


### PR DESCRIPTION
## Summary
- show the delivery address confirmation prompt on direct purchase order cards when no address is on file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690476ea22dc83289a91c88350f89173