### PR TITLE
Stack seller tier cards and improve tier overview layout

### DIFF
--- a/src/app/sellers/profile/page.tsx
+++ b/src/app/sellers/profile/page.tsx
@@ -134,8 +134,8 @@ export default function SellerProfileSettingsPage() {
 
             {/* Tier Progress & Display Section */}
             {sellerTierInfo && (
-              <div className="grid grid-cols-1 gap-10 xl:grid-cols-[1.6fr_1fr]">
-                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur h-full">
+              <div className="flex flex-col gap-10">
+                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur">
                   <TierProgressCard
                     sellerTierInfo={sellerTierInfo}
                     userStats={userStats}
@@ -144,7 +144,7 @@ export default function SellerProfileSettingsPage() {
                     onTierClick={setSelectedTierDetails}
                   />
                 </div>
-                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur h-full">
+                <div className="rounded-3xl border border-white/5 bg-black/40 p-1 backdrop-blur">
                   <TierDisplaySection
                     sellerTierInfo={sellerTierInfo}
                     userStats={userStats}

--- a/src/components/seller-settings/TierDisplaySection.tsx
+++ b/src/components/seller-settings/TierDisplaySection.tsx
@@ -145,7 +145,7 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
         </div>
 
         {/* Tier Badges Row */}
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+        <div className="flex w-full flex-nowrap gap-4 overflow-x-auto pb-2 pr-2 sm:overflow-x-visible sm:pb-0 sm:pr-0">
           {(['Tease', 'Flirt', 'Obsession', 'Desire', 'Goddess'] as TierLevel[]).map((tier) => {
             const isCurrentTier = currentTier === tier;
             const isSelected = selectedTierDetails === tier;
@@ -154,7 +154,7 @@ export default function TierDisplaySection(rawProps: TierDisplaySectionProps) {
               <button
                 key={tier}
                 onClick={() => onTierSelect(isSelected ? null : tier)}
-                className={`group relative flex items-center justify-between gap-3 rounded-2xl border-2 px-4 py-3 text-left transition-all duration-300 ${
+                className={`group relative flex min-w-[220px] flex-shrink-0 items-center justify-between gap-3 rounded-2xl border-2 px-4 py-3 text-left transition-all duration-300 ${
                   isCurrentTier
                     ? 'border-[#ff950e] bg-[#ff950e]/10 shadow-[0_12px_30px_-20px_rgba(255,149,14,0.8)]'
                     : isSelected


### PR DESCRIPTION
## Summary
- stack the Seller Tier Progress and Seller Tier Overview cards vertically so progress appears above the overview on seller pages
- adjust the tier overview row to use a single horizontal line with overflow scrolling to avoid clipping on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906f3bbb0e4832884fa76b5fa06d8f4