### PR TITLE
Adjust admin browse alert spacing

### DIFF
--- a/src/components/browse/BrowseHeader.tsx
+++ b/src/components/browse/BrowseHeader.tsx
@@ -23,7 +23,7 @@ export default function BrowseHeader({
       )}
 
       {user?.role === 'admin' && (
-        <div className="bg-purple-900/20 border border-purple-700 text-purple-300 p-4 rounded-lg mb-6 max-w-3xl mx-auto">
+        <div className="bg-purple-900/20 border border-purple-700 text-purple-300 px-4 py-3 rounded-lg mb-6 mx-auto w-fit max-w-full">
           <p className="text-sm flex items-center gap-2">
             <Crown className="w-4 h-4" />
             Admins can browse for moderation and analytics, but cannot purchase or bid.


### PR DESCRIPTION
## Summary
- reduce the padding inside the admin-only browse alert to tighten its layout
- ensure the admin alert container centers itself by shrinking to fit the content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690bcff494388328a479d48f9f99106c