### PR TITLE
refactor: restyle admin ban management UI

### DIFF
--- a/src/app/admin/bans/page.tsx
+++ b/src/app/admin/bans/page.tsx
@@ -301,20 +301,22 @@ export default function BanManagementPage() {
   return (
     <RequireAuth role="admin">
       <div className="min-h-screen bg-black text-white">
-        <main className="p-8 max-w-7xl mx-auto">
-          <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6">
-            <div>
-              <h1 className="text-3xl font-bold text-[#ff950e] flex items-center">
-                <Shield className="mr-3" />
+        <main className="mx-auto max-w-7xl px-6 py-8 sm:px-8">
+          <div className="mb-8 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <h1 className="flex items-center gap-3 text-3xl font-semibold text-white">
+                <span className="rounded-full border border-[#ff950e]/30 bg-[#ff950e]/10 p-1.5 text-[#ff950e]">
+                  <Shield size={24} />
+                </span>
                 Ban Management
               </h1>
-              <p className="text-gray-400 mt-1">Manage user bans and appeals</p>
+              <p className="text-sm text-zinc-400">Manage user bans and appeals</p>
             </div>
 
-            <div className="flex gap-3 flex-wrap">
+            <div className="flex w-full flex-col items-start gap-3 text-sm sm:flex-row sm:items-center sm:justify-end">
               <button
                 onClick={exportBanData}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2 transition-colors"
+                className="inline-flex items-center gap-2 rounded-lg border border-blue-500/50 bg-blue-500 px-4 py-2 font-medium text-black transition-colors hover:bg-blue-400"
               >
                 <Download size={16} />
                 Export Data
@@ -322,7 +324,7 @@ export default function BanManagementPage() {
               <button
                 onClick={handleRefresh}
                 disabled={isRefreshing}
-                className="px-4 py-2 bg-[#ff950e] text-black rounded-lg hover:bg-[#e88800] flex items-center gap-2 transition-colors disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-lg border border-[#ff950e]/60 bg-[#ff950e] px-4 py-2 font-medium text-black transition-colors hover:bg-[#e88800] disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <RefreshCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
                 Refresh

--- a/src/components/admin/bans/ActiveBansContent.tsx
+++ b/src/components/admin/bans/ActiveBansContent.tsx
@@ -112,18 +112,20 @@ export default function ActiveBansContent({
       : `${validatedTotalCount}`;
 
   return (
-    <div className="space-y-4">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-semibold text-white">Active Bans ({headerCount})</h2>
-        {validatedTotalCount > 0 && <p className="text-sm text-gray-400">Click on a ban to expand details</p>}
+    <div className="space-y-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-2xl font-semibold text-white">Active Bans ({headerCount})</h2>
+        {validatedTotalCount > 0 && (
+          <p className="text-sm text-zinc-500">Click on a ban to expand details</p>
+        )}
       </div>
 
       {filteredBans.length === 0 ? (
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-8 text-center">
-          <UserCheck size={48} className="mx-auto text-gray-600 mb-4" />
-          <p className="text-gray-400 text-lg">No active bans found</p>
+        <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-8 text-center">
+          <UserCheck size={48} className="mx-auto mb-4 text-zinc-600" />
+          <p className="text-lg text-zinc-300">No active bans found</p>
           {filters.searchTerm && (
-            <p className="text-gray-500 text-sm mt-2">
+            <p className="mt-2 text-sm text-zinc-500">
               <SecureMessageDisplay content={`Try adjusting your search terms or filters`} allowBasicFormatting={false} />
             </p>
           )}

--- a/src/components/admin/bans/AnalyticsContent.tsx
+++ b/src/components/admin/bans/AnalyticsContent.tsx
@@ -94,14 +94,14 @@ export default function AnalyticsContent({ banStats }: AnalyticsContentProps) {
       <h2 className="text-xl font-semibold text-white mb-4">Ban Analytics</h2>
 
       {/* Ban Reasons Chart */}
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-          <BarChart3 size={20} className="text-blue-400" />
+      <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-6">
+        <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
+          <BarChart3 size={20} className="text-indigo-400" />
           Ban Reasons Distribution
         </h3>
         <div className="space-y-3">
           {Object.keys(sanitizedBansByReason).length === 0 ? (
-            <p className="text-gray-400 text-center py-4">No ban data available</p>
+            <p className="py-4 text-center text-sm text-zinc-500">No ban data available</p>
           ) : (
             Object.entries(sanitizedBansByReason)
               .sort(([, a], [, b]) => b - a) // Sort by count desc
@@ -109,20 +109,20 @@ export default function AnalyticsContent({ banStats }: AnalyticsContentProps) {
                 const percentage = calculatePercentage(count, total);
                 return (
                   <div key={reason}>
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="text-sm text-gray-300">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-sm text-zinc-200">
                         <SecureMessageDisplay
                           content={formatReasonForDisplay(reason)}
                           allowBasicFormatting={false}
                         />
                       </span>
-                      <span className="text-sm text-gray-400">
+                      <span className="text-sm text-zinc-400">
                         {count.toLocaleString()} ({percentage.toFixed(1)}%)
                       </span>
                     </div>
-                    <div className="w-full bg-gray-700 rounded-full h-2 overflow-hidden">
+                    <div className="h-2 w-full overflow-hidden rounded-full border border-zinc-800 bg-zinc-900">
                       <div
-                        className="bg-[#ff950e] h-2 rounded-full transition-all duration-500"
+                        className="h-2 rounded-full bg-[#ff950e] transition-all duration-500"
                         style={{ width: `${percentage}%` }}
                         role="progressbar"
                         aria-valuenow={Number.isFinite(percentage) ? Math.round(percentage) : 0}
@@ -138,35 +138,35 @@ export default function AnalyticsContent({ banStats }: AnalyticsContentProps) {
       </div>
 
       {/* Appeal Statistics */}
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+      <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-6">
+        <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-white">
           <MessageSquare size={20} className="text-orange-400" />
           Appeal Processing
         </h3>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div className="text-center">
-            <div className="text-2xl font-bold text-blue-400">
+            <div className="text-2xl font-semibold text-indigo-300">
               {sanitizedAppealStats.totalAppeals.toLocaleString()}
             </div>
-            <div className="text-xs text-gray-400">Total Appeals</div>
+            <div className="text-xs text-zinc-500">Total Appeals</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-yellow-400">
+            <div className="text-2xl font-semibold text-amber-300">
               {sanitizedAppealStats.pendingAppeals.toLocaleString()}
             </div>
-            <div className="text-xs text-gray-400">Pending</div>
+            <div className="text-xs text-zinc-500">Pending</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-green-400">
+            <div className="text-2xl font-semibold text-emerald-300">
               {sanitizedAppealStats.approvedAppeals.toLocaleString()}
             </div>
-            <div className="text-xs text-gray-400">Approved</div>
+            <div className="text-xs text-zinc-500">Approved</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-red-400">
+            <div className="text-2xl font-semibold text-rose-300">
               {sanitizedAppealStats.rejectedAppeals.toLocaleString()}
             </div>
-            <div className="text-xs text-gray-400">Rejected</div>
+            <div className="text-xs text-zinc-500">Rejected</div>
           </div>
         </div>
       </div>

--- a/src/components/admin/bans/AppealsContent.tsx
+++ b/src/components/admin/bans/AppealsContent.tsx
@@ -12,38 +12,47 @@ interface AppealsContentProps {
   onShowEvidence: (evidence: string[]) => void;
 }
 
+const severeReasonKeywords = [
+  'harassment',
+  'abuse',
+  'scam',
+  'scamming',
+  'fraud',
+  'payment_fraud',
+  'extortion',
+  'threat',
+  'dox',
+  'hate',
+];
+
 const formatRemainingTime = (ban: BanEntry) => {
   if (!ban || typeof ban !== 'object') return 'Unknown';
 
   if (ban.banType === 'permanent') {
     return (
-      <span className="flex items-center gap-1">
+      <span className="flex items-center gap-1 text-rose-400">
         <InfinityIcon size={14} /> Permanent
       </span>
     );
   }
 
   if (!ban.remainingHours || ban.remainingHours <= 0) {
-    return <span className="text-gray-500">Expired</span>;
+    return <span className="text-zinc-500">Expired</span>;
   }
 
   const hours = Number(ban.remainingHours);
   if (hours < 1) {
     const minutes = Math.ceil(hours * 60);
-    return <span className="text-yellow-400">{minutes}m remaining</span>;
+    return <span className="text-amber-300">{minutes}m remaining</span>;
   }
 
   if (hours < 24) {
-    return <span className="text-orange-400">{Math.ceil(hours)}h remaining</span>;
+    return <span className="text-amber-400">{Math.ceil(hours)}h remaining</span>;
   }
 
   const days = Math.floor(hours / 24);
   const remainingHours = Math.ceil(hours % 24);
-  return (
-    <span className="text-red-400">
-      {days}d {remainingHours}h remaining
-    </span>
-  );
+  return <span className="text-orange-400">{days}d {remainingHours}h remaining</span>;
 };
 
 export default function AppealsContent({
@@ -52,16 +61,14 @@ export default function AppealsContent({
   onShowEvidence,
 }: AppealsContentProps) {
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-semibold text-white mb-4">
-        Pending Appeals ({pendingAppeals.length})
-      </h2>
+    <div className="space-y-5">
+      <h2 className="text-2xl font-semibold text-white">Pending Appeals ({pendingAppeals.length})</h2>
 
       {pendingAppeals.length === 0 ? (
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-8 text-center">
-          <MessageSquare size={48} className="mx-auto text-gray-600 mb-4" />
-          <p className="text-gray-400 text-lg">No pending appeals</p>
-          <p className="text-gray-500 text-sm mt-2">
+        <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-8 text-center">
+          <MessageSquare size={48} className="mx-auto mb-4 text-zinc-600" />
+          <p className="text-lg text-zinc-300">No pending appeals</p>
+          <p className="mt-2 text-sm text-zinc-500">
             All appeals have been processed or no appeals have been submitted
           </p>
         </div>
@@ -76,36 +83,48 @@ export default function AppealsContent({
                 ? ban.appealEvidence.filter((x): x is string => typeof x === 'string')
                 : [];
               const hasEvidence = evidenceList.length > 0;
+              const normalizedReason = String(ban.reason || '').toLowerCase();
+              const normalizedCustomReason = String(ban.customReason || '').toLowerCase();
+              const reasonHighlight = severeReasonKeywords.some((keyword) =>
+                normalizedReason.includes(keyword) || normalizedCustomReason.includes(keyword)
+              );
+              const banTypeChipClass =
+                ban.banType === 'permanent'
+                  ? 'border border-rose-500/40 bg-rose-500/10 text-rose-300'
+                  : 'border border-amber-500/40 bg-amber-500/10 text-amber-300';
 
               return (
-                <div key={ban.id} className="bg-[#1a1a1a] border border-orange-800 rounded-lg p-6">
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-3">
+                <div key={ban.id} className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-6">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div className="flex-1 space-y-3">
+                      <div className="flex flex-wrap items-center gap-3">
                         <h3 className="text-lg font-semibold text-white">
                           <SecureMessageDisplay content={ban.username} allowBasicFormatting={false} />
                         </h3>
-                        <span className="px-2 py-1 bg-orange-900/20 text-orange-400 text-xs rounded font-medium">
+                        <span className="inline-flex items-center rounded-full border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium uppercase text-indigo-300">
                           Appeal {ban.appealStatus || 'Pending'}
+                        </span>
+                        <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium uppercase ${banTypeChipClass}`}>
+                          {ban.banType}
                         </span>
                       </div>
 
-                      <div className="bg-orange-900/10 border border-orange-800 rounded-lg p-4 mb-3">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="text-sm text-orange-400 font-medium">Appeal Message:</div>
+                      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+                        <div className="mb-2 flex flex-col gap-2 text-sm text-indigo-300 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="font-medium uppercase tracking-wide">Appeal Message</div>
 
                           {hasEvidence && (
                             <button
                               onClick={() => onShowEvidence(evidenceList)}
-                              className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 transition-colors"
+                              className="inline-flex items-center gap-2 text-xs font-medium text-indigo-300 transition-colors hover:text-indigo-200"
                             >
-                              <span className="w-3 h-3 bg-blue-400 rounded" />
+                              <span className="h-2 w-2 rounded-full bg-indigo-300" />
                               {evidenceList.length} Evidence File{evidenceList.length !== 1 ? 's' : ''}
                             </button>
                           )}
                         </div>
 
-                        <div className="text-sm text-gray-300 mb-2">
+                        <div className="text-sm text-zinc-200">
                           <SecureMessageDisplay
                             content={ban.appealText || 'No appeal text provided'}
                             allowBasicFormatting={false}
@@ -113,32 +132,33 @@ export default function AppealsContent({
                           />
                         </div>
 
-                        <div className="text-xs text-gray-500">
+                        <div className="text-xs text-zinc-500">
                           Submitted:{' '}
                           {ban.appealDate ? new Date(ban.appealDate).toLocaleString() : 'Unknown'}
                         </div>
                       </div>
 
-                      <div className="text-sm text-gray-400 mb-2">
-                        <span>Original ban reason: </span>
-                        <span className="text-gray-300">{getBanReasonDisplay(ban.reason, ban.customReason)}</span>
+                      <div className="text-sm text-zinc-400">
+                        <span className="font-medium text-zinc-500">Original Ban Reason</span>
+                        <span className={`ml-2 ${reasonHighlight ? 'text-rose-400' : 'text-zinc-200'}`}>
+                          {getBanReasonDisplay(ban.reason, ban.customReason)}
+                        </span>
                       </div>
 
-                      <div className="text-sm text-gray-400">
-                        <span>Ban type: </span>
-                        <span className="text-gray-300">
-                          {ban.banType} (
-                          {ban.banType === 'permanent' ? 'Permanent' : formatRemainingTime(ban)})
+                      <div className="text-sm text-zinc-400">
+                        <span className="font-medium text-zinc-500">Duration</span>
+                        <span className="ml-2 text-zinc-200">
+                          {ban.banType === 'permanent' ? 'Permanent' : formatRemainingTime(ban)}
                         </span>
                       </div>
                     </div>
 
-                    <div className="flex flex-col gap-2 ml-4">
+                    <div className="flex w-full flex-col gap-2 text-xs font-medium md:w-auto md:items-end">
                       <button
                         onClick={() => onReviewAppeal(ban)}
-                        className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 flex items-center transition-colors"
+                        className="inline-flex items-center gap-2 rounded-md border border-indigo-500/40 bg-zinc-900 px-4 py-2 text-indigo-300 transition-all duration-150 hover:bg-zinc-800"
                       >
-                        <MessageSquare size={12} className="mr-1" />
+                        <MessageSquare size={14} />
                         Review Appeal
                       </button>
                     </div>

--- a/src/components/admin/bans/BanCard.tsx
+++ b/src/components/admin/bans/BanCard.tsx
@@ -20,29 +20,29 @@ const formatRemainingTime = (ban: BanEntry) => {
 
   if (ban.banType === 'permanent') {
     return (
-      <span className="flex items-center gap-1 text-red-400">
+      <span className="flex items-center gap-1 text-rose-400">
         <InfinityIcon size={14} /> Permanent
       </span>
     );
   }
 
   if (!ban.remainingHours || ban.remainingHours <= 0) {
-    return <span className="text-gray-500">Expired</span>;
+    return <span className="text-zinc-500">Expired</span>;
   }
 
   const hours = Number(ban.remainingHours);
   if (hours < 1) {
     const minutes = Math.ceil(hours * 60);
-    return <span className="text-yellow-400">{minutes}m remaining</span>;
+    return <span className="text-amber-300">{minutes}m remaining</span>;
   }
 
   if (hours < 24) {
-    return <span className="text-orange-400">{Math.ceil(hours)}h remaining</span>;
+    return <span className="text-amber-400">{Math.ceil(hours)}h remaining</span>;
   }
 
   const days = Math.floor(hours / 24);
   const remainingHours = Math.ceil(hours % 24);
-  return <span className="text-red-400">{days}d {remainingHours}h remaining</span>;
+  return <span className="text-orange-400">{days}d {remainingHours}h remaining</span>;
 };
 
 export default function BanCard({
@@ -59,95 +59,111 @@ export default function BanCard({
     : [];
   const hasEvidence = evidenceList.length > 0;
 
+  const reasonDisplay = getBanReasonDisplay(ban.reason, ban.customReason);
+  const normalizedReason = String(ban.reason || '').toLowerCase();
+  const normalizedCustomReason = String(ban.customReason || '').toLowerCase();
+  const severeReasonKeywords = [
+    'harassment',
+    'abuse',
+    'scam',
+    'scamming',
+    'fraud',
+    'payment_fraud',
+    'extortion',
+    'threat',
+    'dox',
+    'hate',
+  ];
+  const isSevereReason = severeReasonKeywords.some((keyword) =>
+    normalizedReason.includes(keyword) || normalizedCustomReason.includes(keyword)
+  );
+  const reasonTextClass = isSevereReason ? 'text-rose-400' : 'text-zinc-200';
+  const banTypeChipClass =
+    ban.banType === 'permanent'
+      ? 'border border-rose-500/40 bg-rose-500/10 text-rose-300'
+      : 'border border-amber-500/40 bg-amber-500/10 text-amber-300';
+
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6 hover:border-gray-700 transition-colors">
-      <div className="flex justify-between items-start">
-        <div className="flex-1">
-          <div className="flex items-center gap-3 mb-2">
+    <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-6 transition-colors hover:border-zinc-700">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex-1 space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
             <h3 className="text-lg font-semibold text-white">
               <SecureMessageDisplay content={ban.username} allowBasicFormatting={false} />
             </h3>
-            <span
-              className={`px-2 py-1 text-xs rounded font-medium ${
-                ban.banType === 'permanent'
-                  ? 'bg-red-900/20 text-red-400'
-                  : 'bg-orange-900/20 text-orange-400'
-              }`}
-            >
+            <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium uppercase ${banTypeChipClass}`}>
               {ban.banType}
             </span>
             {ban.appealSubmitted && (
-              <span className="px-2 py-1 bg-blue-900/20 text-blue-400 text-xs rounded font-medium">
+              <span className="inline-flex items-center rounded-full border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium text-indigo-300">
                 Appeal {ban.appealStatus ?? 'Pending'}
               </span>
             )}
           </div>
 
-          <div className="text-sm text-gray-400 mb-2">
-            <span>Reason: </span>
-            <span className="text-gray-300">
-              {getBanReasonDisplay(ban.reason, ban.customReason)}
-            </span>
+          <div className="text-sm text-zinc-400">
+            <span className="font-medium text-zinc-500">Reason</span>
+            <span className={`ml-2 ${reasonTextClass}`}>{reasonDisplay}</span>
           </div>
 
-          <div className="text-sm text-gray-400">
-            <span>Duration: </span>
-            {formatRemainingTime(ban)}
+          <div className="text-sm text-zinc-400">
+            <span className="font-medium text-zinc-500">Duration</span>
+            <span className="ml-2">{formatRemainingTime(ban)}</span>
           </div>
         </div>
 
-        <div className="flex flex-col gap-2 ml-4">
+        <div className="flex w-full flex-col gap-2 text-xs font-medium md:w-auto md:items-end">
           <button
             onClick={() => onToggleExpand(ban.id)}
-            className="px-3 py-1 bg-gray-600 text-white text-sm rounded hover:bg-gray-700 flex items-center transition-colors"
+            className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-900 px-3 py-1.5 text-zinc-200 transition-all duration-150 hover:bg-zinc-800"
           >
-            <Eye size={12} className="mr-1" />
-            {isExpanded ? 'Less' : 'More'}
+            <Eye size={12} />
+            {isExpanded ? 'Hide' : 'Details'}
           </button>
 
           {ban.appealSubmitted && ban.appealStatus === 'pending' && (
             <button
               onClick={() => onReviewAppeal(ban)}
-              className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 flex items-center transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-indigo-500/40 bg-zinc-900 px-3 py-1.5 text-indigo-300 transition-all duration-150 hover:bg-zinc-800"
             >
-              <MessageSquare size={12} className="mr-1" />
-              Review
+              <MessageSquare size={12} />
+              Review Appeal
             </button>
           )}
 
           <button
             onClick={() => onUnban(ban)}
-            className="px-3 py-1 bg-green-600 text-white text-sm rounded hover:bg-green-700 flex items-center transition-colors"
+            className="inline-flex items-center gap-1 rounded-md border border-emerald-500/40 bg-zinc-900 px-3 py-1.5 text-emerald-400 transition-all duration-150 hover:bg-zinc-800"
           >
-            <UserCheck size={12} className="mr-1" />
+            <UserCheck size={12} />
             Unban
           </button>
         </div>
       </div>
 
       {isExpanded && (
-        <div className="mt-4 pt-4 border-t border-gray-700">
-          <div className="grid grid-cols-2 gap-4 text-sm">
+        <div className="mt-4 border-t border-zinc-800/80 pt-4">
+          <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
             <div>
-              <span className="text-gray-400">Start Time:</span>
-              <div className="text-gray-300">{new Date(ban.startTime).toLocaleString()}</div>
+              <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">Start Time</span>
+              <div className="mt-1 text-zinc-200">{new Date(ban.startTime).toLocaleString()}</div>
             </div>
             <div>
-              <span className="text-gray-400">Banned By:</span>
-              <div className="text-gray-300">
+              <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">Banned By</span>
+              <div className="mt-1 text-zinc-400">
                 <SecureMessageDisplay content={ban.bannedBy ?? 'Unknown'} allowBasicFormatting={false} />
               </div>
             </div>
             {ban.endTime && (
               <div>
-                <span className="text-gray-400">End Time:</span>
-                <div className="text-gray-300">{new Date(ban.endTime).toLocaleString()}</div>
+                <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">End Time</span>
+                <div className="mt-1 text-zinc-200">{new Date(ban.endTime).toLocaleString()}</div>
               </div>
             )}
             {ban.notes && (
-              <div className="col-span-2">
-                <span className="text-gray-400">Notes:</span>
-                <div className="text-gray-300 mt-1">
+              <div className="md:col-span-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">Notes</span>
+                <div className="mt-1 text-zinc-300">
                   <SecureMessageDisplay content={ban.notes} allowBasicFormatting={false} maxLength={500} />
                 </div>
               </div>
@@ -155,29 +171,29 @@ export default function BanCard({
           </div>
 
           {ban.appealSubmitted && (
-            <div className="mt-4 p-3 bg-blue-900/10 border border-blue-800 rounded">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-sm text-blue-400 font-medium">Appeal Submitted</div>
+            <div className="mt-4 rounded-lg border border-indigo-500/30 bg-indigo-500/5 p-4">
+              <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div className="text-sm font-medium text-indigo-300">Appeal Submitted</div>
 
                 {hasEvidence && (
                   <button
                     onClick={() => onShowEvidence(evidenceList)}
-                    className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 transition-colors"
+                    className="inline-flex items-center gap-2 text-xs font-medium text-indigo-300 transition-colors hover:text-indigo-200"
                   >
-                    <span className="w-2 h-2 bg-blue-400 rounded"></span>
+                    <span className="h-2 w-2 rounded-full bg-indigo-300" />
                     {evidenceList.length} Evidence
                   </button>
                 )}
               </div>
 
-              <div className="text-sm text-gray-300">
+              <div className="text-sm text-zinc-200">
                 <SecureMessageDisplay
                   content={ban.appealText ?? 'No appeal text provided'}
                   allowBasicFormatting={false}
                   maxLength={500}
                 />
               </div>
-              <div className="text-xs text-gray-500 mt-1">
+              <div className="mt-2 text-xs text-zinc-500">
                 {ban.appealDate ? new Date(ban.appealDate).toLocaleString() : 'Unknown date'}
               </div>
             </div>

--- a/src/components/admin/bans/BanFilters.tsx
+++ b/src/components/admin/bans/BanFilters.tsx
@@ -28,17 +28,17 @@ export default function BanFilters({
   };
 
   return (
-    <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 mb-6">
-      <div className="flex flex-col lg:flex-row gap-4">
+    <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-950/80 p-4 md:p-5">
+      <div className="flex flex-col gap-4 lg:flex-row">
         {/* Search */}
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-3 text-gray-400 z-10" size={16} />
+          <Search className="absolute left-3 top-3 z-10 text-zinc-500" size={16} />
           <SecureInput
             type="text"
             placeholder="Search by username or reason..."
             value={filters.searchTerm}
             onChange={handleSearchChange}
-            className="w-full pl-10 pr-4 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e] transition-all"
+            className="w-full rounded-lg border border-zinc-800 bg-zinc-900 py-2 pl-10 pr-4 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-[#ff950e] focus:outline-none focus:ring-0"
             maxLength={100}
             sanitize={true}
             sanitizer={sanitizeSearchQuery}
@@ -50,7 +50,7 @@ export default function BanFilters({
           <select
             value={filters.filterBy}
             onChange={(e) => onFiltersChange({ filterBy: e.target.value as any })}
-            className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-0"
           >
             <option value="all">All Types</option>
             <option value="temporary">Temporary</option>
@@ -63,17 +63,17 @@ export default function BanFilters({
           <select
             value={filters.sortBy}
             onChange={(e) => onFiltersChange({ sortBy: e.target.value as any })}
-            className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#ff950e]"
+            className="rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-[#ff950e] focus:outline-none focus:ring-0"
           >
             <option value="date">Sort by Date</option>
             <option value="username">Sort by Username</option>
             <option value="duration">Sort by Duration</option>
           </select>
           <button
-            onClick={() => onFiltersChange({ 
-              sortOrder: filters.sortOrder === 'asc' ? 'desc' : 'asc' 
+            onClick={() => onFiltersChange({
+              sortOrder: filters.sortOrder === 'asc' ? 'desc' : 'asc'
             })}
-            className="px-3 py-2 bg-[#222] border border-gray-700 rounded-lg text-white hover:bg-[#333] transition-colors"
+            className="inline-flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 transition-colors hover:bg-zinc-800"
           >
             {filters.sortOrder === 'asc' ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </button>

--- a/src/components/admin/bans/BanStatsDashboard.tsx
+++ b/src/components/admin/bans/BanStatsDashboard.tsx
@@ -22,36 +22,76 @@ export default function BanStatsDashboard({ banStats }: BanStatsDashboardProps) 
     appealStats,
   } = banStats || ({} as BanStats);
 
+  const cards: Array<{
+    label: string;
+    value: number;
+    valueClass: string;
+    labelClass: string;
+    borderClass?: string;
+  }> = [
+    {
+      label: 'Active Bans',
+      value: safeNumber(totalActiveBans),
+      valueClass: 'text-red-400',
+      labelClass: 'text-red-300/80',
+      borderClass: 'border-red-500/30 hover:border-red-400/60',
+    },
+    {
+      label: 'Temporary',
+      value: safeNumber(temporaryBans),
+      valueClass: 'text-amber-400',
+      labelClass: 'text-amber-300/80',
+      borderClass: 'border-amber-500/30 hover:border-amber-400/60',
+    },
+    {
+      label: 'Permanent',
+      value: safeNumber(permanentBans),
+      valueClass: 'text-rose-400',
+      labelClass: 'text-rose-300/80',
+      borderClass: 'border-rose-500/30 hover:border-rose-400/60',
+    },
+    {
+      label: 'Appeals',
+      value: safeNumber(pendingAppeals),
+      valueClass: 'text-purple-400',
+      labelClass: 'text-purple-300/80',
+      borderClass: 'border-purple-500/30 hover:border-purple-400/60',
+    },
+    {
+      label: '24h Bans',
+      value: safeNumber(recentBans24h),
+      valueClass: 'text-yellow-300',
+      labelClass: 'text-yellow-200/80',
+      borderClass: 'border-yellow-400/30 hover:border-yellow-300/60',
+    },
+    {
+      label: 'Approved',
+      value: safeNumber(appealStats?.approvedAppeals),
+      valueClass: 'text-emerald-400',
+      labelClass: 'text-emerald-300/80',
+      borderClass: 'border-emerald-500/30 hover:border-emerald-400/60',
+    },
+  ];
+
   return (
     <div
-      className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 mb-6"
+      className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6"
       role="group"
       aria-label="Ban statistics overview"
     >
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-red-400">{safeNumber(totalActiveBans)}</div>
-        <div className="text-xs text-gray-400">Active Bans</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-yellow-400">{safeNumber(temporaryBans)}</div>
-        <div className="text-xs text-gray-400">Temporary</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-purple-400">{safeNumber(permanentBans)}</div>
-        <div className="text-xs text-gray-400">Permanent</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-orange-400">{safeNumber(pendingAppeals)}</div>
-        <div className="text-xs text-gray-400">Appeals</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-blue-400">{safeNumber(recentBans24h)}</div>
-        <div className="text-xs text-gray-400">24h Bans</div>
-      </div>
-      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 text-center hover:border-gray-700 transition-colors">
-        <div className="text-2xl font-bold text-green-400">{safeNumber(appealStats?.approvedAppeals)}</div>
-        <div className="text-xs text-gray-400">Approved</div>
-      </div>
+      {cards.map(({ label, value, valueClass, labelClass, borderClass }) => (
+        <div
+          key={label}
+          className={`rounded-xl border bg-zinc-950/80 px-4 py-3 text-left transition-colors ${
+            borderClass ?? 'border-zinc-800/80 hover:border-zinc-700'
+          }`}
+        >
+          <div className={`text-2xl font-semibold ${valueClass}`}>{value}</div>
+          <div className={`mt-1 text-xs font-medium uppercase tracking-wide ${labelClass}`}>
+            {label}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/admin/bans/BanTabs.tsx
+++ b/src/components/admin/bans/BanTabs.tsx
@@ -40,7 +40,7 @@ export default function BanTabs({
   ];
 
   return (
-    <div className="flex flex-wrap gap-1 bg-[#1a1a1a] border border-gray-800 rounded-lg p-1 mb-6" role="tablist" aria-label="Ban tabs">
+    <div className="mb-6 flex flex-wrap gap-2" role="tablist" aria-label="Ban tabs">
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeTab === tab.key;
@@ -52,13 +52,15 @@ export default function BanTabs({
             aria-selected={isActive}
             aria-controls={`panel-${tab.key}`}
             onClick={() => onTabChange(tab.key)}
-            className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition-all flex items-center justify-center gap-2 ${
-              isActive ? 'bg-[#ff950e] text-black shadow-lg' : 'text-gray-300 hover:text-white hover:bg-[#333]'
+            className={`flex min-w-[140px] flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+              isActive
+                ? 'border-[#ff950e]/60 bg-[#ff950e]/10 text-[#ff950e]'
+                : 'border-zinc-800 bg-zinc-900 text-zinc-300 hover:bg-zinc-800 hover:text-white'
             }`}
           >
             <Icon size={16} />
             <span className="hidden sm:inline">{tab.label}</span>
-            {tab.count !== null && <span className="ml-1">({tab.count})</span>}
+            {tab.count !== null && <span className="ml-1 text-xs text-zinc-400">({tab.count})</span>}
           </button>
         );
       })}

--- a/src/components/admin/bans/ExpiredBansContent.tsx
+++ b/src/components/admin/bans/ExpiredBansContent.tsx
@@ -12,6 +12,19 @@ interface ExpiredBansContentProps {
   filters: FilterOptions;
 }
 
+const severeReasonKeywords = [
+  'harassment',
+  'abuse',
+  'scam',
+  'scamming',
+  'fraud',
+  'payment_fraud',
+  'extortion',
+  'threat',
+  'dox',
+  'hate',
+];
+
 const filterAndSortBans = (bans: BanEntry[], filters: FilterOptions): BanEntry[] => {
   if (!Array.isArray(bans)) return [];
 
@@ -46,13 +59,15 @@ export default function ExpiredBansContent({ expiredBans, filters }: ExpiredBans
   const filteredBans = filterAndSortBans(expiredBans || [], filters);
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-semibold text-white mb-4">Expired Bans ({(expiredBans || []).length})</h2>
+    <div className="space-y-5">
+      <h2 className="text-2xl font-semibold text-white">Expired Bans ({(expiredBans || []).length})</h2>
       {filteredBans.length === 0 ? (
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-8 text-center">
-          <Clock size={48} className="mx-auto text-gray-600 mb-4" />
-          <p className="text-gray-400 text-lg">No expired bans found</p>
-          {filters.searchTerm && <p className="text-gray-500 text-sm mt-2">Try adjusting your search terms or filters</p>}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-8 text-center">
+          <Clock size={48} className="mx-auto mb-4 text-zinc-600" />
+          <p className="text-lg text-zinc-300">No expired bans found</p>
+          {filters.searchTerm && (
+            <p className="mt-2 text-sm text-zinc-500">Try adjusting your search terms or filters</p>
+          )}
         </div>
       ) : (
         <div className="space-y-4">
@@ -65,35 +80,45 @@ export default function ExpiredBansContent({ expiredBans, filters }: ExpiredBans
                   ? null
                   : Math.ceil((new Date(ban.endTime).getTime() - new Date(ban.startTime).getTime()) / (1000 * 60 * 60));
 
+              const normalizedReason = String(ban.reason || '').toLowerCase();
+              const normalizedCustomReason = String(ban.customReason || '').toLowerCase();
+              const reasonHighlight = severeReasonKeywords.some((keyword) =>
+                normalizedReason.includes(keyword) || normalizedCustomReason.includes(keyword)
+              );
+
               return (
-                <div key={ban.id} className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-6 opacity-75">
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
+                <div key={ban.id} className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 space-y-3">
+                      <div className="flex flex-wrap items-center gap-3">
                         <h3 className="text-lg font-semibold text-white">
                           <SecureMessageDisplay content={ban.username} allowBasicFormatting={false} />
                         </h3>
-                        <span className="px-2 py-1 bg-gray-900/20 text-gray-400 text-xs rounded font-medium">Expired/Lifted</span>
+                        <span className="inline-flex items-center rounded-full border border-zinc-700/60 bg-zinc-900 px-2.5 py-1 text-xs font-medium uppercase text-zinc-400">
+                          Expired
+                        </span>
                       </div>
 
-                      <div className="grid grid-cols-2 gap-4 text-sm">
+                      <div className="grid grid-cols-1 gap-3 text-sm text-zinc-400 md:grid-cols-2">
                         <div>
-                          <span className="text-gray-400">Reason:</span>
-                          <span className="text-gray-300 ml-2">{getBanReasonDisplay(ban.reason, ban.customReason)}</span>
+                          <span className="font-medium text-zinc-500">Reason</span>
+                          <span className={`ml-2 ${reasonHighlight ? 'text-rose-400' : 'text-zinc-200'}`}>
+                            {getBanReasonDisplay(ban.reason, ban.customReason)}
+                          </span>
                         </div>
                         <div>
-                          <span className="text-gray-400">Duration:</span>
-                          <span className="text-gray-300 ml-2">
+                          <span className="font-medium text-zinc-500">Duration</span>
+                          <span className="ml-2 text-zinc-200">
                             {ban.banType === 'permanent' ? 'Permanent' : hours !== null ? `${hours} hours` : 'Unknown'}
                           </span>
                         </div>
                         <div>
-                          <span className="text-gray-400">Start:</span>
-                          <span className="text-gray-300 ml-2">{ban.startTime ? new Date(ban.startTime).toLocaleString() : 'Unknown'}</span>
+                          <span className="font-medium text-zinc-500">Start</span>
+                          <span className="ml-2 text-zinc-200">{ban.startTime ? new Date(ban.startTime).toLocaleString() : 'Unknown'}</span>
                         </div>
                         <div>
-                          <span className="text-gray-400">End:</span>
-                          <span className="text-gray-300 ml-2">{ban.endTime ? new Date(ban.endTime).toLocaleString() : 'Manually lifted'}</span>
+                          <span className="font-medium text-zinc-500">End</span>
+                          <span className="ml-2 text-zinc-200">{ban.endTime ? new Date(ban.endTime).toLocaleString() : 'Manually lifted'}</span>
                         </div>
                       </div>
                     </div>

--- a/src/components/admin/bans/HistoryContent.tsx
+++ b/src/components/admin/bans/HistoryContent.tsx
@@ -30,13 +30,13 @@ export default function HistoryContent({ banHistory, filters }: HistoryContentPr
     .slice(0, 50);
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-semibold text-white mb-4">Ban History ({(banHistory || []).length})</h2>
+    <div className="space-y-5">
+      <h2 className="text-2xl font-semibold text-white">Ban History ({(banHistory || []).length})</h2>
       {filteredHistory.length === 0 ? (
-        <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-8 text-center">
-          <FileText size={48} className="mx-auto text-gray-600 mb-4" />
-          <p className="text-gray-400 text-lg">No ban history found</p>
-          <p className="text-gray-500 text-sm mt-2">Ban actions will appear here as they occur</p>
+        <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-8 text-center">
+          <FileText size={48} className="mx-auto mb-4 text-zinc-600" />
+          <p className="text-lg text-zinc-300">No ban history found</p>
+          <p className="mt-2 text-sm text-zinc-500">Ban actions will appear here as they occur</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -44,38 +44,34 @@ export default function HistoryContent({ banHistory, filters }: HistoryContentPr
             .map((entry) => {
               if (!entry || !entry.id) return null;
 
-              const actionClass =
-                entry.action === 'banned'
-                  ? 'bg-red-900/20 text-red-400'
-                  : entry.action === 'unbanned'
-                  ? 'bg-green-900/20 text-green-400'
-                  : entry.action === 'appeal_submitted'
-                  ? 'bg-orange-900/20 text-orange-400'
-                  : entry.action === 'appeal_approved'
-                  ? 'bg-blue-900/20 text-blue-400'
-                  : entry.action === 'appeal_rejected'
-                  ? 'bg-red-900/20 text-red-400'
-                  : 'bg-gray-900/20 text-gray-400';
+              const chipClasses: Record<string, string> = {
+                banned: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+                unbanned: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+                appeal_submitted: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+                appeal_approved: 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300',
+                appeal_rejected: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+              };
+              const actionClass = chipClasses[entry.action as keyof typeof chipClasses] ?? 'border-zinc-700/60 bg-zinc-900 text-zinc-300';
 
               return (
                 <div
                   key={entry.id}
-                  className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-4 hover:border-gray-700 transition-colors"
+                  className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-4 transition-colors hover:border-zinc-700"
                 >
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-1">
+                      <div className="mb-2 flex flex-wrap items-center gap-3">
                         <span className="font-medium text-white">
                           <SecureMessageDisplay content={entry.username || 'Unknown'} allowBasicFormatting={false} />
                         </span>
-                        <span className={`px-2 py-1 text-xs rounded font-medium ${actionClass}`}>
+                        <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium uppercase ${actionClass}`}>
                           {(entry.action || 'unknown').replace('_', ' ').toUpperCase()}
                         </span>
                       </div>
-                      <div className="text-sm text-gray-300 mb-1">
+                      <div className="mb-2 text-sm text-zinc-200">
                         <SecureMessageDisplay content={entry.details || 'No details available'} allowBasicFormatting={false} maxLength={200} />
                       </div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-zinc-500">
                         {entry.timestamp ? new Date(entry.timestamp).toLocaleString() : 'Unknown time'} by{' '}
                         <SecureMessageDisplay content={entry.adminUsername || 'Unknown admin'} allowBasicFormatting={false} className="inline" />
                       </div>


### PR DESCRIPTION
## Summary
- refresh the ban management header and controls to match the new flat admin aesthetic
- restyle stats, filters, tabs, and analytics cards with dark neutral surfaces and subtle accent colors
- rebuild ban list cards, appeals, expired bans, and history chips for improved hierarchy and readability

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_6909579a9ab88328828140feb9ec0dd3