### PR TITLE
Remove Add address button from orders needing addresses

### DIFF
--- a/src/app/sellers/orders-to-fulfil/page.tsx
+++ b/src/app/sellers/orders-to-fulfil/page.tsx
@@ -655,13 +655,6 @@ export default function OrdersToFulfilPage() {
                             >
                               Message buyer
                             </Link>
-                            <button
-                              type="button"
-                              onClick={() => handleOpenAddressModal(order.id)}
-                              className="inline-flex items-center gap-2 rounded-lg border border-[#ff950e]/40 bg-gradient-to-r from-[#ff950e]/80 to-[#ff6a00]/80 px-3 py-1.5 text-xs font-semibold text-black shadow-lg transition-all hover:from-[#ffb347] hover:to-[#ff950e]"
-                            >
-                              Add address
-                            </button>
                           </div>
                         </li>
                       ))}


### PR DESCRIPTION
## Summary
- remove the Add address button from orders needing addresses cards while keeping the Message buyer action intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690c101e6a088328bfc144ec9ef14642