### PR TITLE
Redesign admin reports moderation UI

### DIFF
--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -486,83 +486,85 @@ export default function AdminReportsPage() {
 
   return (
     <RequireAuth role="admin">
-      <main className="p-8 max-w-7xl mx-auto">
-        <Suspense fallback={<div className="h-20 bg-gray-800 rounded mb-6 animate-pulse" />}>
-          <ReportsHeader banContextError={banContextError} lastRefresh={lastRefresh} onRefresh={loadReports} />
-        </Suspense>
+      <main className="min-h-screen w-full bg-[#060606] px-4 py-8 text-zinc-100 sm:px-8">
+        <div className="mx-auto w-full max-w-7xl">
+          <Suspense fallback={<div className="mb-6 h-20 rounded-xl border border-zinc-800/80 bg-zinc-900/60 animate-pulse" />}> 
+            <ReportsHeader banContextError={banContextError} lastRefresh={lastRefresh} onRefresh={loadReports} />
+          </Suspense>
 
-        <Suspense fallback={<AdminStatsSkeleton />}>
-          <ReportsStats reportStats={reportStats} />
-        </Suspense>
+          <Suspense fallback={<AdminStatsSkeleton />}>
+            <ReportsStats reportStats={reportStats} />
+          </Suspense>
 
-        <Suspense fallback={<FiltersSkeletons />}>
-          <ReportsFilters
-            searchTerm={searchTerm}
-            setSearchTerm={handleSearchTermChange}
-            filterBy={filterBy}
-            setFilterBy={setFilterBy}
-            severityFilter={severityFilter}
-            setSeverityFilter={setSeverityFilter}
-            categoryFilter={categoryFilter}
-            setCategoryFilter={setCategoryFilter}
-            sortBy={sortBy}
-            setSortBy={setSortBy}
-            sortOrder={sortOrder}
-            setSortOrder={setSortOrder}
-          />
-        </Suspense>
-
-        {isLoadingReports ? (
-          <ReportListSkeleton count={5} />
-        ) : (
-          <Suspense fallback={<ReportListSkeleton count={5} />}>
-            <ReportsList
-              reports={filteredAndSortedReports}
+          <Suspense fallback={<FiltersSkeletons />}>
+            <ReportsFilters
               searchTerm={searchTerm}
-              expandedReports={expandedReports}
-              toggleExpanded={toggleExpanded}
-              onBan={handleBanFromReport}
-              onResolve={handleMarkResolved}
-              onDelete={handleDeleteReport}
-              onUpdateSeverity={updateReportSeverity}
-              onUpdateCategory={updateReportCategory}
-              onUpdateAdminNotes={updateAdminNotes}
-              getUserReportStats={getUserReportStats}
-              banContext={banContext}
-              reportBanInfo={reportBanInfo}
+              setSearchTerm={handleSearchTermChange}
+              filterBy={filterBy}
+              setFilterBy={setFilterBy}
+              severityFilter={severityFilter}
+              setSeverityFilter={setSeverityFilter}
+              categoryFilter={categoryFilter}
+              setCategoryFilter={setCategoryFilter}
+              sortBy={sortBy}
+              setSortBy={setSortBy}
+              sortOrder={sortOrder}
+              setSortOrder={setSortOrder}
             />
           </Suspense>
-        )}
 
-        {showBanModal && (
-          <Suspense fallback={<ModalSkeleton />}>
-            <BanModal
-              isOpen={showBanModal}
-              banForm={banForm}
-              setBanForm={updateBanForm}
-              isProcessing={isProcessingBan}
-              onClose={() => {
-                setShowBanModal(false);
-                resetBanForm();
-              }}
-              onConfirm={handleManualBan}
-            />
-          </Suspense>
-        )}
+          {isLoadingReports ? (
+            <ReportListSkeleton count={5} />
+          ) : (
+            <Suspense fallback={<ReportListSkeleton count={5} />}>
+              <ReportsList
+                reports={filteredAndSortedReports}
+                searchTerm={searchTerm}
+                expandedReports={expandedReports}
+                toggleExpanded={toggleExpanded}
+                onBan={handleBanFromReport}
+                onResolve={handleMarkResolved}
+                onDelete={handleDeleteReport}
+                onUpdateSeverity={updateReportSeverity}
+                onUpdateCategory={updateReportCategory}
+                onUpdateAdminNotes={updateAdminNotes}
+                getUserReportStats={getUserReportStats}
+                banContext={banContext}
+                reportBanInfo={reportBanInfo}
+              />
+            </Suspense>
+          )}
 
-        {showResolveModal && (
-          <Suspense fallback={<ModalSkeleton />}>
-            <ResolveModal
-              isOpen={showResolveModal}
-              report={selectedReport}
-              onClose={() => {
-                setShowResolveModal(false);
-                setSelectedReport(null);
-              }}
-              onConfirm={confirmResolve}
-            />
-          </Suspense>
-        )}
+          {showBanModal && (
+            <Suspense fallback={<ModalSkeleton />}>
+              <BanModal
+                isOpen={showBanModal}
+                banForm={banForm}
+                setBanForm={updateBanForm}
+                isProcessing={isProcessingBan}
+                onClose={() => {
+                  setShowBanModal(false);
+                  resetBanForm();
+                }}
+                onConfirm={handleManualBan}
+              />
+            </Suspense>
+          )}
+
+          {showResolveModal && (
+            <Suspense fallback={<ModalSkeleton />}>
+              <ResolveModal
+                isOpen={showResolveModal}
+                report={selectedReport}
+                onClose={() => {
+                  setShowResolveModal(false);
+                  setSelectedReport(null);
+                }}
+                onConfirm={confirmResolve}
+              />
+            </Suspense>
+          )}
+        </div>
       </main>
     </RequireAuth>
   );

--- a/src/components/admin/reports/ReportCard.tsx
+++ b/src/components/admin/reports/ReportCard.tsx
@@ -41,43 +41,43 @@ export default function ReportCard({
   // Get severity color and icon
   const getSeverityInfo = (severity: ReportCardProps['report']['severity']) => {
     if (!severity) {
-      return { 
-        color: 'text-gray-400 bg-gray-900/20', 
-        icon: Info, 
-        label: 'Unknown' 
+      return {
+        chipClasses: 'border border-zinc-700 bg-transparent text-zinc-400',
+        icon: Info,
+        label: 'Unknown'
       };
     }
-    
+
     switch (severity) {
-      case 'low': 
-        return { 
-          color: 'text-green-400 bg-green-900/20', 
-          icon: Activity, 
-          label: 'Low' 
+      case 'low':
+        return {
+          chipClasses: 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+          icon: Activity,
+          label: 'Low'
         };
-      case 'medium': 
-        return { 
-          color: 'text-yellow-400 bg-yellow-900/20', 
-          icon: AlertCircle, 
-          label: 'Medium' 
+      case 'medium':
+        return {
+          chipClasses: 'border border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
+          icon: AlertCircle,
+          label: 'Medium'
         };
-      case 'high': 
-        return { 
-          color: 'text-orange-400 bg-orange-900/20', 
-          icon: AlertTriangle, 
-          label: 'High' 
+      case 'high':
+        return {
+          chipClasses: 'border border-orange-500/30 bg-orange-500/10 text-orange-300',
+          icon: AlertTriangle,
+          label: 'High'
         };
-      case 'critical': 
-        return { 
-          color: 'text-red-400 bg-red-900/20', 
-          icon: ShieldAlert, 
-          label: 'Critical' 
+      case 'critical':
+        return {
+          chipClasses: 'border border-red-500/40 bg-red-500/10 text-red-300',
+          icon: ShieldAlert,
+          label: 'Critical'
         };
-      default: 
-        return { 
-          color: 'text-gray-400 bg-gray-900/20', 
-          icon: Info, 
-          label: 'Unknown' 
+      default:
+        return {
+          chipClasses: 'border border-zinc-700 bg-transparent text-zinc-400',
+          icon: Info,
+          label: 'Unknown'
         };
     }
   };
@@ -103,142 +103,142 @@ export default function ReportCard({
   };
 
   return (
-    <div 
-      className={`bg-[#1a1a1a] border ${
-        report.severity === 'critical' ? 'border-red-800' : 
-        report.severity === 'high' ? 'border-orange-800' : 
-        'border-gray-800'
-      } rounded-lg overflow-hidden hover:border-gray-700 transition-all`}
-    >
-      {/* Report Header - Clickable */}
-      <div 
-        className="p-6 cursor-pointer"
-        onClick={onToggle}
-      >
-        <div className="flex justify-between items-start">
-          <div className="flex-1">
-            <div className="flex items-center gap-4 mb-2">
-              <div className="flex items-center gap-2">
-                <User size={16} className="text-gray-400" />
-                <span className="font-semibold text-white">
-                  <SecureMessageDisplay 
+    <div className="rounded-2xl border border-zinc-900/70 bg-zinc-950/80 shadow-none">
+      <div className="flex flex-col gap-5 p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="flex flex-1 flex-col gap-3 text-left transition-colors hover:text-white"
+          >
+            <div className="flex flex-wrap items-center gap-3 text-sm text-zinc-300">
+              <span className="inline-flex items-center gap-2 text-base font-semibold text-white">
+                <User size={16} className="text-zinc-500" />
+                <span>
+                  <SecureMessageDisplay
                     content={report.reporter}
                     allowBasicFormatting={false}
                     className="inline"
                   />
                   {' → '}
-                  <SecureMessageDisplay 
+                  <SecureMessageDisplay
                     content={report.reportee}
                     allowBasicFormatting={false}
                     className="inline"
                   />
                 </span>
-              </div>
-              
-              {/* Status Badges */}
+              </span>
+
               {userBanInfo && (
-                <span className="px-2 py-1 bg-red-900/20 text-red-400 text-xs rounded font-medium">
-                  BANNED
+                <span className="inline-flex items-center rounded-full border border-red-500/40 bg-red-500/10 px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-red-300">
+                  Banned
                 </span>
               )}
-              
-              {/* User Report History - Simple Count */}
-              <div className="flex items-center gap-2">
-                <span className="px-2 py-1 bg-purple-900/20 text-purple-400 text-xs rounded font-medium flex items-center gap-1">
-                  <Users size={12} />
-                  {safeStats.totalReports} Total Reports
-                </span>
-                {safeStats.activeReports > 0 && (
-                  <span className="px-2 py-1 bg-red-900/20 text-red-400 text-xs rounded font-medium">
-                    {safeStats.activeReports} Active
-                  </span>
-                )}
-              </div>
-              
+
               {report.processed && (
-                <span className="px-2 py-1 bg-green-900/20 text-green-400 text-xs rounded font-medium">
-                  PROCESSED
+                <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-emerald-300">
+                  Processed
                 </span>
               )}
             </div>
-            
-            <div className="flex items-center gap-4 text-sm text-gray-400">
-              <span>{new Date(report.date).toLocaleString()}</span>
-              <span className={`px-2 py-0.5 rounded text-xs font-medium flex items-center gap-1 ${severityInfo.color}`}>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-zinc-500">
+              <div className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[0.7rem] ${severityInfo.chipClasses}`}>
                 <severityInfo.icon size={12} />
                 {severityInfo.label}
-              </span>
-              <span className="flex items-center gap-1">
+              </div>
+              <span className="inline-flex items-center gap-1 rounded-full border border-zinc-800 px-2.5 py-1 text-[0.7rem] text-zinc-400">
                 <CategoryIcon size={12} />
                 {report.category || 'uncategorized'}
               </span>
+              <span className="inline-flex items-center gap-1 rounded-full border border-zinc-800 px-2.5 py-1 text-[0.7rem] text-zinc-400">
+                <Activity size={12} />
+                {new Date(report.date).toLocaleString()}
+              </span>
             </div>
-          </div>
-          
-          <div className="flex items-center gap-3">
-            {/* Action Buttons - Only when not processed */}
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+              <span className="inline-flex items-center gap-1 rounded-full border border-zinc-800 px-2.5 py-1">
+                <Users size={12} />
+                {safeStats.totalReports} total reports
+              </span>
+              {safeStats.activeReports > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-red-500/40 px-2.5 py-1 text-red-300">
+                  {safeStats.activeReports} active
+                </span>
+              )}
+              {userBanInfo?.reason && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-red-500/40 px-2.5 py-1 text-red-300">
+                  <ShieldAlert size={12} />
+                  {userBanInfo.reason}
+                </span>
+              )}
+            </div>
+          </button>
+
+          <div className="flex flex-col items-stretch gap-3 md:items-end">
             {!report.processed && (
-              <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
-                {/* Custom Ban */}
+              <div className="flex flex-wrap justify-end gap-2">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onBan();
                   }}
-                  className="px-3 py-1 bg-red-700 text-white text-sm rounded hover:bg-red-800 flex items-center transition-colors"
+                  className="inline-flex items-center gap-2 rounded-lg bg-red-600/80 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-600"
                   disabled={!banContext}
                 >
-                  <Ban size={12} className="mr-1" />
-                  Custom Ban
+                  <Ban size={14} />
+                  Ban
                 </button>
-                
-                {/* Resolve without ban */}
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onResolve();
                   }}
-                  className="px-3 py-1 bg-green-600 text-white text-sm rounded hover:bg-green-700 flex items-center transition-colors"
+                  className="inline-flex items-center gap-2 rounded-lg bg-emerald-600/80 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-600"
                 >
-                  <CheckCircle size={12} className="mr-1" />
-                  Resolve (No Ban)
+                  <CheckCircle size={14} />
+                  Resolve
                 </button>
               </div>
             )}
-            
-            {/* Delete */}
+
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete();
               }}
-              className="px-3 py-1 bg-red-800 text-white text-sm rounded hover:bg-red-900 flex items-center transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-700 hover:text-white"
             >
-              <Trash2 size={12} className="mr-1" />
+              <Trash2 size={14} />
               Delete
             </button>
-            
-            {/* Expand/Collapse */}
-            <div className="flex items-center gap-2 text-gray-400">
-              <span className="text-sm">
-                {Array.isArray(report.messages) ? report.messages.length : 0} messages
-              </span>
-              {isExpanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-            </div>
+
+            <button
+              type="button"
+              onClick={onToggle}
+              className="inline-flex items-center justify-end gap-2 text-xs font-medium uppercase tracking-wide text-zinc-500 transition-colors hover:text-white"
+            >
+              <MessageSquare size={14} />
+              {Array.isArray(report.messages) ? report.messages.length : 0} messages
+              {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+            </button>
           </div>
         </div>
-      </div>
 
-      {/* Expanded Content */}
-      {isExpanded && (
-        <ReportDetails
-          report={report}
-          userStats={userStats}
-          onUpdateSeverity={onUpdateSeverity}
-          onUpdateCategory={onUpdateCategory}
-          onUpdateAdminNotes={onUpdateAdminNotes}
-        />
-      )}
+        {isExpanded && (
+          <ReportDetails
+            report={report}
+            userStats={userStats}
+            onUpdateSeverity={onUpdateSeverity}
+            onUpdateCategory={onUpdateCategory}
+            onUpdateAdminNotes={onUpdateAdminNotes}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/admin/reports/ReportDetails.tsx
+++ b/src/components/admin/reports/ReportDetails.tsx
@@ -90,83 +90,82 @@ export default function ReportDetails({
   }, [userStats]);
 
   return (
-    <div className="border-t border-gray-800 p-6 space-y-4 bg-[#0a0a0a]">
-      {/* User Report History - Simple Statistics */}
-      <div className="p-3 bg-purple-900/10 border border-purple-800 rounded-lg">
-        <div className="flex items-center gap-2 text-purple-400 mb-2">
+    <div className="border-t border-zinc-900/80 pt-5 text-sm text-zinc-300">
+      <div className="space-y-5">
+        {/* User Report History - Simple Statistics */}
+      <div className="rounded-2xl border border-zinc-900/80 bg-zinc-950/60 p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-medium text-[#ff950e]">
           <BarChart3 size={16} />
-          <span className="font-medium">Report Summary for {sanitizeStrict(report.reportee)}</span>
+          <span>Report summary for {sanitizeStrict(report.reportee)}</span>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-          <div>
-            <span className="text-gray-400">Total Reports:</span>
-            <span className="text-white ml-2 font-medium">{stats.totalReports}</span>
+        <div className="grid grid-cols-1 gap-4 text-sm text-zinc-300 md:grid-cols-3">
+          <div className="space-y-1">
+            <span className="block text-xs uppercase tracking-wide text-zinc-500">Total Reports</span>
+            <span className="text-base font-semibold text-zinc-100">{stats.totalReports}</span>
           </div>
-          <div>
-            <span className="text-gray-400">Active Reports:</span>
-            <span className="text-red-400 ml-2 font-medium">{stats.activeReports}</span>
+          <div className="space-y-1">
+            <span className="block text-xs uppercase tracking-wide text-zinc-500">Active Reports</span>
+            <span className="text-base font-semibold text-red-300">{stats.activeReports}</span>
           </div>
-          <div>
-            <span className="text-gray-400">Processed Reports:</span>
-            <span className="text-green-400 ml-2 font-medium">{stats.processedReports}</span>
+          <div className="space-y-1">
+            <span className="block text-xs uppercase tracking-wide text-zinc-500">Processed Reports</span>
+            <span className="text-base font-semibold text-emerald-300">{stats.processedReports}</span>
           </div>
         </div>
 
         {userStats.isBanned && (
-          <div className="mt-3 p-2 bg-red-900/20 border border-red-800 rounded">
-            <div className="text-red-400 text-sm font-medium">Currently Banned</div>
-            <div className="text-gray-300 text-xs">
-              {remainingText}
-            </div>
+          <div className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+            <div className="font-medium">Currently banned</div>
+            <div className="text-xs text-red-200 opacity-80">{remainingText}</div>
           </div>
         )}
       </div>
 
       {/* Messages */}
       <div>
-        <div className="text-sm text-gray-400 mb-2 flex items-center gap-1">
+        <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
           <MessageSquare size={14} />
           Conversation ({report.messages?.length || 0} messages)
         </div>
-        <div className="bg-[#111] rounded-lg max-h-64 overflow-y-auto p-3 space-y-2">
+        <div className="max-h-64 space-y-2 overflow-y-auto rounded-2xl border border-zinc-900/80 bg-zinc-950/40 p-3">
           {report.messages && report.messages.length > 0 ? (
             report.messages.map((msg, idx) => (
               <div
                 key={`${msg.sender}-${msg.date}-${idx}`}
-                className={`p-2 rounded text-sm ${
+                className={`rounded-xl border px-3 py-2 text-sm ${
                   msg.sender === report.reporter
-                    ? 'bg-blue-900/20 text-blue-300'
-                    : 'bg-gray-800 text-gray-300'
+                    ? 'border-[#ff950e]/40 bg-[#ff950e]/10 text-[#ffb347]'
+                    : 'border-zinc-800 bg-zinc-900/60 text-zinc-100'
                 }`}
               >
-                <div className="font-semibold">{sanitizeStrict(msg.sender)}</div>
-                <div className="text-xs text-gray-500">
-                  {new Date(msg.date).toLocaleString()}
+                <div className="flex items-center justify-between text-xs text-zinc-400">
+                  <span className="font-medium text-zinc-200">{sanitizeStrict(msg.sender)}</span>
+                  <span>{new Date(msg.date).toLocaleString()}</span>
                 </div>
                 <SecureMessageDisplay
                   content={msg.content}
-                  className="mt-1"
+                  className="mt-2 text-sm"
                   allowBasicFormatting={false}
                   maxLength={500}
                 />
               </div>
             ))
           ) : (
-            <div className="text-gray-500 text-center py-4">No messages available</div>
+            <div className="py-6 text-center text-sm text-zinc-500">No messages available</div>
           )}
         </div>
       </div>
 
       {/* Severity and Category Controls */}
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div>
-          <label htmlFor="severity-select" className="block text-sm font-medium text-gray-300 mb-1">Severity</label>
+          <label htmlFor="severity-select" className="mb-2 block text-xs font-medium uppercase tracking-wide text-zinc-500">Severity</label>
           <select
             id="severity-select"
             aria-label="Set report severity"
             value={SEVERITIES.includes((report.severity as any)) ? report.severity : 'medium'}
             onChange={(e) => handleSeverityChange(e.target.value)}
-            className="w-full px-3 py-2 bg-[#222] border border-gray-700 rounded text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="w-full rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
           >
             {SEVERITIES.map(s => (
               <option key={s} value={s}>{s[0].toUpperCase() + s.slice(1)}</option>
@@ -175,13 +174,13 @@ export default function ReportDetails({
         </div>
 
         <div>
-          <label htmlFor="category-select" className="block text-sm font-medium text-gray-300 mb-1">Category</label>
+          <label htmlFor="category-select" className="mb-2 block text-xs font-medium uppercase tracking-wide text-zinc-500">Category</label>
           <select
             id="category-select"
             aria-label="Set report category"
             value={CATEGORIES.includes((report.category as any)) ? report.category : 'other'}
             onChange={(e) => handleCategoryChange(e.target.value)}
-            className="w-full px-3 py-2 bg-[#222] border border-gray-700 rounded text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="w-full rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
           >
             {CATEGORIES.map(c => (
               <option key={c} value={c}>
@@ -194,10 +193,10 @@ export default function ReportDetails({
 
       {/* Admin Notes */}
       <div>
-        <div className="flex items-center gap-2 mb-2">
-          <FileText size={14} className="text-gray-400" />
-          <span className="text-sm font-medium text-gray-300">Admin Notes</span>
-          <span className="text-xs text-gray-500">(Auto-saves)</span>
+        <div className="mb-2 flex items-center gap-2 text-sm text-zinc-300">
+          <FileText size={14} className="text-zinc-500" />
+          <span className="font-medium">Admin Notes</span>
+          <span className="text-xs text-zinc-500">(Auto-saves)</span>
         </div>
         <SecureTextarea
           value={adminNotes}
@@ -214,20 +213,21 @@ export default function ReportDetails({
 
       {/* Processed Info */}
       {report.processed && (
-        <div className="p-3 bg-gray-900 border border-gray-700 rounded-lg text-sm">
-          <div className="text-gray-400">
-            Processed by: <span className="text-white">{sanitizeStrict(report.processedBy || 'Unknown')}</span>
+        <div className="rounded-2xl border border-zinc-900/80 bg-zinc-950/60 p-4 text-sm text-zinc-300">
+          <div>
+            Processed by: <span className="font-medium text-zinc-100">{sanitizeStrict(report.processedBy || 'Unknown')}</span>
           </div>
           {report.processedAt && (
-            <div className="text-gray-400">
-              Processed at: <span className="text-white">{new Date(report.processedAt).toLocaleString()}</span>
+            <div className="mt-1">
+              Processed at: <span className="font-medium text-zinc-100">{new Date(report.processedAt).toLocaleString()}</span>
             </div>
           )}
           {report.banApplied && (
-            <div className="text-red-400 mt-1">Ban was applied</div>
+            <div className="mt-2 text-red-300">Ban was applied</div>
           )}
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/admin/reports/ReportsFilters.tsx
+++ b/src/components/admin/reports/ReportsFilters.tsx
@@ -77,17 +77,17 @@ export default function ReportsFilters({
   }, [setSortOrder, sortOrder]);
 
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 mb-6">
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-5 gap-4">
+    <div className="mb-8 rounded-2xl border border-zinc-800/80 bg-zinc-950/70 p-5">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
         {/* Search */}
         <div className="relative xl:col-span-2">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 z-10" size={16} aria-hidden />
+          <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" size={16} aria-hidden />
           <SecureInput
             type="text"
             placeholder="Search by username or notes..."
             value={searchTerm}
             onChange={setSearchTerm}
-            className="w-full pl-10 pr-4 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] transition-all"
+            className="w-full rounded-lg border border-zinc-800 bg-zinc-900/80 py-2 pl-9 pr-4 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
             maxLength={100}
             aria-label="Search reports"
           />
@@ -97,7 +97,7 @@ export default function ReportsFilters({
         <select
           value={(FILTER_STATES as readonly string[]).includes(filterBy as any) ? filterBy : 'all'}
           onChange={(e) => onFilterChange(e.target.value)}
-          className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+          className="h-full w-full rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
           aria-label="Filter by status"
         >
           <option value="all">All Reports</option>
@@ -109,7 +109,7 @@ export default function ReportsFilters({
         <select
           value={(SEVERITIES as readonly string[]).includes(severityFilter as any) ? severityFilter : 'all'}
           onChange={(e) => onSeverityChange(e.target.value)}
-          className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+          className="h-full w-full rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
           aria-label="Filter by severity"
         >
           <option value="all">All Severities</option>
@@ -123,7 +123,7 @@ export default function ReportsFilters({
         <select
           value={(CATEGORIES as readonly string[]).includes(categoryFilter as any) ? categoryFilter : 'all'}
           onChange={(e) => onCategoryChange(e.target.value)}
-          className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+          className="h-full w-full rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
           aria-label="Filter by category"
         >
           <option value="all">All Categories</option>
@@ -136,26 +136,29 @@ export default function ReportsFilters({
       </div>
 
       {/* Sort Controls */}
-      <div className="flex items-center gap-3 mt-4">
-        <span className="text-sm text-gray-400">Sort by:</span>
-        <select
-          value={(SORT_BY as readonly string[]).includes(sortBy as any) ? sortBy : 'date'}
-          onChange={(e) => onSortByChange(e.target.value)}
-          className="px-3 py-1.5 bg-[#222] border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
-          aria-label="Sort reports by"
-        >
-          <option value="date">Date</option>
-          <option value="severity">Severity</option>
-          <option value="reporter">Reporter</option>
-        </select>
-        <button
-          type="button"
-          onClick={toggleSortOrder}
-          className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white hover:bg-[#333] transition-colors"
-          aria-label={`Change sort order (currently ${sortOrder})`}
-        >
-          {sortOrder === 'asc' ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-        </button>
+      <div className="mt-5 flex flex-col gap-3 border-t border-zinc-900 pt-4 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+        <span className="font-medium text-zinc-300">Sort</span>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={(SORT_BY as readonly string[]).includes(sortBy as any) ? sortBy : 'date'}
+            onChange={(e) => onSortByChange(e.target.value)}
+            className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-2 focus:ring-[#ff950e]/40"
+            aria-label="Sort reports by"
+          >
+            <option value="date">Date</option>
+            <option value="severity">Severity</option>
+            <option value="reporter">Reporter</option>
+          </select>
+          <button
+            type="button"
+            onClick={toggleSortOrder}
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-200 transition-colors hover:border-zinc-700 hover:text-white"
+            aria-label={`Change sort order (currently ${sortOrder})`}
+          >
+            {sortOrder === 'asc' ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+            <span className="hidden sm:inline">{sortOrder === 'asc' ? 'Ascending' : 'Descending'}</span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/reports/ReportsHeader.tsx
+++ b/src/components/admin/reports/ReportsHeader.tsx
@@ -9,18 +9,20 @@ export default function ReportsHeader({ banContextError, lastRefresh, onRefresh 
   const last = lastRefresh instanceof Date ? lastRefresh : new Date();
 
   return (
-    <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6">
-      <div>
-        <h1 className="text-3xl font-bold text-[#ff950e] flex items-center">
-          <Shield className="mr-3" />
+    <div className="mb-8 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="space-y-2">
+        <h1 className="flex items-center gap-3 text-3xl font-semibold text-white">
+          <span className="rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 p-1.5 text-[#ff950e]">
+            <Shield size={24} />
+          </span>
           Reports & Moderation
         </h1>
-        <p className="text-gray-400 mt-1">
+        <p className="max-w-2xl text-sm text-zinc-400">
           Review user reports and make manual ban decisions
         </p>
         {banContextError && (
-          <p className="text-red-400 text-sm mt-2 flex items-center">
-            <AlertTriangle size={14} className="mr-1" />
+          <p className="flex items-start gap-2 text-sm text-red-400">
+            <AlertTriangle size={16} className="mt-0.5" />
             <SecureMessageDisplay
               content={banContextError}
               allowBasicFormatting={false}
@@ -30,17 +32,15 @@ export default function ReportsHeader({ banContextError, lastRefresh, onRefresh 
         )}
       </div>
 
-      <div className="flex items-center gap-4">
-        <div className="text-sm text-gray-400">
-          Last refresh: {last.toLocaleTimeString()}
-        </div>
+      <div className="flex w-full flex-col items-start gap-3 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-end">
+        <span>Last refresh: {last.toLocaleTimeString()}</span>
         <button
           type="button"
           onClick={onRefresh}
-          className="px-4 py-2 bg-[#ff950e] text-black rounded-lg hover:bg-[#e88800] flex items-center font-medium transition-colors"
+          className="inline-flex items-center gap-2 rounded-lg border border-[#ff950e]/60 bg-[#ff950e] px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-[#e88800]"
           aria-label="Refresh reports"
         >
-          <RefreshCw size={16} className="mr-2" />
+          <RefreshCw size={16} />
           Refresh
         </button>
       </div>

--- a/src/components/admin/reports/ReportsList.tsx
+++ b/src/components/admin/reports/ReportsList.tsx
@@ -27,11 +27,11 @@ export default function ReportsList({
 
   if (safeReports.length === 0) {
     return (
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-8 text-center">
-        <AlertTriangle size={48} className="mx-auto text-gray-600 mb-4" />
-        <p className="text-gray-400 text-lg">No reports found</p>
+      <div className="rounded-2xl border border-zinc-800/80 bg-zinc-950/70 p-10 text-center">
+        <AlertTriangle size={40} className="mx-auto mb-4 text-zinc-600" />
+        <p className="text-base font-medium text-zinc-300">No reports found</p>
         {searchTerm && (
-          <p className="text-gray-500 text-sm mt-2">
+          <p className="mt-2 text-sm text-zinc-500">
             Try adjusting your search terms or filters
           </p>
         )}
@@ -40,7 +40,7 @@ export default function ReportsList({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {safeReports.map((report, index) => {
         // Validate report structure
         if (!report || typeof report.id !== 'string' || !report.id || typeof report.reportee !== 'string' || !report.reportee) {

--- a/src/components/admin/reports/ReportsStats.tsx
+++ b/src/components/admin/reports/ReportsStats.tsx
@@ -19,32 +19,26 @@ export default function ReportsStats({ reportStats }: ReportsStatsProps) {
     withBans: safeNumber(reportStats?.withBans),
   };
 
+  const cards: Array<{ label: string; value: number; className?: string }> = [
+    { label: 'Total Reports', value: totals.total },
+    { label: 'Pending', value: totals.unprocessed, className: 'text-[#ff950e]' },
+    { label: 'Critical', value: totals.critical, className: 'text-red-400' },
+    { label: 'Today', value: totals.today, className: 'text-zinc-200' },
+    { label: 'Processed', value: totals.processed, className: 'text-emerald-400' },
+    { label: 'Resulted in Bans', value: totals.withBans, className: 'text-rose-400' }
+  ];
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 mb-6">
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-white">{totals.total}</div>
-        <div className="text-xs text-gray-400">Total Reports</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-yellow-400">{totals.unprocessed}</div>
-        <div className="text-xs text-gray-400">Pending</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-red-400">{totals.critical}</div>
-        <div className="text-xs text-gray-400">Critical</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-blue-400">{totals.today}</div>
-        <div className="text-xs text-gray-400">Today</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-green-400">{totals.processed}</div>
-        <div className="text-xs text-gray-400">Processed</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-purple-400">{totals.withBans}</div>
-        <div className="text-xs text-gray-400">Resulted in Bans</div>
-      </div>
+    <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+      {cards.map(({ label, value, className }) => (
+        <div
+          key={label}
+          className="rounded-xl border border-zinc-800/80 bg-zinc-950/80 px-4 py-3 text-left shadow-none"
+        >
+          <div className={`text-2xl font-semibold tracking-tight text-white ${className ?? ''}`.trim()}>{value}</div>
+          <div className="mt-1 text-xs font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the admin reports dashboard container with a flat dark backdrop and refreshed header layout
- simplify report statistics, filters, and empty state styling to match the PantyPost dark/orange palette
- modernize report rows and details with minimal cards, compact actions, and consistent on-brand accents

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_69094d7de1708328bbafc966103d46e2