### PR TITLE
Add accent colours to admin report statistics

### DIFF
--- a/src/components/admin/reports/ReportsStats.tsx
+++ b/src/components/admin/reports/ReportsStats.tsx
@@ -19,24 +19,78 @@ export default function ReportsStats({ reportStats }: ReportsStatsProps) {
     withBans: safeNumber(reportStats?.withBans),
   };
 
-  const cards: Array<{ label: string; value: number; className?: string }> = [
-    { label: 'Total Reports', value: totals.total },
-    { label: 'Pending', value: totals.unprocessed, className: 'text-[#ff950e]' },
-    { label: 'Critical', value: totals.critical, className: 'text-red-400' },
-    { label: 'Today', value: totals.today, className: 'text-zinc-200' },
-    { label: 'Processed', value: totals.processed, className: 'text-emerald-400' },
-    { label: 'Resulted in Bans', value: totals.withBans, className: 'text-rose-400' }
+  const cards: Array<{
+    label: string;
+    value: number;
+    valueClass?: string;
+    labelClass?: string;
+    borderClass?: string;
+  }> = [
+    {
+      label: 'Total Reports',
+      value: totals.total,
+      valueClass: 'text-slate-100',
+      labelClass: 'text-zinc-400',
+      borderClass: 'border-zinc-800/80 hover:border-zinc-700',
+    },
+    {
+      label: 'Pending',
+      value: totals.unprocessed,
+      valueClass: 'text-[#ff950e]',
+      labelClass: 'text-[#ff950e]/80',
+      borderClass: 'border-[#ff950e]/30 hover:border-[#ff950e]/60',
+    },
+    {
+      label: 'Critical',
+      value: totals.critical,
+      valueClass: 'text-red-400',
+      labelClass: 'text-red-300/80',
+      borderClass: 'border-red-500/30 hover:border-red-400/60',
+    },
+    {
+      label: 'Today',
+      value: totals.today,
+      valueClass: 'text-indigo-400',
+      labelClass: 'text-indigo-300/80',
+      borderClass: 'border-indigo-500/30 hover:border-indigo-400/60',
+    },
+    {
+      label: 'Processed',
+      value: totals.processed,
+      valueClass: 'text-emerald-400',
+      labelClass: 'text-emerald-300/80',
+      borderClass: 'border-emerald-500/30 hover:border-emerald-400/60',
+    },
+    {
+      label: 'Resulted in Bans',
+      value: totals.withBans,
+      valueClass: 'text-rose-400',
+      labelClass: 'text-rose-300/80',
+      borderClass: 'border-rose-500/30 hover:border-rose-400/60',
+    },
   ];
 
   return (
     <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
-      {cards.map(({ label, value, className }) => (
+      {cards.map(({ label, value, valueClass, labelClass, borderClass }) => (
         <div
           key={label}
-          className="rounded-xl border border-zinc-800/80 bg-zinc-950/80 px-4 py-3 text-left shadow-none"
+          className={`rounded-xl border bg-zinc-950/80 px-4 py-3 text-left shadow-none transition-colors ${
+            borderClass ?? 'border-zinc-800/80 hover:border-zinc-700'
+          }`}
         >
-          <div className={`text-2xl font-semibold tracking-tight text-white ${className ?? ''}`.trim()}>{value}</div>
-          <div className="mt-1 text-xs font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+          <div
+            className={`text-2xl font-semibold tracking-tight ${valueClass ?? 'text-white'}`}
+          >
+            {value}
+          </div>
+          <div
+            className={`mt-1 text-xs font-medium uppercase tracking-wide ${
+              labelClass ?? 'text-zinc-500'
+            }`}
+          >
+            {label}
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add semantic accent colours to each reports statistics card while keeping the new minimal layout
- tint labels and borders with subtle hues for improved legibility on the dark background
- add gentle hover transitions to reinforce the flat, modern treatment without introducing shadows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690951b070dc8328a45315237b8fa315