### PR TITLE
Refine premium seller tips layout

### DIFF
--- a/src/app/sellers/my-listings/page.tsx
+++ b/src/app/sellers/my-listings/page.tsx
@@ -341,11 +341,11 @@ function MyListingsContent() {
                 Premium Seller Tips
               </h2>
               <p className="mt-2 text-sm text-white/70">Elevate your premium catalog with subscriber-only experiences.</p>
-              <ul className="mt-6 space-y-4 text-sm text-white/80">
+              <ul className="mt-6 space-y-4 text-left text-sm text-white/80 sm:max-w-2xl sm:space-y-5 sm:mx-auto">
                 {PREMIUM_TIPS.map((tip, index) => (
                   <li key={index} className="flex items-start gap-3">
-                    <span className="mt-[6px] inline-flex h-2.5 w-8 flex-shrink-0 rounded-full bg-[#ff950e]" />
-                    <span>{tip}</span>
+                    <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#ff950e]" />
+                    <span className="flex-1 leading-relaxed">{tip}</span>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- tighten the Premium Seller Tips list width for improved readability
- adjust bullet sizing and text wrapping so list items stay compact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906d3155a3883288a53eb654a90abbe